### PR TITLE
SSRF protection filter

### DIFF
--- a/app/ai-app/services/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/examples/ssrf_filtering.py
+++ b/app/ai-app/services/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/examples/ssrf_filtering.py
@@ -1,0 +1,134 @@
+import asyncio
+
+from dotenv import load_dotenv, find_dotenv
+from kdcube_ai_app.infra.service_hub.cache import create_kv_cache
+
+from kdcube_ai_app.apps.chat.sdk.tools.backends.web.egress_policy import NavigationGuard
+from kdcube_ai_app.apps.chat.sdk.tools.backends.web.reputation.abstract_reputation_provider import \
+    AbstractReputationProvider
+
+load_dotenv(find_dotenv())
+
+class MockReputationProvider(AbstractReputationProvider):
+    async def check_url(self, url: str) -> bool:
+        await asyncio.sleep(1)
+        return "malware" not in url
+
+async def main():
+    print("--- SSRF Protection Demo ---")
+
+    cache = create_kv_cache()
+
+    guard = NavigationGuard(MockReputationProvider(), cache)
+
+    test_url = "https://google.com"
+    context = {"check_reputation": True}
+
+    print(f"\n--- Test 1 ---")
+    v1 = await guard.get_navigation_verdict(test_url, context)
+    print(f"Verdict: {v1.reason}")
+
+    print(f"\n--- Test 2 ---")
+    v2 = await guard.get_navigation_verdict(test_url, context)
+    print(f"Verdict: {v2.reason}")
+
+    print(f"\n--- Key check ---")
+    key = guard._generate_cache_key("google.com")
+    print(f"Key: {key}")
+    in_redis = await cache.get(key)
+    print(f"Data in Redis: {in_redis}")
+
+# import ssl
+# import socket
+# import requests
+# from urllib3.connection import HTTPSConnection
+# from requests.adapters import HTTPAdapter
+# from urllib.parse import urlparse
+#
+#
+# class PinnedHTTPSConnection(HTTPSConnection):
+#     def __init__(self, *args, dest_ip: str, server_hostname: str, **kwargs):
+#         self.dest_ip = dest_ip
+#         self.server_hostname = server_hostname
+#         super().__init__(*args, **kwargs)
+#
+#     def connect(self):
+#         sock = socket.create_connection(
+#             (self.dest_ip, self.port),
+#             self.timeout,
+#             self.source_address,
+#         )
+#
+#         context = ssl.create_default_context()
+#         self.sock = context.wrap_socket(
+#             sock,
+#             server_hostname=self.server_hostname,  # ← SNI
+#         )
+#
+# class PinnedHTTPSAdapter(HTTPAdapter):
+#     def __init__(self, dest_ip: str, hostname: str, **kwargs):
+#         self.dest_ip = dest_ip
+#         self.hostname = hostname
+#         super().__init__(**kwargs)
+#
+#     def get_connection(self, url, proxies=None):
+#         return PinnedHTTPSConnection(
+#             host=self.hostname,
+#             port=443,
+#             dest_ip=self.dest_ip,
+#             server_hostname=self.hostname,
+#         )
+#
+#
+#
+# async def fetch_with_ip_pinning(url: str, guard: NavigationGuard):
+#     verdict = await guard.get_navigation_verdict(
+#         url,
+#         context={"check_reputation": False}
+#     )
+#
+#     if not verdict.allowed:
+#         raise RuntimeError(f"Blocked: {verdict.reason} {verdict.details}")
+#
+#     hostname = verdict.details["hostname"]
+#     pinned_ip = verdict.details["resolved_ips"][0]
+#
+#     parsed = urlparse(url)
+#
+#     session = requests.Session()
+#     session.mount(
+#         f"{parsed.scheme}://{hostname}",
+#         PinnedHTTPSAdapter(
+#             dest_ip=pinned_ip,
+#             hostname=hostname
+#         )
+#     )
+#
+#     response = session.get(
+#         url,
+#         timeout=5,
+#         allow_redirects=False
+#     )
+#
+#     response.raise_for_status()
+#     return response.json()
+#
+# async def main2():
+#     guard = NavigationGuard(
+#         reputation_provider=None,
+#         cache=None
+#     )
+#
+#     url = "https://jsonplaceholder.typicode.com/posts/1"
+#
+#     data = await fetch_with_ip_pinning(url, guard)
+#
+#     print("✅ SUCCESS")
+#     print(data)
+#
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
+
+

