### PR TITLE
feat(economics): SQL usage ledger billing + deploy/sink defect fixes

### DIFF
--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/ingress/economics/admin.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/ingress/economics/admin.py
@@ -4,6 +4,7 @@
 # apps/chat/ingress/economics/admin.py
 
 import logging
+from datetime import datetime, timezone
 from typing import Optional
 
 from pydantic import BaseModel, Field
@@ -314,3 +315,59 @@ async def list_pending_stripe_requests(
         })
 
     return {"status": "ok", "count": len(items), "items": items}
+
+
+@admin_router.get("/admin/cost-by-user")
+async def get_cost_by_user(
+        date_from: str | None = Query(
+            None, description="Start date YYYY-MM-DD (default: first of current month, UTC)"
+        ),
+        date_to: str | None = Query(
+            None, description="End date YYYY-MM-DD inclusive (default: today, UTC)"
+        ),
+        session: UserSession = Depends(auth_without_pressure()),
+):
+    """Real (ledger-derived) spend per user across the workspace, sorted by cost.
+
+    Aggregates actual usage from the accounting ledger and prices it per model
+    with real input/output/cache rates (the same engine behind /api/opex/*), so
+    the admin "cost per user" view reflects true spend rather than the
+    quota-equivalent estimate used for rate-limit enforcement.
+    """
+    settings = get_settings()
+
+    today = datetime.now(timezone.utc).date()
+    df = date_from or today.replace(day=1).isoformat()
+    dt = date_to or today.isoformat()
+
+    # Authoritative source: the SQL usage ledger view. Fall back to the
+    # file-based accounting scan only if the DB is unavailable or empty for the
+    # window (e.g. before the migration / sink is deployed).
+    pg_pool = getattr(router.state, "pg_pool", None)
+    res = None
+    if pg_pool is not None:
+        try:
+            from kdcube_ai_app.apps.chat.sdk.infra.economics.usage_ledger import UsageLedgerStore
+            store = UsageLedgerStore(pg_pool, tenant=settings.TENANT, project=settings.PROJECT)
+            if await store.has_data(date_from=df, date_to=dt):
+                res = await store.cost_by_user(date_from=df, date_to=dt)
+        except Exception:
+            logger.exception("SQL usage ledger read failed; falling back to file accounting")
+            res = None
+
+    if res is None:
+        from kdcube_ai_app.apps.chat.ingress.opex.cost import build_rate_calculator, cost_by_user
+        calc = build_rate_calculator()
+        try:
+            res = await cost_by_user(
+                calc,
+                tenant=settings.TENANT,
+                project=settings.PROJECT,
+                date_from=df,
+                date_to=dt,
+            )
+        except Exception as e:
+            logger.exception("Admin cost-by-user failed")
+            raise HTTPException(status_code=500, detail=str(e))
+
+    return {"status": "ok", **res}

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/ingress/economics/me.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/ingress/economics/me.py
@@ -4,6 +4,7 @@
 # apps/chat/ingress/economics/me.py
 
 import logging
+from datetime import datetime, timezone
 
 from fastapi import Depends, HTTPException, Query, APIRouter
 
@@ -86,6 +87,65 @@ async def get_my_budget_breakdown(
         reservations_limit=50,
         bundle_ids=[resolved_bundle_id] if resolved_bundle_id else None,
     )
