### PR TITLE
fix(oauth_mcp): redirect unauthenticated /oauth/authorize to login

### DIFF
--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/ingress/oauth_mcp/routes.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/ingress/oauth_mcp/routes.py
@@ -140,6 +140,16 @@ async def authorize(request: Request) -> Response:
 
     user, denied = await _require_admin(request)
     if denied is not None:
+        # Browser entry point: on a missing session, send the user to the platform
+        # login with a return-to (url-encoded so the multi-param authorize URL
+        # survives) instead of a dead-end JSON 401. 403 (authenticated non-admin)
+        # still returns its JSON.
+        if getattr(denied, "status_code", None) == 401:
+            from urllib.parse import quote
+            return_to = request.url.path
+            if request.url.query:
+                return_to += "?" + request.url.query
+            return RedirectResponse(f"/signin?next={quote(return_to, safe='')}", status_code=302)
         return denied
 
     # Synchronizer CSRF token bound to the consenting admin, embedded in the form.


### PR DESCRIPTION
GET /oauth/authorize is the browser entry point of the consent flow. On a missing session it returned JSON `401 login_required` — a dead end when an MCP client (claude.ai connector) opens it in a popup. This redirects to the platform login (`/signin?next=<url-encoded authorize URL>`) so the user can sign in and land back on consent; URL-encoding keeps the multi-param authorize URL intact (a plain nginx `error_page 401` truncates at the first `&`). 403 (authenticated non-admin) still returns its JSON.