--- a/app/ai-app/services/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/tools/backends/web/egress_policy.py
+++ b/app/ai-app/services/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/tools/backends/web/egress_policy.py
@@ -1,0 +1,216 @@
+import ipaddress
+import socket
+import asyncio
+import hashlib
+from typing import Optional, Union, Dict, Any, Iterable
+from enum import Enum
+from dataclasses import dataclass, field, asdict
+from urllib.parse import urlparse, urlunparse
+
+from kdcube_ai_app.apps.chat.sdk.tools.backends.web.reputation.abstract_reputation_provider import \
+    AbstractReputationProvider
+from kdcube_ai_app.infra.service_hub.cache import KVCache, create_kv_cache
+
+
+class ReasonCode(str, Enum):
+    ALLOWED = "ALLOWED"
+    BLOCKED_LOCALHOST = "BLOCKED_LOCALHOST"
+    BLOCKED_PRIVATE_IP = "BLOCKED_PRIVATE_IP"
+    BLOCKED_LINK_LOCAL = "BLOCKED_LINK_LOCAL"
+    BLOCKED_UNSAFE_REPUTATION = "BLOCKED_UNSAFE_REPUTATION"
+    BLOCKED_NOT_IN_ALLOWLIST = "BLOCKED_NOT_IN_ALLOWLIST"
+    RESOLUTION_FAILED = "RESOLUTION_FAILED"
+    INVALID_URL = "INVALID_URL"
+
+
+@dataclass
+class Verdict:
+    allowed: bool
+    reason: ReasonCode
+    details: Dict[str, Any] = field(default_factory=dict)
+
+BLOCKED_HOSTNAMES = {"localhost", "metadata.google.internal"}
+
+def normalize_hostname(hostname: str) -> str:
+    if not hostname:
+        return ""
+    normalized = hostname.strip().lower()
+    if normalized.endswith("."):
+        normalized = normalized[:-1]
+
+    if normalized.startswith("[") and normalized.endswith("]"):
+        normalized = normalized[1:-1]
+
+    return normalized
+
+
+def sanitize_url_for_scanning(url: str) -> str:
+    try:
+        parsed = urlparse(url)
+        return urlunparse((parsed.scheme, parsed.netloc, parsed.path, parsed.params, "", ""))
+    except Exception:
+        return url
+
+
+def _get_ip_violation_reason(ip: Union[ipaddress.IPv4Address, ipaddress.IPv6Address]) -> Optional[ReasonCode]:
+    if ip.is_loopback:
+        return ReasonCode.BLOCKED_LOCALHOST
+    if ip.is_link_local:
+        return ReasonCode.BLOCKED_LINK_LOCAL
+
+    if isinstance(ip, ipaddress.IPv6Address):
+         if ip.is_private:
+             return ReasonCode.BLOCKED_PRIVATE_IP
+         if str(ip).startswith("fec0:"):
+             return ReasonCode.BLOCKED_PRIVATE_IP
+         if ip == ipaddress.IPv6Address("::"):
+             return ReasonCode.BLOCKED_PRIVATE_IP
+
+    if isinstance(ip, ipaddress.IPv4Address):
+        if str(ip).startswith("0."):
+            return ReasonCode.BLOCKED_PRIVATE_IP
+        if ip.is_private:
+            return ReasonCode.BLOCKED_PRIVATE_IP
+        if ip in ipaddress.IPv4Network("100.64.0.0/10"):
+            return ReasonCode.BLOCKED_PRIVATE_IP
+        if ip.is_multicast or ip.is_reserved:
+            return ReasonCode.BLOCKED_PRIVATE_IP
+
+    return None
+
+
+def is_blocked_hostname(hostname: str, extra_blocked: Optional[Iterable[str]] = None) -> bool:
+    normalized = normalize_hostname(hostname)
+    if not normalized:
+        return False
+
+    if normalized in BLOCKED_HOSTNAMES:
+        return True
+
+    if extra_blocked:
+        for extra in extra_blocked:
+            if normalize_hostname(extra) == normalized:
+                return True
+
+    if (normalized.endswith(".localhost") or
+            normalized.endswith(".local") or
+            normalized.endswith(".internal")):
+        return True
+
+    return False
+
+
+class NavigationGuard:
+    def __init__(
+        self,
+        reputation_provider: Optional[AbstractReputationProvider] = None,
+        cache: Optional[KVCache] = None
+    ):
+        self.reputation_provider = reputation_provider
+        self.cache = cache or create_kv_cache()
+
+    def _generate_cache_key(self, hostname: str) -> str:
+        normalized = normalize_hostname(hostname)
+        hash_digest = hashlib.sha256(normalized.encode('utf-8')).hexdigest()
+        return f"nav_guard_egress:{hash_digest}"
+
+    async def get_navigation_verdict(self, url: str, context: Optional[Dict[str, Any]] = None) -> Verdict:
+        """
+        Analyzes a URL and returns a Verdict indicating if it is safe to navigate to.
+
+        Args:
+            url: The full URL or hostname to check.
+            context: Optional dictionary for configuration (e.g., 'allowlist', 'check_reputation').
+                     Structure example: {'allowlist': ['example.com'], 'check_reputation': True}
+
+        Returns:
+            Verdict object containing allowed status, reason code, and details (resolved IP, hostname).
+        """
+        context = context or {}
+
+        if "://" not in url:
+            hostname = url
+        else:
+            try:
+                parsed = urlparse(url)
+                hostname = parsed.hostname
+                if not hostname:
+                    if parsed.path and not parsed.netloc:
+                        return Verdict(False, ReasonCode.INVALID_URL, {"error": "Local file or invalid scheme"})
+                    return Verdict(False, ReasonCode.INVALID_URL, {"error": "No hostname found"})
+            except Exception as e:
+                return Verdict(False, ReasonCode.INVALID_URL, {"error": str(e)})
+
+        normalized_host = normalize_hostname(hostname)
+
+        allowlist = context.get('allowlist', [])
+        if allowlist:
+            if normalized_host not in [normalize_hostname(h) for h in allowlist]:
+                return Verdict(False, ReasonCode.BLOCKED_NOT_IN_ALLOWLIST, {"hostname": normalized_host})
+
+        extra_blocked = context.get('blocked_hostnames', [])
+        if is_blocked_hostname(normalized_host, extra_blocked):
+            return Verdict(False, ReasonCode.BLOCKED_LOCALHOST, {"hostname": normalized_host})
+
+        cache_key = self._generate_cache_key(normalized_host)
+
+        cached = await self.cache.get_json(cache_key) if self.cache else None
+        if cached:
+            return Verdict(**cached)
+
+        try:
+            try:
+                ip_obj = ipaddress.ip_address(normalized_host)
+                violation = _get_ip_violation_reason(ip_obj)
+                if violation:
+                    return Verdict(False, violation, {"ip": str(ip_obj), "input_type": "ip_literal"})
+                
+                final_details = {"ip": str(ip_obj), "input_type": "ip_literal"}
+            except ValueError:
+                loop = asyncio.get_running_loop()
+                addr_info = await loop.getaddrinfo(normalized_host, None, proto=socket.IPPROTO_TCP)
+
+                resolved_ips = set()
+                for _, _, _, _, sockaddr in addr_info:
+                    resolved_ips.add(sockaddr[0])
+
+                if not resolved_ips:
+                    return Verdict(False, ReasonCode.RESOLUTION_FAILED, {"hostname": normalized_host})
+
+                for ip_str in resolved_ips:
+                    try:
+                        ip_obj = ipaddress.ip_address(ip_str)
+                        violation = _get_ip_violation_reason(ip_obj)
+                        if violation:
+                            return Verdict(False, violation, {"hostname": normalized_host, "blocked_ip": ip_str})
+                    except ValueError:
+                        continue
+                
+                final_details = {"hostname": normalized_host, "resolved_ips": list(resolved_ips)}
+
+        except Exception as e:
+            return Verdict(False, ReasonCode.RESOLUTION_FAILED, {"hostname": normalized_host, "error": str(e)})
+
+        if context.get('check_reputation'):
+            url_to_scan = sanitize_url_for_scanning(url)
+            is_safe = await self.reputation_provider.check_url(url_to_scan)
+            if not is_safe:
+                verdict = Verdict(False, ReasonCode.BLOCKED_UNSAFE_REPUTATION, {
+                    "hostname": normalized_host,
+                    "provider": "google_safe_browsing"
+                })
+                await self._save_to_cache(cache_key, verdict)
+
+                return verdict
+
+        verdict = Verdict(True, ReasonCode.ALLOWED, final_details)
+        await self._save_to_cache(cache_key, verdict)
+
+        return verdict
+
+    async def _save_to_cache(self, key: str, verdict: Verdict):
+        if not self.cache:
+            return
+        data = asdict(verdict)
+        data['reason'] = verdict.reason.value
+        await self.cache.set_json(key, data)