+
+
+@me_router.get("/me/cost-breakdown")
+async def get_my_cost_breakdown(
+        date_from: str | None = Query(
+            None, description="Start date YYYY-MM-DD (default: first of current month, UTC)"
+        ),
+        date_to: str | None = Query(
+            None, description="End date YYYY-MM-DD inclusive (default: today, UTC)"
+        ),
+        session: UserSession = Depends(require_auth(RequireUser())),
+):
+    """Real (ledger-derived) spend for the authenticated user, broken down by model.
+
+    Unlike /me/budget-breakdown (which reports quota-equivalent dollars: blended
+    tokens priced at the reference model's OUTPUT rate), this reports actual spend
+    computed per model with real input/output/cache rates from the price table.
+    """
+    settings = get_settings()
+    user_id = session.user_id
+    if not user_id:
+        raise HTTPException(status_code=401, detail="User ID not found in session")
+
+    today = datetime.now(timezone.utc).date()
+    df = date_from or today.replace(day=1).isoformat()
+    dt = date_to or today.isoformat()
+
+    # Authoritative source: the SQL usage ledger. Fall back to the file-based
+    # accounting scan only if the DB is unavailable or has no rows for the window
+    # (e.g. before the migration / sink is deployed).
+    pg_pool = getattr(router.state, "pg_pool", None)
+    res = None
+    if pg_pool is not None:
+        try:
+            from kdcube_ai_app.apps.chat.sdk.infra.economics.usage_ledger import UsageLedgerStore
+            store = UsageLedgerStore(pg_pool, tenant=settings.TENANT, project=settings.PROJECT)
+            if await store.has_data(date_from=df, date_to=dt):
+                res = await store.cost_for_user(user_id=user_id, date_from=df, date_to=dt)
+        except Exception:
+            logger.exception("SQL usage ledger read failed; falling back to file accounting")
+            res = None
+
+    if res is None:
+        from kdcube_ai_app.apps.chat.ingress.opex.cost import build_rate_calculator, cost_for_user
+        calc = build_rate_calculator()
+        try:
+            res = await cost_for_user(
+                calc,
+                tenant=settings.TENANT,
+                project=settings.PROJECT,
+                user_id=user_id,
+                date_from=df,
+                date_to=dt,
+            )
+        except Exception as e:
+            logger.exception("User cost-breakdown failed")
+            raise HTTPException(status_code=500, detail=str(e))
+
+    return {"status": "ok", **res}
 
 
 @me_router.get("/me/subscription")

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/ingress/opex/cost.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/ingress/opex/cost.py
@@ -1,0 +1,187 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Elena Viter
+
+# apps/chat/ingress/opex/cost.py
+"""
+Shared true-cost helpers.
+
+Turns accounting usage *rollups* into real USD spend, priced per (service,
+provider, model) with each model's own input/output (and cache) rates via the
+canonical engine `infra.accounting.usage.compute_rollup_cost` -- the SAME
+computation that powers /api/opex/*. So every "cost per user" surface agrees to
+the cent.
+
+Why this exists:
+    The economics dashboards historically priced usage as
+    `equivalent_tokens * reference_model_OUTPUT_rate` (see
+    user_budget.UserBudgetBreakdownService): that charges input tokens at the
+    output rate and prices every model at the reference model's rate. It is a
+    quota-equivalent estimate, NOT real spend. These helpers expose the real,
+    per-model spend so both the user and admin dashboards can show it.
+
+Consumers:
+    - GET /api/economics/me/cost-breakdown   (this user's true spend)
+    - GET /api/economics/admin/cost-by-user  (per-user true spend, all users)
+"""
+from typing import Any, Dict, List
+
+from kdcube_ai_app.infra.accounting.usage import compute_rollup_cost
+
+__all__ = [
+    "build_rate_calculator",
+    "assemble_cost",
+    "cost_for_user",
+    "cost_by_user",
+]
+
+
+def build_rate_calculator():
+    """Construct a RateCalculator over the configured accounting storage.
+
+    Mirrors opex.opex._get_calculator (raw events under 'accounting', rolled-up
+    aggregates under 'analytics') but without the app.state cache, so routers
+    that only have get_settings() available can use it. Heavy deps are imported
+    lazily so this module's pure helpers stay importable on their own.
+    """
+    from kdcube_ai_app.apps.chat.sdk.config import get_settings
+    from kdcube_ai_app.storage.storage import create_storage_backend
+    from kdcube_ai_app.infra.accounting.calculator import RateCalculator
+
+    settings = get_settings()
+    kdcube_path = settings.STORAGE_PATH or "file:///tmp/kdcube_data"
+    backend = create_storage_backend(kdcube_path)
+    return RateCalculator(backend, base_path="accounting", agg_base="analytics")
+
+
+def _tokens_from_rollup(rollup: List[dict]) -> Dict[str, int]:
+    """Sum raw token counts across a rollup, split by kind (for display)."""
+    agg = {
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "cache_read_tokens": 0,
+        "cache_write_tokens": 0,
+        "embedding_tokens": 0,
+    }
+    for item in rollup or []:
+        spent = item.get("spent", {}) or {}
+        agg["input_tokens"] += int(spent.get("input", 0) or 0)
+        agg["output_tokens"] += int(spent.get("output", 0) or 0)
+        agg["cache_read_tokens"] += int(spent.get("cache_read", 0) or 0)
+        agg["cache_write_tokens"] += (
+            int(spent.get("cache_5m_write", 0) or 0)
+            + int(spent.get("cache_1h_write", 0) or 0)
+            + int(spent.get("cache_creation", 0) or 0)
+        )
+        agg["embedding_tokens"] += int(spent.get("tokens", 0) or 0)
+    return agg
+
+
+def assemble_cost(rollup: List[dict]) -> Dict[str, Any]:
+    """Turn a usage rollup into a compact true-cost payload.
+
+    Returns {total_cost_usd, by_model[], tokens{}} where each by_model entry is
+    {service, provider, model, cost_usd} priced with real per-model input/output
+    (and cache) rates.
+    """
+    rollup = rollup or []
+    est = compute_rollup_cost(rollup) or {}
+    breakdown = est.get("breakdown", []) or []
+
+    # compute_rollup_cost preserves input order (one breakdown entry per rollup
+    # item), so zip to attach each line's token split for a per-model table.
+    by_model = []
+    for item, b in zip(rollup, breakdown):
+        spent = item.get("spent", {}) or {}
+        by_model.append({
+            **b,
+            "input_tokens": int(spent.get("input", 0) or 0),
+            "output_tokens": int(spent.get("output", 0) or 0),
+            "embedding_tokens": int(spent.get("tokens", 0) or 0),
+        })
+
+    return {
+        "total_cost_usd": round(float(est.get("total_cost_usd", 0.0) or 0.0), 6),
+        "by_model": by_model,
+        "tokens": _tokens_from_rollup(rollup),
+    }
+
+
+def _event_count(user_data: dict) -> int:
+    # The aggregate path exposes event_count at the top level of the user entry;
+    # the raw-scan fallback nests it inside "total". Accept either.
+    user_data = user_data or {}
+    raw = user_data.get("event_count")
+    if raw is None:
+        raw = (user_data.get("total") or {}).get("event_count", 0)
+    try:
+        return int(raw or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+async def cost_for_user(
+    calc,
+    *,
+    tenant: str,
+    project: str,
+    user_id: str,
+    date_from: str,
+    date_to: str,
+) -> Dict[str, Any]:
+    """True spend for a single user over [date_from, date_to] (YYYY-MM-DD).
+
+    Uses the calculator's single-user path so we never build or price every
+    other user's usage just to report one user's spend.
+    """
+    user_data = await calc.usage_for_user(
+        tenant_id=tenant,
+        project_id=project,
+        user_id=user_id,
+        date_from=date_from,
+        date_to=date_to,
+    ) or {}
+    rollup = user_data.get("rollup") or []
+    out = assemble_cost(rollup)
+    out.update(
+        {
+            "user_id": user_id,
+            "date_from": date_from,
+            "date_to": date_to,
+            "event_count": _event_count(user_data),
+        }
+    )
+    return out
+
+
+async def cost_by_user(
+    calc,
+    *,
+    tenant: str,
+    project: str,
+    date_from: str,
+    date_to: str,
+) -> Dict[str, Any]:
+    """True spend per user across the workspace, sorted by cost descending."""
+    by_user = await calc.usage_by_user(
+        tenant_id=tenant,
+        project_id=project,
+        date_from=date_from,
+        date_to=date_to,
+    )
+
+    users: List[Dict[str, Any]] = []
+    total = 0.0
+    for uid, user_data in (by_user or {}).items():
+        rollup = (user_data or {}).get("rollup") or []
+        c = assemble_cost(rollup)
+        total += c["total_cost_usd"]
+        users.append({"user_id": uid, **c, "event_count": _event_count(user_data)})
+
+    users.sort(key=lambda u: u["total_cost_usd"], reverse=True)
+    return {
+        "date_from": date_from,
+        "date_to": date_to,
+        "total_cost_usd": round(total, 6),
+        "total_users": len(users),
+        "users": users,
+    }

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/ingress/opex/opex.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/ingress/opex/opex.py
@@ -13,7 +13,7 @@ from kdcube_ai_app.apps.chat.ingress.resolvers import require_auth, auth_without
 from kdcube_ai_app.apps.chat.sdk.config import get_settings
 from kdcube_ai_app.auth.AuthManager import RequireUser
 from kdcube_ai_app.auth.sessions import UserSession
-from kdcube_ai_app.infra.accounting.usage import price_table
+from kdcube_ai_app.infra.accounting.usage import price_table, compute_rollup_cost
 from kdcube_ai_app.storage.storage import create_storage_backend
 from kdcube_ai_app.infra.accounting.calculator import (
     RateCalculator,
@@ -175,122 +175,16 @@ def _compute_cost_estimate(rollup: List[dict]) -> dict:
 
     NOW SUPPORTS: llm, embedding, web_search
     """
-    configuration = price_table()
-    llm_pricelist = configuration.get("llm", [])
-    emb_pricelist = configuration.get("embedding", [])
-    web_search_pricelist = configuration.get("web_search", [])  # NEW
-
     config_str = get_settings().PLATFORM.ACCOUNTING.ACCOUNTING_SERVICES or "{}"
     try:
         accounting_services_config = json.loads(config_str)
     except json.JSONDecodeError:
         accounting_services_config = {}
 
-    def _find_llm_price(provider: str, model: str):
-        for p in llm_pricelist:
-            if p.get("provider") == provider and p.get("model") == model:
-                return p
-        return None
-
-    def _find_emb_price(provider: str, model: str):
-        for p in emb_pricelist:
-            if p.get("provider") == provider and p.get("model") == model:
-                return p
-        return None
-
-    def _find_web_search_price(provider: str, tier: str):
-        """Find web_search price entry by provider and tier."""
-        for p in web_search_pricelist:
-            if p.get("provider") == provider and p.get("tier") == tier:
-                return p
-        return None
-
-    def _get_web_search_tier(provider: str) -> str:
-        """Get tier for web_search provider from config."""
-        web_search_config = accounting_services_config.get("web_search", {})
-        provider_config = web_search_config.get(provider, {})
-        defaults = {"brave": "base", "duckduckgo": "free"}
-        return provider_config.get("tier", defaults.get(provider, "free"))
-
-    total_cost = 0.0
-    breakdown = []
-
-    for item in rollup:
-        service = item.get("service")
-        provider = item.get("provider")
-        model = item.get("model")
-        spent = item.get("spent", {}) or {}
-
-        cost_usd = 0.0
-        tier = None  # for web_search
-        pr = {}
-
-        if service == "llm":
-            pr = _find_llm_price(provider, model)
-            if pr:
-                input_cost = (float(spent.get("input", 0)) / 1_000_000.0) * float(pr.get("input_tokens_1M", 0.0))
-                output_cost = (float(spent.get("output", 0)) / 1_000_000.0) * float(pr.get("output_tokens_1M", 0.0))
-                cache_read_cost = (float(spent.get("cache_read", 0)) / 1_000_000.0) * float(pr.get("cache_read_tokens_1M", 0.0))
-
-                cache_write_cost = 0.0
-                cache_pricing = pr.get("cache_pricing")
-
-                if cache_pricing and isinstance(cache_pricing, dict):
-                    cache_5m_tokens = float(spent.get("cache_5m_write", 0))
-                    cache_1h_tokens = float(spent.get("cache_1h_write", 0))
-
-                    if cache_5m_tokens > 0:
-                        price_5m = float(cache_pricing.get("5m", {}).get("write_tokens_1M", 0.0))
-                        cache_write_cost += (cache_5m_tokens / 1_000_000.0) * price_5m
-
-                    if cache_1h_tokens > 0:
-                        price_1h = float(cache_pricing.get("1h", {}).get("write_tokens_1M", 0.0))
-                        cache_write_cost += (cache_1h_tokens / 1_000_000.0) * price_1h
-                else:
-                    cache_write_tokens = float(spent.get("cache_creation", 0))
-                    cache_write_price = float(pr.get("cache_write_tokens_1M", 0.0))
-                    cache_write_cost = (cache_write_tokens / 1_000_000.0) * cache_write_price
-
-                cost_usd = input_cost + output_cost + cache_write_cost + cache_read_cost
-
-        elif service == "embedding":
-            pr = _find_emb_price(provider, model)
-            if pr:
-                cost_usd = (float(spent.get("tokens", 0)) / 1_000_000.0) * float(pr.get("tokens_1M", 0.0))
-
-        elif service == "web_search":
-            # NEW: web_search cost calculation
-            tier = _get_web_search_tier(provider)
-            pr = _find_web_search_price(provider, tier)
-
-            if pr:
-                search_queries = float(spent.get("search_queries", 0))
-                cost_per_1k = float(pr.get("cost_per_1k_requests", 0.0))
-                cost_usd = (search_queries / 1000.0) * cost_per_1k
-
-        total_cost += cost_usd
-
-        # Include tier in breakdown for web_search
-        breakdown_item = {
-            "service": service,
-            "provider": provider,
-            "model": model,
-            "cost_usd": cost_usd,
-        }
-
-        if service == "web_search" and tier:
-            breakdown_item["tier"] = tier
-            breakdown_item["search_queries"] = spent.get("search_queries", 0)
-            breakdown_item["search_results"] = spent.get("search_results", 0)
-            if pr:
-                breakdown_item["cost_per_1k_requests"] = pr.get("cost_per_1k_requests", 0.0)
-
-        breakdown.append(breakdown_item)
-
-    return {
-        "total_cost_usd": total_cost,
-        "breakdown": breakdown
-    }
+    # Delegate to the canonical, dependency-light pricing engine in
+    # infra.accounting.usage so /api/opex/* and the economics cost-breakdown
+    # endpoints price usage identically (per-model input/output/cache rates).
+    return compute_rollup_cost(rollup, accounting_services_config=accounting_services_config)
 
 # =============================================================================
 # API Endpoints

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/processor.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/processor.py
@@ -2611,7 +2611,7 @@ class EnhancedChatRequestProcessor:
                         data={"default_model": (payload.config.values or {}).get("selected_model"), "task_id": task_id},
                     )
 
-                    async with bind_accounting(envelope, storage_backend, enabled=True):
+                    async with bind_accounting(envelope, storage_backend, enabled=True, pg_pool=self.pg_pool):
                         async with with_accounting("chat.orchestrator",
                                                    app_bundle_id=payload.routing.bundle_id,
                                                    conversation_id=payload.routing.conversation_id,

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/economics/pricing.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/economics/pricing.py
@@ -1,0 +1,120 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Elena Viter
+
+# apps/chat/sdk/infra/economics/pricing.py
+"""
+Effective-dated model pricing.
+
+Cost is recorded from the provider's REPORTED cost when available (the billed
+ground truth). When it is not reported, cost is computed from a price table --
+and that table is time-versioned here so a price change applies from a chosen
+date forward while historical events keep the price that was in effect.
+
+  * seed_from_code()  -> one-time seed from the in-code price_table() at epoch,
+    so every historical event has a defined fallback price.
+  * update_price()    -> record a new price version effective from a given date
+    ("start the change"); older events are unaffected.
+  * table_as_of(when) -> a price_table()-shaped dict with the rate in effect at
+    `when`, for compute_rollup_cost(). Returns None when unseeded (callers then
+    use the in-code table), so this is fully backward compatible.
+
+Pricing is logically global; it is stored per project schema (alongside the
+usage ledger) so the write/backfill path -- which already holds the project pool
+-- can resolve it without a cross-schema dependency.
+"""
+import json
+import logging
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+from kdcube_ai_app.ops.deployment.sql.db_deployment import project_schema as _project_schema
+from kdcube_ai_app.infra.accounting.usage import price_table
+
+logger = logging.getLogger(__name__)
+
+_EPOCH = datetime(1970, 1, 1, tzinfo=timezone.utc)
+
+
+class ModelPricingStore:
+    def __init__(self, pg_pool, *, tenant: str, project: str):
+        self.pool = pg_pool
+        self.tenant = tenant
+        self.project = project
+        self.schema = _project_schema(tenant, project)
+
+    async def is_empty(self) -> bool:
+        async with self.pool.acquire() as conn:
+            row = await conn.fetchrow(f"SELECT 1 FROM {self.schema}.model_pricing LIMIT 1")
+        return row is None
+
+    async def seed_from_code(self, *, force: bool = False) -> int:
+        """Seed the table from the in-code price_table() (effective at epoch).
+
+        No-op if already seeded (unless force). Returns rows inserted.
+        """
+        if not force and not await self.is_empty():
+            return 0
+        pt = price_table() or {}
+        rows: List[tuple] = []
+        for svc in ("llm", "embedding", "web_search"):
+            for item in (pt.get(svc) or []):
+                provider = item.get("provider")
+                model = item.get("model") or item.get("tier")
+                if not provider or not model:
+                    continue
+                rows.append((svc, provider, model, json.dumps(item), _EPOCH, "seed:code"))
+        if not rows:
+            return 0
+        async with self.pool.acquire() as conn:
+            await conn.executemany(
+                f"""INSERT INTO {self.schema}.model_pricing
+                    (service_type, provider, model, rates, effective_from, note)
+                    VALUES ($1,$2,$3,$4::jsonb,$5,$6)""",
+                rows,
+            )
+        return len(rows)
+
+    async def update_price(
+        self,
+        *,
+        service_type: str,
+        provider: str,
+        model: str,
+        rates: Dict[str, Any],
+        effective_from: Optional[datetime] = None,
+        note: Optional[str] = None,
+    ) -> None:
+        """Record a new price version, effective from `effective_from` (default now)."""
+        async with self.pool.acquire() as conn:
+            await conn.execute(
+                f"""INSERT INTO {self.schema}.model_pricing
+                    (service_type, provider, model, rates, effective_from, note)
+                    VALUES ($1,$2,$3,$4::jsonb, COALESCE($5, NOW()), $6)""",
+                service_type, provider, model, json.dumps(rates), effective_from, note,
+            )
+
+    async def table_as_of(self, when: datetime) -> Optional[dict]:
+        """price_table()-shaped dict with the rates effective at `when`.
+
+        Returns None when no pricing rows exist (caller falls back to the in-code
+        table), keeping behavior identical until the table is seeded.
+        """
+        async with self.pool.acquire() as conn:
+            rows = await conn.fetch(
+                f"""SELECT DISTINCT ON (service_type, provider, model)
+                        service_type, rates
+                    FROM {self.schema}.model_pricing
+                    WHERE effective_from <= $1
+                    ORDER BY service_type, provider, model, effective_from DESC""",
+                when,
+            )
+        if not rows:
+            return None
+        out: Dict[str, List[dict]] = {"llm": [], "embedding": [], "web_search": []}
+        for r in rows:
+            svc = r["service_type"]
+            rates = r["rates"]
+            if isinstance(rates, str):
+                rates = json.loads(rates)
+            out.setdefault(svc, []).append(rates)
+        return out

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/economics/usage_ledger.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/economics/usage_ledger.py
@@ -19,6 +19,7 @@ Two roles:
     that powers /api/economics/admin/cost-by-user and /me/cost-breakdown. The
     query lives in the function, as required.
 """
+import datetime as _dt
 import logging
 from typing import Any, Dict, List, Optional
 
@@ -26,6 +27,20 @@ from kdcube_ai_app.ops.deployment.sql.db_deployment import project_schema as _pr
 from kdcube_ai_app.infra.accounting.usage import compute_rollup_cost
 
 logger = logging.getLogger(__name__)
+
+
+def _as_date(x) -> _dt.date:
+    """Coerce a window bound to a `datetime.date`.
+
+    asyncpg infers a *date* OID for params bound to a `$n::date` cast and requires
+    a real `datetime.date` object — given an ISO string it raises
+    `DataError: invalid input for query argument ... ('str' object has no attribute
+    'toordinal')`, which silently yields no rows → dashboards / cost endpoints show
+    "$0 / no spend" even with priced ledger rows. Accept a date as-is; otherwise
+    parse the leading YYYY-MM-DD."""
+    if isinstance(x, _dt.date):
+        return x
+    return _dt.date.fromisoformat(str(x)[:10])
 
 
 # --------------------------------------------------------------------------- #
@@ -284,7 +299,7 @@ class UsageLedgerStore:
             GROUP BY user_id, service_type, provider, model
         """
         async with self.pool.acquire() as conn:
-            rows = await conn.fetch(sql, self.tenant, self.project, date_from, date_to)
+            rows = await conn.fetch(sql, self.tenant, self.project, _as_date(date_from), _as_date(date_to))
         users = list(self._assemble([dict(r) for r in rows]).values())
         users.sort(key=lambda u: u["total_cost_usd"], reverse=True)
         return {
@@ -310,7 +325,7 @@ class UsageLedgerStore:
             GROUP BY user_id, service_type, provider, model
         """
         async with self.pool.acquire() as conn:
-            rows = await conn.fetch(sql, self.tenant, self.project, user_id, date_from, date_to)
+            rows = await conn.fetch(sql, self.tenant, self.project, user_id, _as_date(date_from), _as_date(date_to))
         users = self._assemble([dict(r) for r in rows])
         u = users.get(user_id) or {
             "user_id": user_id, "total_cost_usd": 0.0, "by_model": [],
@@ -331,7 +346,7 @@ class UsageLedgerStore:
             LIMIT 1
         """
         async with self.pool.acquire() as conn:
-            row = await conn.fetchrow(sql, self.tenant, self.project, date_from, date_to)
+            row = await conn.fetchrow(sql, self.tenant, self.project, _as_date(date_from), _as_date(date_to))
         return row is not None
 
 

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/economics/usage_ledger.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/economics/usage_ledger.py
@@ -1,0 +1,356 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Elena Viter
+
+# apps/chat/ingress/economics/usage_ledger.py  (SQL-backed usage accounting)
+"""
+SQL-backed per-user usage/cost ledger.
+
+The authoritative source for "cost per user" is a transactional Postgres table,
+`<schema>.llm_usage_events` (one row per accounting event, with the per-model
+input/output token split and computed USD cost), aggregated by the plain view
+`<schema>.llm_usage_by_user_model` (user / model / day / month). This replaces
+scanning the brittle file-based accounting store, which is only written
+opportunistically and was the cause of dashboards showing "$0 / no spend".
+
+Two roles:
+  * write side  -> UsageLedgerStore.record_event(): called from the accounting
+    write path (see SQLUsageAccountingStorage); idempotent on event_id.
+  * read side   -> UsageLedgerStore.cost_by_user() / cost_for_user(): the SQL
+    that powers /api/economics/admin/cost-by-user and /me/cost-breakdown. The
+    query lives in the function, as required.
+"""
+import logging
+from typing import Any, Dict, List, Optional
+
+from kdcube_ai_app.ops.deployment.sql.db_deployment import project_schema as _project_schema
+from kdcube_ai_app.infra.accounting.usage import compute_rollup_cost
+
+logger = logging.getLogger(__name__)
+
+
+def _spent_from_usage(usage: dict) -> dict:
+    """Map a ServiceUsage-shaped dict to the rollup 'spent' keys compute_rollup_cost reads."""
+    usage = usage or {}
+    cache_creation = usage.get("cache_creation")
+    spent = {
+        "input": int(usage.get("input_tokens", 0) or 0),
+        "output": int(usage.get("output_tokens", 0) or 0),
+        "cache_read": int(usage.get("cache_read_tokens", 0) or 0),
+        "tokens": int(usage.get("embedding_tokens", 0) or 0),
+        "search_queries": int(usage.get("search_queries", 0) or 0),
+        "search_results": int(usage.get("search_results", 0) or 0),
+    }
+    if isinstance(cache_creation, dict):
+        spent["cache_5m_write"] = int(cache_creation.get("ephemeral_5m_input_tokens", 0) or 0)
+        spent["cache_1h_write"] = int(cache_creation.get("ephemeral_1h_input_tokens", 0) or 0)
+    else:
+        spent["cache_creation"] = int(usage.get("cache_creation_tokens", 0) or 0)
+    return spent
+
+
+def cost_usd_for_event(*, service_type: str, provider: str, model: str, usage: dict,
+                       pricing_table: Optional[dict] = None) -> float:
+    """Real USD cost for a single usage event.
+
+    Prefers the provider-REPORTED cost (usage.cost_usd) when present and positive
+    -- that is the ground truth the provider billed. Otherwise computes from the
+    price table via the canonical engine. `pricing_table`, when given, is a
+    price_table()-shaped dict resolved as-of the event's time (see
+    ModelPricingStore); when omitted, the current code price table is used.
+    """
+    reported = (usage or {}).get("cost_usd")
+    if reported is not None:
+        try:
+            v = float(reported)
+            if v > 0:
+                return round(v, 6)
+        except (TypeError, ValueError):
+            pass
+    rollup = [{"service": service_type, "provider": provider, "model": model,
+               "spent": _spent_from_usage(usage)}]
+    est = compute_rollup_cost(rollup, pricing_table=pricing_table) or {}
+    return round(float(est.get("total_cost_usd", 0.0) or 0.0), 6)
+
+
+class UsageLedgerStore:
+    """Read/write access to <schema>.llm_usage_events and its aggregation view."""
+
+    def __init__(self, pg_pool, *, tenant: str, project: str):
+        self.pool = pg_pool
+        self.tenant = tenant
+        self.project = project
+        self.schema = _project_schema(tenant, project)
+
+    # ----------------------------- write side -----------------------------
+
+    async def record_event(
+        self,
+        *,
+        event_id: Optional[str],
+        user_id: Optional[str],
+        request_id: Optional[str] = None,
+        conversation_id: Optional[str] = None,
+        turn_id: Optional[str] = None,
+        agent: Optional[str] = None,
+        bundle_id: Optional[str] = None,
+        service_type: str,
+        provider: Optional[str],
+        model: Optional[str],
+        usage: dict,
+        created_at=None,
+        pricing_table: Optional[dict] = None,
+    ) -> None:
+        """Insert one usage row. Idempotent on event_id (ON CONFLICT DO NOTHING)."""
+        spent = _spent_from_usage(usage)
+        cost = cost_usd_for_event(service_type=service_type, provider=provider or "", model=model or "",
+                                  usage=usage, pricing_table=pricing_table)
+        cache_write = int(spent.get("cache_5m_write", 0)) + int(spent.get("cache_1h_write", 0)) + int(spent.get("cache_creation", 0))
+
+        sql = f"""
+            INSERT INTO {self.schema}.llm_usage_events (
+                tenant, project, user_id, request_id, conversation_id, turn_id, agent, bundle_id,
+                service_type, provider, model,
+                input_tokens, output_tokens, cache_read_tokens, cache_write_tokens,
+                embedding_tokens, search_queries, requests, cost_usd, event_id, created_at
+            ) VALUES (
+                $1,$2,$3,$4,$5,$6,$7,$8,
+                $9,$10,$11,
+                $12,$13,$14,$15,
+                $16,$17,$18,$19,$20, COALESCE($21, NOW())
+            )
+            ON CONFLICT (event_id) WHERE event_id IS NOT NULL DO NOTHING
+        """
+        async with self.pool.acquire() as conn:
+            await conn.execute(
+                sql,
+                self.tenant, self.project, user_id, request_id, conversation_id, turn_id, agent, bundle_id,
+                str(service_type), provider, model,
+                int(spent.get("input", 0)), int(spent.get("output", 0)), int(spent.get("cache_read", 0)), int(cache_write),
+                int(spent.get("tokens", 0)), int(spent.get("search_queries", 0)),
+                int(usage.get("requests", 0) or 0), float(cost), event_id, created_at,
+            )
+
+    # ----------------------------- read side -----------------------------
+
+    @staticmethod
+    def _assemble(rows: List[dict]) -> Dict[str, Dict[str, Any]]:
+        """Group flat (user, model) rows into {user_id: {total_cost_usd, by_model[], tokens{}, event_count}}."""
+        users: Dict[str, Dict[str, Any]] = {}
+        for r in rows:
+            uid = r["user_id"] or "(unknown)"
+            u = users.get(uid)
+            if u is None:
+                u = {"user_id": uid, "total_cost_usd": 0.0, "by_model": [],
+                     "tokens": {"input_tokens": 0, "output_tokens": 0, "cache_read_tokens": 0,
+                                "cache_write_tokens": 0, "embedding_tokens": 0},
+                     "event_count": 0}
+                users[uid] = u
+            cost = round(float(r["cost_usd"] or 0.0), 6)
+            inp = int(r["input_tokens"] or 0)
+            out = int(r["output_tokens"] or 0)
+            u["total_cost_usd"] = round(u["total_cost_usd"] + cost, 6)
+            u["tokens"]["input_tokens"] += inp
+            u["tokens"]["output_tokens"] += out
+            u["tokens"]["embedding_tokens"] += int(r["embedding_tokens"] or 0)
+            u["event_count"] += int(r["requests"] or 0)
+            u["by_model"].append({
+                "service": r["service_type"], "provider": r["provider"], "model": r["model"],
+                "cost_usd": cost, "input_tokens": inp, "output_tokens": out,
+                "embedding_tokens": int(r["embedding_tokens"] or 0),
+            })
+        for u in users.values():
+            u["by_model"].sort(key=lambda m: m["cost_usd"], reverse=True)
+        return users
+
+    async def cost_by_user(self, *, date_from: str, date_to: str) -> Dict[str, Any]:
+        """Per-user true spend across the workspace, sorted by cost descending."""
+        sql = f"""
+            SELECT user_id, service_type, provider, model,
+                   SUM(cost_usd)       AS cost_usd,
+                   SUM(input_tokens)   AS input_tokens,
+                   SUM(output_tokens)  AS output_tokens,
+                   SUM(embedding_tokens) AS embedding_tokens,
+                   SUM(requests)       AS requests
+            FROM {self.schema}.llm_usage_by_user_model
+            WHERE tenant=$1 AND project=$2
+              AND day >= $3::date AND day < ($4::date + INTERVAL '1 day')
+            GROUP BY user_id, service_type, provider, model
+        """
+        async with self.pool.acquire() as conn:
+            rows = await conn.fetch(sql, self.tenant, self.project, date_from, date_to)
+        users = list(self._assemble([dict(r) for r in rows]).values())
+        users.sort(key=lambda u: u["total_cost_usd"], reverse=True)
+        return {
+            "date_from": date_from,
+            "date_to": date_to,
+            "total_cost_usd": round(sum(u["total_cost_usd"] for u in users), 6),
+            "total_users": len(users),
+            "users": users,
+        }
+
+    async def cost_for_user(self, *, user_id: str, date_from: str, date_to: str) -> Dict[str, Any]:
+        """True spend for a single user, broken down by model."""
+        sql = f"""
+            SELECT user_id, service_type, provider, model,
+                   SUM(cost_usd)       AS cost_usd,
+                   SUM(input_tokens)   AS input_tokens,
+                   SUM(output_tokens)  AS output_tokens,
+                   SUM(embedding_tokens) AS embedding_tokens,
+                   SUM(requests)       AS requests
+            FROM {self.schema}.llm_usage_by_user_model
+            WHERE tenant=$1 AND project=$2 AND user_id=$3
+              AND day >= $4::date AND day < ($5::date + INTERVAL '1 day')
+            GROUP BY user_id, service_type, provider, model
+        """
+        async with self.pool.acquire() as conn:
+            rows = await conn.fetch(sql, self.tenant, self.project, user_id, date_from, date_to)
+        users = self._assemble([dict(r) for r in rows])
+        u = users.get(user_id) or {
+            "user_id": user_id, "total_cost_usd": 0.0, "by_model": [],
+            "tokens": {"input_tokens": 0, "output_tokens": 0, "cache_read_tokens": 0,
+                       "cache_write_tokens": 0, "embedding_tokens": 0},
+            "event_count": 0,
+        }
+        u = dict(u)
+        u.update({"date_from": date_from, "date_to": date_to})
+        return u
+
+    async def has_data(self, *, date_from: str, date_to: str) -> bool:
+        """True if any usage rows exist for the window (used to decide SQL vs file fallback)."""
+        sql = f"""
+            SELECT 1 FROM {self.schema}.llm_usage_events
+            WHERE tenant=$1 AND project=$2
+              AND created_at >= $3::date AND created_at < ($4::date + INTERVAL '1 day')
+            LIMIT 1
+        """
+        async with self.pool.acquire() as conn:
+            row = await conn.fetchrow(sql, self.tenant, self.project, date_from, date_to)
+        return row is not None
+
+
+class SQLUsageAccountingStorage:
+    """IAccountingStorage wrapper that mirrors each accounting event into the SQL
+    usage ledger, in addition to the wrapped (file) storage.
+
+    Fail-safe by design: the wrapped storage write happens first and its result is
+    returned; a failure in the SQL mirror is swallowed (logged at debug) so usage
+    accounting can never block or fail a turn. Tenant/project are taken from each
+    event, so it is correct in a multi-tenant process.
+    """
+
+    def __init__(self, inner, pg_pool):
+        self._inner = inner
+        self._pool = pg_pool
+
+    def __getattr__(self, name):
+        # Delegate any non-overridden attribute/method (e.g. turn_cache, flush)
+        # to the wrapped storage so this wrapper is a drop-in for FileAccountingStorage.
+        return getattr(self._inner, name)
+
+    async def store_event(self, event) -> bool:
+        ok = True
+        try:
+            ok = await self._inner.store_event(event)
+        finally:
+            try:
+                await self._mirror(event)
+            except Exception:
+                logger.warning("SQL usage sink: mirror insert failed (usage ledger row "
+                               "not written; cost-per-user may under-report)", exc_info=True)
+        return ok
+
+    async def _mirror(self, event) -> None:
+        d = event.to_dict() if hasattr(event, "to_dict") else dict(event)
+        service = str(d.get("service_type") or "").strip()
+        if service not in ("llm", "embedding", "web_search"):
+            return
+        ctx = d.get("context") or {}
+        tenant = d.get("tenant_id") or ctx.get("tenant_id")
+        project = d.get("project_id") or ctx.get("project_id")
+        if not tenant or not project:
+            return
+        store = UsageLedgerStore(self._pool, tenant=str(tenant), project=str(project))
+        await store.record_event(
+            event_id=d.get("event_id"),
+            user_id=d.get("user_id") or ctx.get("user_id"),
+            request_id=d.get("request_id") or ctx.get("request_id"),
+            conversation_id=ctx.get("conversation_id") or d.get("conversation_id"),
+            turn_id=ctx.get("turn_id") or d.get("turn_id"),
+            agent=(d.get("metadata") or {}).get("agent_name") or ctx.get("component"),
+            bundle_id=d.get("app_bundle_id") or ctx.get("app_bundle_id"),
+            service_type=service,
+            provider=d.get("provider"),
+            model=d.get("model_or_service"),
+            usage=d.get("usage") or {},
+        )
+
+
+async def backfill_usage_ledger(
+    *,
+    pg_pool,
+    storage_backend,
+    tenant: str,
+    project: str,
+    date_from: str,
+    date_to: str,
+    base_path: str = "accounting",
+    agg_base: str = "analytics",
+    pricing_table: Optional[dict] = None,
+) -> Dict[str, int]:
+    """Import existing file accounting events into <schema>.llm_usage_events.
+
+    Idempotent (ON CONFLICT event_id DO NOTHING) -- safe to re-run. Each row keeps
+    the original event timestamp so historical time-window queries stay correct.
+    Returns {"scanned": <files seen>, "recorded": <usage rows written>}.
+    """
+    import json
+    from datetime import datetime
+    from kdcube_ai_app.infra.accounting.calculator import RateCalculator, AccountingQuery
+
+    calc = RateCalculator(storage_backend, base_path=base_path, agg_base=agg_base)
+    store = UsageLedgerStore(pg_pool, tenant=tenant, project=project)
+    q = AccountingQuery(tenant_id=tenant, project_id=project, date_from=date_from, date_to=date_to)
+
+    def _parse_ts(s):
+        if not s:
+            return None
+        try:
+            return datetime.fromisoformat(str(s).replace("Z", "+00:00"))
+        except Exception:
+            return None
+
+    scanned = 0
+    recorded = 0
+    async for path in calc._iter_event_paths(q):
+        scanned += 1
+        try:
+            raw = await calc.fs.read_text_a(path)
+            ev = json.loads(raw)
+        except Exception:
+            logger.debug("backfill: unreadable event %s", path, exc_info=True)
+            continue
+        service = str(ev.get("service_type") or "").strip()
+        if service not in ("llm", "embedding", "web_search"):
+            continue
+        ctx = ev.get("context") or {}
+        try:
+            await store.record_event(
+                event_id=ev.get("event_id"),
+                user_id=ev.get("user_id") or ctx.get("user_id"),
+                request_id=ev.get("request_id") or ctx.get("request_id"),
+                conversation_id=ctx.get("conversation_id") or ev.get("conversation_id"),
+                turn_id=ctx.get("turn_id") or ev.get("turn_id"),
+                agent=(ev.get("metadata") or {}).get("agent_name") or ctx.get("component"),
+                bundle_id=ev.get("app_bundle_id") or ctx.get("app_bundle_id"),
+                service_type=service,
+                provider=ev.get("provider"),
+                model=ev.get("model_or_service"),
+                usage=ev.get("usage") or {},
+                created_at=_parse_ts(ev.get("timestamp")),
+                pricing_table=pricing_table,
+            )
+            recorded += 1
+        except Exception:
+            logger.debug("backfill: insert failed for %s", path, exc_info=True)
+    logger.info("backfill_usage_ledger %s/%s [%s..%s]: scanned=%d recorded=%d",
+                tenant, project, date_from, date_to, scanned, recorded)

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/economics/usage_ledger.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/economics/usage_ledger.py
@@ -28,6 +28,113 @@ from kdcube_ai_app.infra.accounting.usage import compute_rollup_cost
 logger = logging.getLogger(__name__)
 
 
+# --------------------------------------------------------------------------- #
+# Self-healing schema bootstrap
+# --------------------------------------------------------------------------- #
+# The authoritative copy of this DDL lives in
+# ops/deployment/sql/chatbot/deploy-kdcube-proj-schema.sql (rendered with the
+# project schema substituted for <SCHEMA>). The deploy-time SQL step is fragile
+# and has been observed NOT to run on some targets, leaving the ledger tables
+# absent -> every mirror insert raised asyncpg.UndefinedTableError and was
+# dropped fail-safe (cost-per-user silently under-reported). To make the runtime
+# correct wherever the patched code runs, we keep an identical, fully idempotent
+# (IF NOT EXISTS / CREATE OR REPLACE) copy here and apply it once per process at
+# sink-attach time. Keep it in sync with the SQL file.
+_LEDGER_DDL_TEMPLATE = """
+CREATE TABLE IF NOT EXISTS {schema}.llm_usage_events (
+    id                 BIGSERIAL PRIMARY KEY,
+    tenant             VARCHAR(255) NOT NULL,
+    project            VARCHAR(255) NOT NULL,
+    user_id            VARCHAR(255),
+    request_id         VARCHAR(255),
+    conversation_id    VARCHAR(255),
+    turn_id            VARCHAR(255),
+    agent              VARCHAR(255),
+    bundle_id          VARCHAR(255),
+    service_type       VARCHAR(64) NOT NULL,
+    provider           VARCHAR(128),
+    model              VARCHAR(255),
+    input_tokens       BIGINT NOT NULL DEFAULT 0,
+    output_tokens      BIGINT NOT NULL DEFAULT 0,
+    cache_read_tokens  BIGINT NOT NULL DEFAULT 0,
+    cache_write_tokens BIGINT NOT NULL DEFAULT 0,
+    embedding_tokens   BIGINT NOT NULL DEFAULT 0,
+    search_queries     BIGINT NOT NULL DEFAULT 0,
+    requests           BIGINT NOT NULL DEFAULT 0,
+    cost_usd           NUMERIC(18,6) NOT NULL DEFAULT 0,
+    event_id           VARCHAR(128),
+    created_at         TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_llm_usage_event_id
+  ON {schema}.llm_usage_events (event_id) WHERE event_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_llm_usage_tenant_project_time
+  ON {schema}.llm_usage_events (tenant, project, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_llm_usage_user_time
+  ON {schema}.llm_usage_events (tenant, project, user_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_llm_usage_model_time
+  ON {schema}.llm_usage_events (tenant, project, model, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_llm_usage_request
+  ON {schema}.llm_usage_events (tenant, project, request_id);
+
+CREATE TABLE IF NOT EXISTS {schema}.model_pricing (
+    id             BIGSERIAL PRIMARY KEY,
+    service_type   VARCHAR(64) NOT NULL,
+    provider       VARCHAR(128) NOT NULL,
+    model          VARCHAR(255) NOT NULL,
+    rates          JSONB NOT NULL,
+    effective_from TIMESTAMPTZ NOT NULL DEFAULT now(),
+    note           TEXT,
+    created_at     TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_model_pricing_lookup
+  ON {schema}.model_pricing (service_type, provider, model, effective_from DESC);
+
+CREATE OR REPLACE VIEW {schema}.llm_usage_by_user_model AS
+SELECT
+    tenant,
+    project,
+    user_id,
+    service_type,
+    provider,
+    model,
+    date_trunc('day', created_at)   AS day,
+    date_trunc('month', created_at) AS month,
+    sum(input_tokens)       AS input_tokens,
+    sum(output_tokens)      AS output_tokens,
+    sum(cache_read_tokens)  AS cache_read_tokens,
+    sum(cache_write_tokens) AS cache_write_tokens,
+    sum(embedding_tokens)   AS embedding_tokens,
+    sum(search_queries)     AS search_queries,
+    sum(requests)           AS requests,
+    sum(cost_usd)           AS cost_usd,
+    count(*)                AS events
+FROM {schema}.llm_usage_events
+GROUP BY tenant, project, user_id, service_type, provider, model,
+         date_trunc('day', created_at), date_trunc('month', created_at);
+"""
+
+
+async def ensure_ledger_schema(pg_pool, *, tenant: str, project: str) -> str:
+    """Idempotently create the usage-ledger tables/indexes/view for a project schema.
+
+    Mirrors the DDL appended to deploy-kdcube-proj-schema.sql, schema-qualified
+    via project_schema(tenant, project). Safe to call repeatedly and concurrently
+    (every statement is IF NOT EXISTS / CREATE OR REPLACE). Returns the schema name.
+
+    Callers should treat failures as non-fatal (the mirror write path is already
+    fail-safe); this raises so callers can decide whether to log/skip the lazy
+    pricing seed.
+    """
+    schema = _project_schema(tenant, project)
+    ddl = _LEDGER_DDL_TEMPLATE.format(schema=schema)
+    async with pg_pool.acquire() as conn:
+        # asyncpg executes a multi-statement string via the simple query protocol
+        # when no args are passed, which is exactly what we want for DDL.
+        await conn.execute(ddl)
+    return schema
+
+
 def _spent_from_usage(usage: dict) -> dict:
     """Map a ServiceUsage-shaped dict to the rollup 'spent' keys compute_rollup_cost reads."""
     usage = usage or {}

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/chatbot/entrypoint.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/chatbot/entrypoint.py
@@ -1689,7 +1689,34 @@ class BaseEntrypoint:
 
         storage = _get_storage()
         if storage is None or storage.__class__.__name__ == "NoOpAccountingStorage":
-            AccountingSystem.init_storage(create_storage_backend(get_settings().STORAGE_PATH), enabled=True)
+            base_storage = create_storage_backend(get_settings().STORAGE_PATH)
+            # Mirror each event into the SQL usage ledger (authoritative source for
+            # cost-per-user). Fail-safe: never blocks the file write / the turn.
+            if getattr(self, "pg_pool", None) is not None:
+                try:
+                    from kdcube_ai_app.apps.chat.sdk.infra.economics.usage_ledger import SQLUsageAccountingStorage
+                    base_storage = SQLUsageAccountingStorage(base_storage, self.pg_pool)
+                    logger.info("SQL usage sink attached (mirroring accounting events to the usage ledger)")
+                except Exception:
+                    logger.warning("Could not attach SQL usage sink to accounting storage; "
+                                   "cost-per-user will fall back to file accounting", exc_info=True)
+            AccountingSystem.init_storage(base_storage, enabled=True)
+        elif getattr(self, "pg_pool", None) is not None and \
+                storage.__class__.__name__ != "SQLUsageAccountingStorage":
+            # A real (non-NoOp) accounting storage is already initialized (the
+            # common runtime path). Wrap it so new turns still mirror to the SQL
+            # usage ledger -- otherwise ongoing spend never accrues and only the
+            # backfill-seeded history is ever visible. Fail-safe: a failure here
+            # leaves the existing storage untouched and never breaks startup.
+            try:
+                from kdcube_ai_app.apps.chat.sdk.infra.economics.usage_ledger import SQLUsageAccountingStorage
+                AccountingSystem.init_storage(
+                    SQLUsageAccountingStorage(storage, self.pg_pool), enabled=True
+                )
+                logger.info("SQL usage sink attached (wrapped existing accounting storage)")
+            except Exception:
+                logger.warning("Could not wrap existing accounting storage with SQL usage sink; "
+                               "cost-per-user will fall back to file accounting", exc_info=True)
 
         async with with_accounting(
             bundle_id or "chat.orchestrator",

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/infra/accounting/calculator.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/infra/accounting/calculator.py
@@ -1005,7 +1005,13 @@ class AccountingCalculator:
         for key_tuple, usage in result["groups"].items():
             user_id = usage.get("user_id")
             if user_id:
-                by_user[user_id] = {"total": usage}
+                # Surface a per-user request count (summed usage.requests) so the
+                # raw-scan path matches the aggregate path's event_count instead of
+                # leaving it unset/None.
+                by_user[user_id] = {
+                    "total": usage,
+                    "event_count": int(usage.get("requests", 0) or 0),
+                }
 
         # Add compact rollup per user (raw)
         for user_id in list(by_user.keys()):
@@ -1022,6 +1028,69 @@ class AccountingCalculator:
             by_user[user_id]["rollup"] = await self.usage_rollup_compact(user_query)
 
         return by_user
+
+    async def usage_for_user(
+            self,
+            *,
+            tenant_id: str,
+            project_id: str,
+            user_id: str,
+            date_from: str,
+            date_to: str,
+            app_bundle_id: Optional[str] = None,
+            service_types: Optional[List[str]] = None,
+            hard_file_limit: Optional[int] = None,
+    ) -> Dict[str, Any]:
+        """
+        Spendings for a SINGLE user in given timeframe: {total, rollup, event_count}.
+
+        Prefers per-user daily aggregates (so a single user's spend matches exactly
+        what the cross-user view reports). Falls back to a user-scoped raw scan
+        (prefix-optimized via query.user_id, so it reads only this user's events)
+        whenever the aggregates do NOT cover this user with content -- i.e. when
+        there are no aggregates at all, OR aggregates exist for the project but not
+        for this user/window (e.g. recent usage not yet aggregated, or partial
+        aggregates). This prevents reporting "$0 / no spend" for a user who has
+        real raw events that simply haven't been rolled up yet.
+        """
+        # Fast path: reuse the per-user daily aggregates when they actually
+        # contain this user's usage.
+        try:
+            agg = await self._usage_by_user_with_aggregates(
+                tenant_id=tenant_id,
+                project_id=project_id,
+                date_from=date_from,
+                date_to=date_to,
+            )
+        except Exception:
+            logger.exception("[usage_for_user] aggregate path failed")
+            agg = None
+
+        if agg is not None:
+            data = agg.get(user_id)
+            if data and (data.get("rollup") or data.get("total")):
+                return data
+            # Aggregates exist but don't cover this user -> do not trust the empty
+            # result; fall through to the authoritative raw scan below.
+
+        # Fallback: user-scoped raw scan.
+        query = AccountingQuery(
+            tenant_id=tenant_id,
+            project_id=project_id,
+            user_id=user_id,
+            date_from=date_from,
+            date_to=date_to,
+            app_bundle_id=app_bundle_id,
+            service_types=service_types,
+            hard_file_limit=hard_file_limit,
+        )
+        usage = await self.query_usage(query)
+        rollup = await self.usage_rollup_compact(query)
+        return {
+            "total": usage.get("total", {}) or {},
+            "rollup": rollup,
+            "event_count": int(usage.get("event_count", 0) or 0),
+        }
 
     async def usage_all_users(
             self,

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/infra/accounting/envelope.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/infra/accounting/envelope.py
@@ -88,11 +88,54 @@ def build_envelope_from_session(session, *, tenant_id,
         # user_session=session
     )
 
+def _maybe_wrap_with_sql_usage_sink(pg_pool) -> None:
+    """Wrap the current async-local accounting storage with the SQL usage-ledger
+    mirror so every accounting event for this turn is also written to
+    <schema>.llm_usage_events (the authoritative cost-per-user source).
+
+    This is the single accounting chokepoint hit by every LIVE turn: chat-proc
+    binds the turn via bind_accounting before invoking the bundle entrypoint --
+    including BaseEntrypointWithEconomics, whose run() overrides BaseEntrypoint.run
+    and never calls AccountingSystem.init_storage itself. Fail-safe and idempotent:
+    skipped when pg_pool is None or the storage is already wrapped; any failure
+    leaves the existing storage untouched and never breaks the turn.
+    """
+    if pg_pool is None:
+        return
+    try:
+        storage = _storage_var.get()
+        if storage is None or storage.__class__.__name__ in (
+            "NoOpAccountingStorage",
+            "SQLUsageAccountingStorage",
+        ):
+            return
+        from kdcube_ai_app.apps.chat.sdk.infra.economics.usage_ledger import (
+            SQLUsageAccountingStorage,
+        )
+        _storage_var.set(SQLUsageAccountingStorage(storage, pg_pool))
+        import logging
+        logging.getLogger("accounting").info(
+            "SQL usage sink attached (mirroring accounting events to the usage "
+            "ledger via bind_accounting; storage=%s)",
+            storage.__class__.__name__,
+        )
+    except Exception:
+        import logging
+        logging.getLogger("accounting").warning(
+            "Could not attach SQL usage sink to accounting storage; cost-per-user "
+            "will fall back to file accounting",
+            exc_info=True,
+        )
+
+
 @asynccontextmanager
-async def bind_accounting(envelope: AccountingEnvelope, storage_backend, *, enabled: bool = True):
+async def bind_accounting(envelope: AccountingEnvelope, storage_backend, *, enabled: bool = True, pg_pool=None):
     """
     Init storage + set base context for the current task.
     Clears context on exit.
+
+    When pg_pool is provided, the per-turn accounting storage is additionally
+    wrapped with the SQL usage-ledger mirror (cost-per-user accrual).
     """
     AccountingSystem.init_storage(storage_backend, enabled)
     # When we spawn a task with asyncio.create_task(...), the current ContextVars are copied.
@@ -113,6 +156,10 @@ async def bind_accounting(envelope: AccountingEnvelope, storage_backend, *, enab
     ctx_token = _context_var.set(ctx)
     # Optionally also isolate storage if you use different backends per task
     store_token = _storage_var.set(_storage_var.get())  # no-op isolation, or set a specific one
+    # Mirror accounting events into the SQL usage ledger for this turn (idempotent,
+    # fail-safe). Wraps the per-scope storage slot so the reset in finally restores
+    # the previous storage cleanly.
+    _maybe_wrap_with_sql_usage_sink(pg_pool)
     # seed enrichment
     ctx.event_enrichment = {
         "metadata": dict(envelope.metadata or {}),

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/infra/accounting/envelope.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/infra/accounting/envelope.py
@@ -88,7 +88,55 @@ def build_envelope_from_session(session, *, tenant_id,
         # user_session=session
     )
 
-def _maybe_wrap_with_sql_usage_sink(pg_pool) -> None:
+# Per-process guard: which project schemas we have already ensured the ledger
+# schema for. Keyed by project_schema(tenant, project) so a multi-tenant process
+# bootstraps each schema exactly once. Bounded by the number of tenant/projects.
+_ledger_schema_ensured: set = set()
+
+
+async def _ensure_ledger_schema_once(pg_pool, *, tenant, project) -> None:
+    """Self-heal: create the usage-ledger tables/indexes/view once per process per
+    project schema, then lazily seed model_pricing from code if it's empty.
+
+    The deploy-time SQL DDL step is fragile and has been observed not to run on
+    some targets, leaving the ledger tables absent -> every mirror insert raised
+    asyncpg.UndefinedTableError and was dropped (cost-per-user under-reported).
+    Ensuring the schema here makes the runtime correct wherever the patched code
+    runs. Fully fail-safe: any failure is logged and never breaks the turn.
+    """
+    if pg_pool is None or not tenant or not project:
+        return
+    import logging
+    log = logging.getLogger("accounting")
+    try:
+        from kdcube_ai_app.apps.chat.sdk.infra.economics.usage_ledger import (
+            ensure_ledger_schema,
+        )
+        schema = await ensure_ledger_schema(pg_pool, tenant=str(tenant), project=str(project))
+    except Exception:
+        log.warning(
+            "Could not ensure ledger schema for %s/%s; cost-per-user mirror may "
+            "fail until the schema is created",
+            tenant, project, exc_info=True,
+        )
+        return
+    _ledger_schema_ensured.add(schema)
+    log.info("ledger schema ensured (%s)", schema)
+    # Lazy pricing seed: only when the price table is empty (idempotent).
+    try:
+        from kdcube_ai_app.apps.chat.sdk.infra.economics.pricing import ModelPricingStore
+        store = ModelPricingStore(pg_pool, tenant=str(tenant), project=str(project))
+        if await store.is_empty():
+            n = await store.seed_from_code()
+            log.info("ledger pricing seeded from code (%s rows) for %s", n, schema)
+    except Exception:
+        log.warning(
+            "Could not seed model_pricing for %s/%s (fallback to in-code price "
+            "table)", tenant, project, exc_info=True,
+        )
+
+
+async def _maybe_wrap_with_sql_usage_sink(pg_pool, *, tenant=None, project=None) -> None:
     """Wrap the current async-local accounting storage with the SQL usage-ledger
     mirror so every accounting event for this turn is also written to
     <schema>.llm_usage_events (the authoritative cost-per-user source).
@@ -99,6 +147,10 @@ def _maybe_wrap_with_sql_usage_sink(pg_pool) -> None:
     and never calls AccountingSystem.init_storage itself. Fail-safe and idempotent:
     skipped when pg_pool is None or the storage is already wrapped; any failure
     leaves the existing storage untouched and never breaks the turn.
+
+    On first attach for a given project schema, the ledger tables/indexes/view are
+    self-healed (created IF NOT EXISTS) and the price table is lazily seeded so the
+    mirror insert below cannot fail with UndefinedTableError.
     """
     if pg_pool is None:
         return
@@ -109,6 +161,16 @@ def _maybe_wrap_with_sql_usage_sink(pg_pool) -> None:
             "SQLUsageAccountingStorage",
         ):
             return
+        # Ensure the destination schema exists before we start mirroring into it.
+        # Guarded so the DDL/seed only runs once per process per project schema.
+        from kdcube_ai_app.ops.deployment.sql.db_deployment import project_schema
+        try:
+            already = bool(tenant and project) and \
+                project_schema(str(tenant), str(project)) in _ledger_schema_ensured
+        except Exception:
+            already = False
+        if not already:
+            await _ensure_ledger_schema_once(pg_pool, tenant=tenant, project=project)
         from kdcube_ai_app.apps.chat.sdk.infra.economics.usage_ledger import (
             SQLUsageAccountingStorage,
         )
@@ -159,7 +221,9 @@ async def bind_accounting(envelope: AccountingEnvelope, storage_backend, *, enab
     # Mirror accounting events into the SQL usage ledger for this turn (idempotent,
     # fail-safe). Wraps the per-scope storage slot so the reset in finally restores
     # the previous storage cleanly.
-    _maybe_wrap_with_sql_usage_sink(pg_pool)
+    await _maybe_wrap_with_sql_usage_sink(
+        pg_pool, tenant=envelope.tenant_id, project=envelope.project_id
+    )
     # seed enrichment
     ctx.event_enrichment = {
         "metadata": dict(envelope.metadata or {}),

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/infra/accounting/usage.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/infra/accounting/usage.py
@@ -831,6 +831,93 @@ def _get_web_search_tier(provider: str,
     defaults = {"brave": "base", "duckduckgo": "free"}
     return provider_config.get("tier", defaults.get(provider, "free"))
 
+def compute_rollup_cost(rollup: Optional[List[dict]],
+                        accounting_services_config: Optional[dict] = None,
+                        pricing_table: Optional[dict] = None) -> Dict[str, Any]:
+    """Turn a usage rollup into real USD cost, priced per (service, provider, model).
+
+    LLM cost uses each model's OWN input and output rates (plus 5m/1h or legacy
+    cache-write and cache-read rates); embeddings use per-1M token rates; web
+    search uses per-1k-request rates. This is the canonical cost path shared by
+    the /api/opex/* endpoints and the economics cost-breakdown endpoints, so
+    every "cost" surface in the product agrees.
+
+    Pure function: depends only on the price table (and, for web-search tier
+    resolution, the optional ACCOUNTING_SERVICES config). `accounting_services_config`
+    is only consulted when a web_search item is present; pass {} to stay fully
+    settings-free.
+
+    Returns {"total_cost_usd": float, "breakdown": [ {service, provider, model,
+    cost_usd, ...} ]}.
+    """
+    if not pricing_table:
+        pricing_table = price_table()
+
+    total_cost = 0.0
+    breakdown: List[Dict[str, Any]] = []
+
+    for item in rollup or []:
+        service = item.get("service")
+        provider = item.get("provider")
+        model = item.get("model")
+        spent = item.get("spent", {}) or {}
+
+        cost_usd = 0.0
+        tier = None
+        pr = None
+
+        if service == "llm":
+            pr = _find_llm_price(provider, model, pricing_table)
+            if pr:
+                input_cost = (float(spent.get("input", 0)) / 1_000_000.0) * float(pr.get("input_tokens_1M", 0.0))
+                output_cost = (float(spent.get("output", 0)) / 1_000_000.0) * float(pr.get("output_tokens_1M", 0.0))
+                cache_read_cost = (float(spent.get("cache_read", 0)) / 1_000_000.0) * float(pr.get("cache_read_tokens_1M", 0.0))
+
+                cache_write_cost = 0.0
+                cache_pricing = pr.get("cache_pricing")
+                if cache_pricing and isinstance(cache_pricing, dict):
+                    cache_5m_tokens = float(spent.get("cache_5m_write", 0))
+                    cache_1h_tokens = float(spent.get("cache_1h_write", 0))
+                    if cache_5m_tokens > 0:
+                        cache_write_cost += (cache_5m_tokens / 1_000_000.0) * float(cache_pricing.get("5m", {}).get("write_tokens_1M", 0.0))
+                    if cache_1h_tokens > 0:
+                        cache_write_cost += (cache_1h_tokens / 1_000_000.0) * float(cache_pricing.get("1h", {}).get("write_tokens_1M", 0.0))
+                else:
+                    cache_write_tokens = float(spent.get("cache_creation", 0))
+                    cache_write_cost = (cache_write_tokens / 1_000_000.0) * float(pr.get("cache_write_tokens_1M", 0.0))
+
+                cost_usd = input_cost + output_cost + cache_write_cost + cache_read_cost
+
+        elif service == "embedding":
+            pr = _find_emb_price(provider, model, pricing_table)
+            if pr:
+                cost_usd = (float(spent.get("tokens", 0)) / 1_000_000.0) * float(pr.get("tokens_1M", 0.0))
+
+        elif service == "web_search":
+            tier = _get_web_search_tier(provider, accounting_services_config)
+            pr = _find_web_search_price(provider, tier, pricing_table)
+            if pr:
+                cost_usd = (float(spent.get("search_queries", 0)) / 1000.0) * float(pr.get("cost_per_1k_requests", 0.0))
+
+        total_cost += cost_usd
+
+        breakdown_item: Dict[str, Any] = {
+            "service": service,
+            "provider": provider,
+            "model": model,
+            "cost_usd": cost_usd,
+        }
+        if service == "web_search" and tier:
+            breakdown_item["tier"] = tier
+            breakdown_item["search_queries"] = spent.get("search_queries", 0)
+            breakdown_item["search_results"] = spent.get("search_results", 0)
+            if pr:
+                breakdown_item["cost_per_1k_requests"] = pr.get("cost_per_1k_requests", 0.0)
+        breakdown.append(breakdown_item)
+
+    return {"total_cost_usd": total_cost, "breakdown": breakdown}
+
+
 # Referent prices
 def _ref_out_price_1m(ref_provider: str, ref_model: str) -> float:
     pr = _find_llm_price(ref_provider, ref_model)

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/ops/deployment/sql/chatbot/deploy-kdcube-proj-schema.sql
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/ops/deployment/sql/chatbot/deploy-kdcube-proj-schema.sql
@@ -1127,3 +1127,87 @@ DROP TRIGGER IF EXISTS trg_cp_ext_econ_events_updated_at ON <SCHEMA>.external_ec
 CREATE TRIGGER trg_cp_ext_econ_events_updated_at
   BEFORE UPDATE ON <SCHEMA>.external_economics_events
   FOR EACH ROW EXECUTE FUNCTION <SCHEMA>.update_updated_at();
+
+-- =========================================
+-- LLM USAGE LEDGER (authoritative per-user spend)
+--  - one row per accounting event (llm / embedding / web_search)
+--  - cost_usd is the provider-reported cost when available, else priced
+--    from model_pricing via the canonical engine
+--  - aggregated by the llm_usage_by_user_model view
+-- =========================================
+CREATE TABLE IF NOT EXISTS <SCHEMA>.llm_usage_events (
+    id                 BIGSERIAL PRIMARY KEY,
+    tenant             VARCHAR(255) NOT NULL,
+    project            VARCHAR(255) NOT NULL,
+    user_id            VARCHAR(255),
+    request_id         VARCHAR(255),
+    conversation_id    VARCHAR(255),
+    turn_id            VARCHAR(255),
+    agent              VARCHAR(255),
+    bundle_id          VARCHAR(255),
+    service_type       VARCHAR(64) NOT NULL,
+    provider           VARCHAR(128),
+    model              VARCHAR(255),
+    input_tokens       BIGINT NOT NULL DEFAULT 0,
+    output_tokens      BIGINT NOT NULL DEFAULT 0,
+    cache_read_tokens  BIGINT NOT NULL DEFAULT 0,
+    cache_write_tokens BIGINT NOT NULL DEFAULT 0,
+    embedding_tokens   BIGINT NOT NULL DEFAULT 0,
+    search_queries     BIGINT NOT NULL DEFAULT 0,
+    requests           BIGINT NOT NULL DEFAULT 0,
+    cost_usd           NUMERIC(18,6) NOT NULL DEFAULT 0,
+    event_id           VARCHAR(128),
+    created_at         TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Idempotency for the write path: ON CONFLICT (event_id) WHERE event_id IS NOT NULL
+CREATE UNIQUE INDEX IF NOT EXISTS uq_llm_usage_event_id
+  ON <SCHEMA>.llm_usage_events (event_id) WHERE event_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_llm_usage_tenant_project_time
+  ON <SCHEMA>.llm_usage_events (tenant, project, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_llm_usage_user_time
+  ON <SCHEMA>.llm_usage_events (tenant, project, user_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_llm_usage_model_time
+  ON <SCHEMA>.llm_usage_events (tenant, project, model, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_llm_usage_request
+  ON <SCHEMA>.llm_usage_events (tenant, project, request_id);
+
+-- Effective-dated model price table (fallback pricing for events without a
+-- provider-reported cost). Logically global; stored per project schema.
+CREATE TABLE IF NOT EXISTS <SCHEMA>.model_pricing (
+    id             BIGSERIAL PRIMARY KEY,
+    service_type   VARCHAR(64) NOT NULL,
+    provider       VARCHAR(128) NOT NULL,
+    model          VARCHAR(255) NOT NULL,
+    rates          JSONB NOT NULL,
+    effective_from TIMESTAMPTZ NOT NULL DEFAULT now(),
+    note           TEXT,
+    created_at     TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_model_pricing_lookup
+  ON <SCHEMA>.model_pricing (service_type, provider, model, effective_from DESC);
+
+-- Per-(user, model, day/month) rollup powering /me/cost-breakdown and
+-- /admin/cost-by-user.
+CREATE OR REPLACE VIEW <SCHEMA>.llm_usage_by_user_model AS
+SELECT
+    tenant,
+    project,
+    user_id,
+    service_type,
+    provider,
+    model,
+    date_trunc('day', created_at)   AS day,
+    date_trunc('month', created_at) AS month,
+    sum(input_tokens)       AS input_tokens,
+    sum(output_tokens)      AS output_tokens,
+    sum(cache_read_tokens)  AS cache_read_tokens,
+    sum(cache_write_tokens) AS cache_write_tokens,
+    sum(embedding_tokens)   AS embedding_tokens,
+    sum(search_queries)     AS search_queries,
+    sum(requests)           AS requests,
+    sum(cost_usd)           AS cost_usd,
+    count(*)                AS events
+FROM <SCHEMA>.llm_usage_events
+GROUP BY tenant, project, user_id, service_type, provider, model,
+         date_trunc('day', created_at), date_trunc('month', created_at);

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/ops/deployment/sql/chatbot/drop-kdcube-proj-schema.sql
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/ops/deployment/sql/chatbot/drop-kdcube-proj-schema.sql
@@ -91,6 +91,11 @@ DROP TABLE IF EXISTS <SCHEMA>.user_memory CASCADE;
 DROP TABLE IF EXISTS <SCHEMA>.conv_messages CASCADE;
 
 -- ---------- Economics tables ----------
+-- LLM usage ledger
+DROP VIEW  IF EXISTS <SCHEMA>.llm_usage_by_user_model;
+DROP TABLE IF EXISTS <SCHEMA>.model_pricing CASCADE;
+DROP TABLE IF EXISTS <SCHEMA>.llm_usage_events CASCADE;
+
 DROP VIEW IF EXISTS <SCHEMA>.tenant_project_budget_absorption_detail;
 DROP VIEW IF EXISTS <SCHEMA>.tenant_project_budget_absorption;
 DROP VIEW IF EXISTS <SCHEMA>.tenant_project_budget_status;


### PR DESCRIPTION
## Summary

Lands the **per-user cost / billing** feature into the platform and brings the two defect fixes that make it work in a real deployment. Currently this ships to cloud (yey.boats) only as an out-of-tree hotpatch in the embedded repo's `scripts/cloud/02-deploy-kdcube.sh`; cloud builds the platform from a released tag via `kdcube refresh --release <tag>` and never applies embedded `patches/`, so the feature has to live upstream to survive a release. **Merging + releasing this lets the embedded cloud hotpatch be retired.**

## Feature

- **SQL usage ledger** — `llm_usage_events` + `model_pricing` tables and an aggregation view; effective-dated pricing engine (`apps/chat/sdk/infra/economics/pricing.py`) and a `UsageLedgerStore` (`.../economics/usage_ledger.py`) for ledger-derived spend queries.
- **Economics endpoints** — `GET /api/economics/admin/cost-by-user` (real, ledger-derived spend per user, with fallback to file-based accounting) and `/me/cost-breakdown`; opex cost calculator (`apps/chat/ingress/opex/cost.py`) + `opex.py` wiring.
- **Accounting plumbing** — calculator/usage updates (`infra/accounting/{calculator,usage}.py`) and the chatbot `entrypoint.py` hook.

## The two defect fixes (the part previously missing upstream)

1. **Idempotent ledger DDL** appended to the canonical project schema `ops/deployment/sql/chatbot/deploy-kdcube-proj-schema.sql` (with matching `drop-...sql` entries), so the ledger tables exist on a normal schema deploy instead of only via an out-of-band migration.
2. **Live SQL sink** attached via `bind_accounting` in `infra/accounting/envelope.py` (`SQLUsageAccountingStorage` wrapping the storage backend), fed a `pg_pool` threaded through from `apps/chat/processor.py`, so per-turn usage is actually written to the ledger.

## Verification

- Patch applied cleanly against current `main` (`git apply --check -p1` → 0).
- All changed/new Python files pass `python -m py_compile`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)