### PR TITLE
Pdf footer bundle config

### DIFF
--- a/app/ai-app/deployment/bundles.yaml
+++ b/app/ai-app/deployment/bundles.yaml
@@ -2,6 +2,9 @@ bundles:
   version: "1"
   default_bundle_id: "app@2-0"
   items:
+    - id: "react@2026-02-10-02-44"
+      config:
+        pdf_footer: "Made by KDCube"
     - id: "app@2-0"
       name: "Customer App"
       repo: "git@github.com:org/customer-repo.git"
@@ -9,6 +12,7 @@ bundles:
       subdir: "service/bundles"
       module: "app@2-0.entrypoint"
       config:
+        pdf_footer: "Made by Customer App"
         model_id: "gpt-4o-mini"
         features:
           web_search: true

--- a/app/ai-app/docs/sdk/bundle/bundle-platform-properties-README.md
+++ b/app/ai-app/docs/sdk/bundle/bundle-platform-properties-README.md
@@ -51,6 +51,7 @@ runtime secrets provider: `secrets-service`, `aws-sm`, `secrets-file`, or
 | `execution.runtime` | no default | `BaseEntrypoint`, `RuntimeCtx`, exec runtime | Per-bundle exec runtime selection/overrides |
 | `exec_runtime` | no default | same as `execution.runtime` | Legacy compatibility alias for `execution.runtime` |
 | `mcp.services` | no default | `BaseWorkflow`, MCP runtime/bootstrap | MCP server transport/auth config for tool subsystem |
+| `pdf_footer` | no default | `rendering_tools.write_pdf` | Per-bundle footer text embedded in all rendered PDF formats (markdown, html, mermaid). Read via `get_plain("b:bundles.items.<bundle_id>.pdf_footer")`. |
 
 ## `role_models`
 