--- a/app/ai-app/services/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/tools/backends/web/egress_policy_test.py
+++ b/app/ai-app/services/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/tools/backends/web/egress_policy_test.py
@@ -1,0 +1,159 @@
+import unittest
+from unittest.mock import patch, AsyncMock
+import socket
+from egress_policy import NavigationGuard, ReasonCode
+from reputation.abstract_reputation_provider import AbstractReputationProvider
+
+
+class TestNavigationGuard(unittest.IsolatedAsyncioTestCase):
+
+    def setUp(self):
+        self.mock_cache = AsyncMock()
+        self.mock_cache.get_json.return_value = None
+        self.guard = NavigationGuard(cache=self.mock_cache)
+
+    async def test_ip_literals_blocked(self):
+        # Loopback
+        verdict = await self.guard.get_navigation_verdict("http://127.0.0.1")
+        self.assertFalse(verdict.allowed)
+        self.assertEqual(verdict.reason, ReasonCode.BLOCKED_LOCALHOST)
+
+        # Private
+        verdict = await self.guard.get_navigation_verdict("http://10.0.0.1")
+        self.assertFalse(verdict.allowed)
+        self.assertEqual(verdict.reason, ReasonCode.BLOCKED_PRIVATE_IP)
+
+        # Link-local
+        verdict = await self.guard.get_navigation_verdict("http://169.254.1.1")
+        self.assertFalse(verdict.allowed)
+        self.assertEqual(verdict.reason, ReasonCode.BLOCKED_LINK_LOCAL)
+
+    async def test_ip_literals_allowed(self):
+        # Public
+        verdict = await self.guard.get_navigation_verdict("http://8.8.8.8")
+        self.assertTrue(verdict.allowed)
+        self.assertEqual(verdict.reason, ReasonCode.ALLOWED)
+
+    async def test_blocked_hostnames(self):
+        verdict = await self.guard.get_navigation_verdict("http://localhost")
+        self.assertFalse(verdict.allowed)
+        self.assertEqual(verdict.reason, ReasonCode.BLOCKED_LOCALHOST)
+
+        verdict = await self.guard.get_navigation_verdict("http://metadata.google.internal")
+        self.assertFalse(verdict.allowed)
+
+    async def test_extra_blocked_hostnames(self):
+        context = {'blocked_hostnames': ['forbidden.com', 'bad-site.org']}
+
+        verdict = await self.guard.get_navigation_verdict("http://forbidden.com", context)
+        self.assertFalse(verdict.allowed)
+        self.assertEqual(verdict.reason, ReasonCode.BLOCKED_LOCALHOST)
+
+        with patch('asyncio.get_running_loop') as mock_loop:
+            mock_dns = AsyncMock()
+            mock_loop.return_value.getaddrinfo = mock_dns
+            mock_dns.return_value = [
+                (socket.AF_INET, socket.SOCK_STREAM, 6, '', ('93.184.216.34', 80))
+            ]
+            verdict = await self.guard.get_navigation_verdict("http://good-site.com", context)
+            self.assertTrue(verdict.allowed)
+
+    async def test_allowlist(self):
+        context = {'allowlist': ['example.com']}
+        with patch('asyncio.get_running_loop') as mock_loop:
+            mock_dns = AsyncMock()
+            mock_loop.return_value.getaddrinfo = mock_dns
+            mock_dns.return_value = [
+                (socket.AF_INET, socket.SOCK_STREAM, 6, '', ('93.184.216.34', 80))
+            ]
+            verdict = await self.guard.get_navigation_verdict("http://example.com", context)
+            self.assertTrue(verdict.allowed)
+
+        context = {'allowlist': ['example.com']}
+        verdict = await self.guard.get_navigation_verdict("http://google.com", context)
+        self.assertFalse(verdict.allowed)
+        self.assertEqual(verdict.reason, ReasonCode.BLOCKED_NOT_IN_ALLOWLIST)
+
+    async def test_dns_resolution_allowed(self):
+        with patch('asyncio.get_running_loop') as mock_loop:
+            mock_dns = AsyncMock()
+            mock_loop.return_value.getaddrinfo = mock_dns
+            mock_dns.return_value = [
+                (socket.AF_INET, socket.SOCK_STREAM, 6, '', ('8.8.8.8', 80))
+            ]
+
+            verdict = await self.guard.get_navigation_verdict("http://google.com")
+            self.assertTrue(verdict.allowed)
+            self.assertEqual(verdict.reason, ReasonCode.ALLOWED)
+            self.mock_cache.set_json.assert_called()
+
+    async def test_dns_resolution_blocked(self):
+        with patch('asyncio.get_running_loop') as mock_loop:
+            mock_dns = AsyncMock()
+            mock_loop.return_value.getaddrinfo = mock_dns
+            mock_dns.return_value = [
+                (socket.AF_INET, socket.SOCK_STREAM, 6, '', ('127.0.0.1', 80))
+            ]
+
+            verdict = await self.guard.get_navigation_verdict("http://malicious.com")
+            self.assertFalse(verdict.allowed)
+            self.assertEqual(verdict.reason, ReasonCode.BLOCKED_LOCALHOST)
+
+    async def test_cache_hit_returns_verdict_immediately(self):
+        cached_verdict_data = {
+            "allowed": True,
+            "reason": ReasonCode.ALLOWED,
+            "details": {"source": "cache"}
+        }
+        self.mock_cache.get_json.return_value = cached_verdict_data
+
+        verdict = await self.guard.get_navigation_verdict("http://google.com")
+
+        self.assertTrue(verdict.allowed)
+        self.assertEqual(verdict.details["source"], "cache")
+        self.mock_cache.get_json.assert_called_once()
+
+    async def test_cache_save_on_success(self):
+        with patch('asyncio.get_running_loop') as mock_loop:
+            mock_dns = AsyncMock()
+            mock_loop.return_value.getaddrinfo = mock_dns
+            mock_dns.return_value = [
+                (socket.AF_INET, socket.SOCK_STREAM, 6, '', ('8.8.8.8', 80))
+            ]
+
+            await self.guard.get_navigation_verdict("http://google.com")
+
+            self.mock_cache.set_json.assert_called_once()
+
+            args, _ = self.mock_cache.set_json.call_args
+            key, data = args
+            self.assertIn("nav_guard_egress", key)
+            self.assertEqual(data["allowed"], True)
+            self.assertEqual(data["reason"], ReasonCode.ALLOWED.value)
+
+    async def test_reputation_check_cached(self):
+        mock_provider = AsyncMock(spec=AbstractReputationProvider)
+        guard = NavigationGuard(reputation_provider=mock_provider, cache=self.mock_cache)
+
+        mock_provider.check_url.return_value = False
+
+        with patch('asyncio.get_running_loop') as mock_loop:
+            mock_dns = AsyncMock()
+            mock_loop.return_value.getaddrinfo = mock_dns
+            mock_dns.return_value = [(socket.AF_INET, 6, 6, '', ('8.8.8.8', 80))]
+
+            verdict = await guard.get_navigation_verdict(
+                "http://phishing.com",
+                context={'check_reputation': True}
+            )
+
+            self.assertFalse(verdict.allowed)
+            self.assertEqual(verdict.reason, ReasonCode.BLOCKED_UNSAFE_REPUTATION)
+
+            self.mock_cache.set_json.assert_called_once()
+            _, data = self.mock_cache.set_json.call_args[0]
+            self.assertEqual(data['reason'], ReasonCode.BLOCKED_UNSAFE_REPUTATION.value)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/app/ai-app/services/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/tools/backends/web/reputation/abstract_reputation_provider.py
+++ b/app/ai-app/services/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/tools/backends/web/reputation/abstract_reputation_provider.py
@@ -1,0 +1,6 @@
+from abc import ABC, abstractmethod
+
+class AbstractReputationProvider(ABC):
+    @abstractmethod
+    async def check_url(self, url: str) -> bool:
+        pass