@@ -334,6 +335,29 @@ config:
             - sg-<group_id>  # terraform output -raw ecs_tasks_sg_id
           assign_public_ip: DISABLED
 ```
+
+## `pdf_footer`
+
+This property controls the footer text embedded by `rendering_tools.write_pdf` into produced PDF files.
+
+When set, the footer is injected directly into the rendered content (not as a Chromium page margin header/footer), so it is visible in both the canvas preview window and the downloaded PDF.
+
+Applies to all three input formats: `markdown`, `html`, and `mermaid`.
+
+Example:
+
+```yaml
+config:
+  pdf_footer: "Made by Acme Corp"
+```
+
+Read by the platform via:
+
+```python
+get_plain(f"b:bundles.items.{bundle_id}.pdf_footer")
+```
+
+Bundle id is resolved from the current execution context (request context → `RUNTIME_GLOBALS_JSON` → env vars), so the correct bundle footer is applied in all runtimes: react agent loop and isolated code execution.
 
 ## Bundle author guidance
 

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/ingress/economics/routines.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/ingress/economics/routines.py
@@ -13,7 +13,7 @@ from zoneinfo import ZoneInfo
 import redis.asyncio as aioredis
 from croniter import croniter
 
-from kdcube_ai_app.apps.chat.sdk.config import get_settings, get_secret, read_plain
+from kdcube_ai_app.apps.chat.sdk.config import get_settings, get_secret, read_plain, _plain_or_settings
 from kdcube_ai_app.apps.chat.sdk.infra.economics.project_budget import ProjectBudgetLimiter
 from kdcube_ai_app.infra.redis.client import get_async_redis_client
 
@@ -22,13 +22,6 @@ logger = logging.getLogger(__name__)
 SUBSCRIPTION_TZ = ZoneInfo("UTC")
 
 _economics_redis: Optional[aioredis.Redis] = None
-
-
-def _plain_or_settings(plain_key: str, settings_attr: str, default=None):
-    value = read_plain(plain_key, default=None)
-    if value is not None:
-        return value
-    return getattr(get_settings(), settings_attr, default)
 
 
 async def _get_redis() -> Optional[aioredis.Redis]:

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/config.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/config.py
@@ -129,17 +129,14 @@ def _parse_plain_key(key: str) -> tuple[Path, str]:
     raw = str(key or "").strip()
     if not raw:
         return _ASSEMBLY_YAML_PATH, ""
-    for prefix in ("a:", "assembly:"):
+    for prefix, path in {
+        "a:": _ASSEMBLY_YAML_PATH,
+        "assembly:": _ASSEMBLY_YAML_PATH,
+        "b:": _BUNDLES_YAML_PATH,
+        "bundles:": _BUNDLES_YAML_PATH,
+    }.items():
         if raw.startswith(prefix):
-            return _ASSEMBLY_YAML_PATH, raw[len(prefix):]
-    for prefix in ("b:", "bundles:"):
-        if raw.startswith(prefix):
-            tail = raw[len(prefix):]
-            # Auto-inject "bundles.items." so callers write get_plain("b:<bundle_id>.<key>")
-            # matching the bundles.yaml list structure, without knowing the internal path.
-            if tail and not tail.startswith("bundles."):
-                tail = "bundles.items." + tail
-            return _BUNDLES_YAML_PATH, tail
+            return path, raw[len(prefix):]
     return _ASSEMBLY_YAML_PATH, raw
 
 

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/config.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/config.py
@@ -212,6 +212,12 @@ def get_plain(key: str, default: Any = None) -> Any:
 def read_plain(key: str, default: Any = None) -> Any:
     return get_plain(key, default=default)
 
+def _plain_or_settings(plain_key: str, settings_attr: str, default=None):
+    value = read_plain(plain_key, default=None)
+    if value is not None:
+        return value
+    return getattr(get_settings(), settings_attr, default)
+
 
 def _resolve_current_user_bundle_scope(
     *,

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/config.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/config.py
@@ -129,14 +129,17 @@ def _parse_plain_key(key: str) -> tuple[Path, str]:
     raw = str(key or "").strip()
     if not raw:
         return _ASSEMBLY_YAML_PATH, ""
-    for prefix, path in {
-        "a:": _ASSEMBLY_YAML_PATH,
-        "assembly:": _ASSEMBLY_YAML_PATH,
-        "b:": _BUNDLES_YAML_PATH,
-        "bundles:": _BUNDLES_YAML_PATH,
-    }.items():
+    for prefix in ("a:", "assembly:"):
         if raw.startswith(prefix):
-            return path, raw[len(prefix):]
+            return _ASSEMBLY_YAML_PATH, raw[len(prefix):]
+    for prefix in ("b:", "bundles:"):
+        if raw.startswith(prefix):
+            tail = raw[len(prefix):]
+            # Auto-inject "bundles.items." so callers write get_plain("b:<bundle_id>.<key>")
+            # matching the bundles.yaml list structure, without knowing the internal path.
+            if tail and not tail.startswith("bundles."):
+                tail = "bundles.items." + tail
+            return _BUNDLES_YAML_PATH, tail
     return _ASSEMBLY_YAML_PATH, raw
 
 

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/config.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/config.py
@@ -193,13 +193,31 @@ def _resolve_dotted_value(data: Any, dotted_path: str) -> Any:
                 return None
             continue
         if isinstance(cur, list):
-            if not segment.isdigit():
+            if segment.isdigit():
+                list_idx = int(segment)
+                if list_idx < 0 or list_idx >= len(cur):
+                    return None
+                cur = cur[list_idx]
+                idx += 1
+                continue
+            # Search list items by "id" field, supporting compound ids with dots
+            found = None
+            next_idx = idx
+            for end in range(len(segments), idx, -1):
+                compound = ".".join(segments[idx:end])
+                for item in cur:
+                    if isinstance(item, dict) and item.get("id") == compound:
+                        found = item
+                        next_idx = end
+                        break
+                if found is not None:
+                    break
+            if found is None:
                 return None
-            list_idx = int(segment)
-            if list_idx < 0 or list_idx >= len(cur):
-                return None
-            cur = cur[list_idx]
-            idx += 1
+            # Navigate into "config" section if present — b:<bundle_id>.<key>
+            # resolves as bundle["config"]["<key>"], not bundle["<key>"]
+            cur = found.get("config", found)
+            idx = next_idx
             continue
         return None
     return cur

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/tools/md2pdf_async.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/tools/md2pdf_async.py
@@ -448,8 +448,11 @@ class AsyncMarkdownPDF:
             page_size = self.pdf_options.format or "A4"
 
             # 4) Add **generic** print CSS (not tailored to any particular HTML)
+            # bottom margin must match pdf_options.margin_bottom so CSS layout and
+            # Playwright's footer zone don't overlap when display_header_footer=True
+            _bottom_margin = self.pdf_options.margin_bottom or "20mm"
             PRINT_SAFE_CSS = f"""
-            @page {{ size: {page_size} {orient}; margin: 16mm 16mm 20mm 16mm; }}
+            @page {{ size: {page_size} {orient}; margin: 16mm 16mm {_bottom_margin} 16mm; }}
             
             * {{ -webkit-print-color-adjust: exact; print-color-adjust: exact; }}
             

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/tools/rendering_tools.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/tools/rendering_tools.py
@@ -11,7 +11,7 @@ import re
 import json
 import textwrap
 import asyncio
-from typing import Annotated, Optional, Any, Dict
+from typing import Annotated, Optional, Any, Dict, List
 
 import semantic_kernel as sk
 import logging
@@ -30,6 +30,8 @@ from kdcube_ai_app.apps.chat.sdk.tools.docx_renderer import render_docx
 from kdcube_ai_app.apps.chat.sdk.tools.pptx_renderer import render_pptx
 from kdcube_ai_app.apps.chat.sdk.tools.md2pdf_async import AsyncMarkdownPDF, PDFOptions, get_shared_md2pdf
 from kdcube_ai_app.apps.chat.sdk.util import _defence
+from kdcube_ai_app.infra.accounting import _get_context
+from kdcube_ai_app.apps.chat.sdk.config import get_plain
 
 # Bound at runtime by ToolManager
 _SERVICE = None

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/tools/rendering_tools.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/tools/rendering_tools.py
@@ -30,7 +30,7 @@ from kdcube_ai_app.apps.chat.sdk.tools.docx_renderer import render_docx
 from kdcube_ai_app.apps.chat.sdk.tools.pptx_renderer import render_pptx
 from kdcube_ai_app.apps.chat.sdk.tools.md2pdf_async import AsyncMarkdownPDF, PDFOptions, get_shared_md2pdf
 from kdcube_ai_app.apps.chat.sdk.util import _defence
-from kdcube_ai_app.apps.chat.sdk.config import get_plain
+from kdcube_ai_app.apps.chat.sdk.config import get_plain, _resolve_current_bundle_id
 
 # Bound at runtime by ToolManager
 _SERVICE = None
@@ -46,6 +46,62 @@ def bind_integrations(integrations):
 
 logger = logging.getLogger("rendering_tools")
 _DATA_URI_RE = re.compile(r"data:[^;]+;base64,", re.IGNORECASE)
+
+_FOOTER_DIV_STYLE = (
+    "font-size:8pt;color:#6b7280;text-align:center;"
+    "border-top:1px solid #e5e7eb;padding-top:6px;margin-top:20px;"
+    "width:100%;"
+)
+
+
+def _pdf_bundle_id() -> str | None:
+    """Resolve bundle id for the current execution context.
+
+    Tries RUNTIME_GLOBALS_JSON (set by iso runtime) first, then falls back
+    to the request-context / env-var resolver so the tool works in both the
+    react-agent loop and isolated code-execution runtimes.
+    """
+    import json as _json
+    rg = _json.loads(os.getenv("RUNTIME_GLOBALS_JSON") or "{}")
+    bid = str((rg.get("EXEC_CONTEXT") or {}).get("bundle_id") or "").strip()
+    if bid:
+        return bid
+    try:
+        return _resolve_current_bundle_id()
+    except Exception:
+        return None
+
+
+def _pdf_footer_text() -> str | None:
+    """Return the configured pdf_footer for the current bundle, or None."""
+    bundle_id = _pdf_bundle_id()
+    if not bundle_id:
+        return None
+    return get_plain(f"b:{bundle_id}.pdf_footer") or None
+
+
+def _inject_footer_html(html_content: str, footer_text: str) -> str:
+    """Embed footer div before </body>; append at end if tag not found."""
+    import html as _html
+    footer_div = (
+        f'<div style="{_FOOTER_DIV_STYLE}">'
+        f'{_html.escape(str(footer_text))}</div>'
+    )
+    lower = html_content.lower()
+    idx = lower.rfind("</body>")
+    if idx != -1:
+        return html_content[:idx] + footer_div + "\n" + html_content[idx:]
+    return html_content + "\n" + footer_div
+
+
+def _inject_footer_md(md_content: str, footer_text: str) -> str:
+    """Append footer as an HTML div at the end of markdown content."""
+    import html as _html
+    footer_div = (
+        f'\n\n<div style="{_FOOTER_DIV_STYLE}">'
+        f'{_html.escape(str(footer_text))}</div>'
+    )
+    return md_content + footer_div
 
 
 def _warn_on_data_uri(content: str, tool_name: str) -> None:
@@ -868,6 +924,10 @@ class RenderingTools:
                 conv.pdf_options.landscape = landscape
                 conv.extra_css = []
 
+                _mermaid_footer = _pdf_footer_text()
+                if _mermaid_footer:
+                    mermaid_html = _inject_footer_html(mermaid_html, _mermaid_footer)
+
                 await conv.convert_html_string(
                     html=mermaid_html,
                     output_pdf=str(out_path),
@@ -889,20 +949,6 @@ class RenderingTools:
                 conv.extra_css = []
                 conv.pdf_options.display_header_footer = False
                 conv.pdf_options.landscape = landscape
-                import json as _json
-                _rg_html = _json.loads(os.getenv("RUNTIME_GLOBALS_JSON") or "{}")
-                _bid_html = str((_rg_html.get("EXEC_CONTEXT") or {}).get("bundle_id") or "").strip() or None
-                if _bid_html:
-                    _footer_html = get_plain(f"b:bundles.items.{_bid_html}.pdf_footer")
-                    if _footer_html:
-                        import html as _html
-                        conv.pdf_options.footer_html = (
-                            f'<div style="font-size:8pt;color:#6b7280;width:100%;'
-                            f'text-align:center;padding:4px 10mm 0;">'
-                            f'{_html.escape(str(_footer_html))}</div>'
-                        )
-                        conv.pdf_options.display_header_footer = True
-                        conv.pdf_options.margin_bottom = "20mm"
                 content = _ensure_html_wrapper(content, title=title or "Document")
                 if resolve_citations:
                     try:
@@ -917,6 +963,10 @@ class RenderingTools:
                                 content = _replace_html_citations(content, cmap)
                     except Exception:
                         pass
+
+                _html_footer = _pdf_footer_text()
+                if _html_footer:
+                    content = _inject_footer_html(content, _html_footer)
 
                 await conv.convert_html_string(
                     html=content,
@@ -973,23 +1023,6 @@ class RenderingTools:
 
             conv.pdf_options = pdf_opts
 
-            import json as _json
-            _rg = _json.loads(os.getenv("RUNTIME_GLOBALS_JSON") or "{}")
-            bundle_id = str((_rg.get("EXEC_CONTEXT") or {}).get("bundle_id") or "").strip() or None
-
-            if bundle_id:
-                pdf_footer = get_plain(f"b:bundles.items.{bundle_id}.pdf_footer")
-
-                if pdf_footer:
-                    import html as _html
-
-                    conv.pdf_options.footer_html = (
-                        f'<div style="font-size:8pt;color:#6b7280;width:100%;'
-                        f'text-align:center;padding:4px 10mm 0;">'
-                        f'{_html.escape(str(pdf_footer))}</div>'
-                    )
-                    conv.pdf_options.display_header_footer = True
-
             conv.enable_mathjax = False
             conv.extra_css = css_files
 
@@ -1006,6 +1039,11 @@ class RenderingTools:
 
             if include_sources_section and by_id:
                 final_md += md_utils._create_clean_sources_section(by_id, order)
+
+            _md_footer = _pdf_footer_text()
+            if _md_footer:
+                final_md = _inject_footer_md(final_md, _md_footer)
+
             await conv.convert_string(
                 markdown_text=final_md,
                 output_pdf=str(out_path),

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/tools/rendering_tools.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/tools/rendering_tools.py
@@ -77,7 +77,7 @@ def _pdf_footer_text() -> str | None:
     bundle_id = _pdf_bundle_id()
     if not bundle_id:
         return None
-    return get_plain(f"b:{bundle_id}.pdf_footer") or None
+    return get_plain(f"b:bundles.items.{bundle_id}.pdf_footer") or None
 
 
 def _inject_footer_html(html_content: str, footer_text: str) -> str:

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/tools/rendering_tools.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/tools/rendering_tools.py
@@ -30,7 +30,6 @@ from kdcube_ai_app.apps.chat.sdk.tools.docx_renderer import render_docx
 from kdcube_ai_app.apps.chat.sdk.tools.pptx_renderer import render_pptx
 from kdcube_ai_app.apps.chat.sdk.tools.md2pdf_async import AsyncMarkdownPDF, PDFOptions, get_shared_md2pdf
 from kdcube_ai_app.apps.chat.sdk.util import _defence
-from kdcube_ai_app.infra.accounting import _get_context
 from kdcube_ai_app.apps.chat.sdk.config import get_plain
 
 # Bound at runtime by ToolManager
@@ -890,6 +889,20 @@ class RenderingTools:
                 conv.extra_css = []
                 conv.pdf_options.display_header_footer = False
                 conv.pdf_options.landscape = landscape
+                import json as _json
+                _rg_html = _json.loads(os.getenv("RUNTIME_GLOBALS_JSON") or "{}")
+                _bid_html = str((_rg_html.get("EXEC_CONTEXT") or {}).get("bundle_id") or "").strip() or None
+                if _bid_html:
+                    _footer_html = get_plain(f"b:bundles.items.{_bid_html}.pdf_footer")
+                    if _footer_html:
+                        import html as _html
+                        conv.pdf_options.footer_html = (
+                            f'<div style="font-size:8pt;color:#6b7280;width:100%;'
+                            f'text-align:center;padding:4px 10mm 0;">'
+                            f'{_html.escape(str(_footer_html))}</div>'
+                        )
+                        conv.pdf_options.display_header_footer = True
+                        conv.pdf_options.margin_bottom = "20mm"
                 content = _ensure_html_wrapper(content, title=title or "Document")
                 if resolve_citations:
                     try:
@@ -959,6 +972,23 @@ class RenderingTools:
                 )
 
             conv.pdf_options = pdf_opts
+
+            import json as _json
+            _rg = _json.loads(os.getenv("RUNTIME_GLOBALS_JSON") or "{}")
+            bundle_id = str((_rg.get("EXEC_CONTEXT") or {}).get("bundle_id") or "").strip() or None
+
+            if bundle_id:
+                pdf_footer = get_plain(f"b:bundles.items.{bundle_id}.pdf_footer")
+
+                if pdf_footer:
+                    import html as _html
+
+                    conv.pdf_options.footer_html = (
+                        f'<div style="font-size:8pt;color:#6b7280;width:100%;'
+                        f'text-align:center;padding:4px 10mm 0;">'
+                        f'{_html.escape(str(pdf_footer))}</div>'
+                    )
+                    conv.pdf_options.display_header_footer = True
 
             conv.enable_mathjax = False
             conv.extra_css = css_files

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/infra/channel/email.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/infra/channel/email.py
@@ -5,16 +5,9 @@ import logging
 from email.message import EmailMessage
 from typing import Optional, Sequence
 
-from kdcube_ai_app.apps.chat.sdk.config import get_settings, get_secret, read_plain
+from kdcube_ai_app.apps.chat.sdk.config import get_settings, get_secret, read_plain, _plain_or_settings
 
 logger = logging.getLogger(__name__)
-
-
-def _plain_or_settings(plain_key: str, settings_attr: str, default=None):
-    value = read_plain(plain_key, default=None)
-    if value is not None:
-        return value
-    return getattr(get_settings(), settings_attr, default)
 
 
 def _smtp_settings() -> dict:


### PR DESCRIPTION
 ## Bundle-driven PDF footer for write_pdf                                                                                                                                
                                                                                                                                                                           
  Adds support for a per-bundle `pdf_footer` config value that is automatically                                                                                            
  embedded into all PDFs produced by `rendering_tools.write_pdf`.                                                                                                          
                                                                                                                                                                           
  ### How it works
                                                                                                                                                                           
  Set `pdf_footer` in `bundles.yaml` for a bundle:                                                                                                                         
   
  ```yaml                                                                                                                                                                  
  config:         
    pdf_footer: "Made by Acme Corp"

  The footer is embedded directly into the rendered content for all three                                                                                                  
  input formats (markdown, html, mermaid), so it appears both in the
  canvas preview window and in the downloaded PDF.                                                                                                                         
                  
  Bundle id is resolved from the current execution context and works in all                                                                                                
  runtimes: react-agent loop and isolated code execution.
                                                                                                                                                                           
  Changes         
                                                                                                                                                                           
  - rendering_tools.py — footer injection helpers + applied to all formats                                                                                                 
  - config.py — bundle id resolution across runtimes
  - bundle-platform-properties-README.md — pdf_footer documented as a                                                                                                      
  reserved bundle platform property