--- a/app/ai-app/services/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/tools/backends/web/reputation/google_safe_browsing_provider.py
+++ b/app/ai-app/services/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/tools/backends/web/reputation/google_safe_browsing_provider.py
@@ -1,0 +1,50 @@
+import aiohttp
+
+from reputation.abstract_reputation_provider import AbstractReputationProvider
+
+
+class GoogleSafeBrowsingReputationProvider(AbstractReputationProvider):
+    API_URL = "https://safebrowsing.googleapis.com/v4/threatMatches:find"
+
+    def __init__(self, api_key: str, client_id: str = "url-checker", client_ver: str = "1.0.0"):
+        self.api_key = api_key
+        self.client_id = client_id
+        self.client_ver = client_ver
+
+    async def check_url(self, url: str) -> bool:
+        params = {'key': self.api_key}
+
+        payload = {
+            "client": {
+                "clientId": self.client_id,
+                "clientVersion": self.client_ver
+            },
+            "threatInfo": {
+                "threatTypes": [
+                    "MALWARE",
+                    "SOCIAL_ENGINEERING",
+                    "UNWANTED_SOFTWARE",
+                    "POTENTIALLY_HARMFUL_APPLICATION"
+                ],
+                "platformTypes": ["ANY_PLATFORM"],
+                "threatEntryTypes": ["URL"],
+                "threatEntries": [
+                    {"url": url}
+                ]
+            }
+        }
+
+        async with aiohttp.ClientSession() as session:
+            try:
+                async with session.post(self.API_URL, params=params, json=payload) as resp:
+                    if resp.status != 200:
+                        return True
+
+                    data = await resp.json()
+
+                    if not data or "matches" not in data:
+                        return True
+                    return False
+
+            except Exception:
+                return True


### PR DESCRIPTION
Added a comprehensive SSRF (Server-Side Request Forgery) protection layer for outbound web requests. This includes:
- NavigationGuard: A core component to validate URLs and hostnames before connection. It checks for:
    - Blocked IP ranges (Localhost, Private, Link-Local, Multicast, Reserved).
    - Blocked hostnames (e.g., localhost, metadata services).
    - DNS resolution to validate underlying IPs.
    - URL Allowlisting and Blocklisting support.
- Caching of verification verdicts to improve performance.
- Integration interface for URL reputation providers (`AbstractReputationProvider`).
- Implementation of Google Safe Browsing as a reputation provider.
- Unit tests for policy enforcement and resolution logic.
- Example usage script.