### PR TITLE
fix(oauth_mcp): chain session validators (bundle authority first) so /mcp and /oauth/authorize both authenticate

### DIFF
--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/ingress/oauth_mcp/deps.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/ingress/oauth_mcp/deps.py
@@ -38,18 +38,43 @@ def get_authenticate(request: Request) -> AuthenticateFn:
     if fn is not None:
         return fn
 
+    # oauth_mcp authenticates TWO distinct token kinds, so try each validator in
+    # turn and accept the first that resolves a user. ORDER MATTERS:
+    #   1) the platform bundle authority — validates the integration ACCESS token
+    #      minted for /mcp by grants.mint_feedback_reader_access_token (a STATEFUL
+    #      bundle kst1: a real Redis session whose roles live in the user record).
+    #      It is strict: it rejects the stateless web-login token (no session
+    #      record), which then falls through to (2).
+    #   2) the platform gateway's configured session manager (resolved from
+    #      AUTH_PROVIDER) — validates the admin's web-login session at
+    #      /oauth/authorize (e.g. a stateless kdcube_ext kst1 carrying roles in its
+    #      claims).
+    # Bundle MUST come first: a custom provider's verifier may share the token
+    # schema and would otherwise ACCEPT the access token but read roles from its
+    # (role-less) claims -> empty roles -> 403 "feedback-reader role required".
+    # A single hardcoded manager breaks one of the two endpoints.
+    from kdcube_ai_app.apps.chat.ingress.resolvers import create_auth_manager
     from kdcube_ai_app.auth.bundle import BundleSessionAuthManager, get_bundle_session_authority
 
     tenant, project = oauth_tenant_project(request)
-    authority = get_bundle_session_authority(tenant=tenant, project=project)
-    manager = BundleSessionAuthManager(authority=authority)
+    managers = [
+        BundleSessionAuthManager(
+            authority=get_bundle_session_authority(tenant=tenant, project=project)
+        ),
+        create_auth_manager(),
+    ]
 
     async def _authenticate(token: str) -> Optional[dict]:
-        try:
-            user = await manager.authenticate(token)
-        except Exception:
-            return None
-        return {"sub": user.sub, "roles": list(user.roles or [])}
+        for manager in managers:
+            try:
+                user = await manager.authenticate(token)
+            except Exception:
+                continue
+            if user is None:
+                continue
+            sub = getattr(user, "sub", None) or getattr(user, "username", None)
+            return {"sub": sub, "roles": list(getattr(user, "roles", None) or [])}
+        return None
 
     return _authenticate
 

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/ingress/oauth_mcp/tests/test_authorize.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/ingress/oauth_mcp/tests/test_authorize.py
@@ -141,9 +141,18 @@ def client():
     return TestClient(app)
 
 
-def test_authorize_requires_authentication(client):
-    r = client.get("/oauth/authorize", params=_params())
-    assert r.status_code == 401
+def test_authorize_unauthenticated_redirects_to_signin(client):
+    # A browser hitting /oauth/authorize without a session must be sent to the
+    # platform login (with a return-to) rather than getting a dead-end JSON 401.
+    r = client.get("/oauth/authorize", params=_params(), follow_redirects=False)
+    assert r.status_code == 302
+    loc = r.headers["location"]
+    assert loc.startswith("/signin?next=")
+    nxt = dict(up.parse_qsl(up.urlsplit(loc).query))["next"]
+    # the full authorize request (path + multi-param query) is preserved url-encoded
+    assert nxt.startswith("/oauth/authorize")
+    assert "client_id=claude" in up.unquote(nxt)
+    assert "code_challenge=" in up.unquote(nxt)
 
 
 def test_authorize_rejects_non_admin(client):

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/ingress/oauth_mcp/tests/test_deps_auth_manager.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/ingress/oauth_mcp/tests/test_deps_auth_manager.py
@@ -1,0 +1,110 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Elena Viter
+
+"""get_authenticate must accept BOTH oauth_mcp token kinds, bundle authority first.
+
+oauth_mcp authenticates two distinct tokens:
+  - the integration ACCESS token at /mcp — a STATEFUL platform bundle kst1
+    (roles in the Redis user record), and
+  - the admin's web-login session at /oauth/authorize — validated by the gateway's
+    configured manager (a stateless token carrying roles in its claims).
+
+Both share the kst1 schema, so the gateway's custom verifier will ACCEPT the
+access token but read empty roles from its (role-less) claims -> 403. The bundle
+authority must therefore be tried FIRST. The app.state override still wins.
+"""
+from __future__ import annotations
+
+import types
+
+import pytest
+
+from kdcube_ai_app.apps.chat.ingress.oauth_mcp import deps
+
+
+def _request_without_override():
+    state = types.SimpleNamespace()  # no oauth_authenticate attribute
+    app = types.SimpleNamespace(state=state)
+    return types.SimpleNamespace(app=app)
+
+
+def _patch_managers(monkeypatch, gateway, bundle_manager):
+    import kdcube_ai_app.apps.chat.ingress.resolvers as resolvers
+    import kdcube_ai_app.auth.bundle as bundle
+
+    monkeypatch.setattr(resolvers, "create_auth_manager", lambda *a, **k: gateway)
+    monkeypatch.setattr(bundle, "BundleSessionAuthManager", lambda *a, **k: bundle_manager)
+    monkeypatch.setattr(bundle, "get_bundle_session_authority", lambda *a, **k: object())
+
+
+class _WebUser:
+    sub = "google:admin@example.test"
+    roles = ["kdcube:role:super-admin"]
+
+
+class _IntegrationUser:
+    sub = "integration:claude:google:admin@example.test"
+    roles = ["kdcube:role:feedback-reader"]
+
+
+class _RolelessUser:
+    sub = "integration:claude:google:admin@example.test"
+    roles = []  # the bug: gateway accepts the access token but loses its roles
+
+
+class _GreedyGatewayManager:
+    """Custom session manager: validates the web token, AND (the bug) ACCEPTS the
+    integration access token but with EMPTY roles (shared schema, no roles in claims)."""
+    async def authenticate(self, token: str):
+        if token == "web-session":
+            return _WebUser()
+        if token == "integration-access":
+            return _RolelessUser()
+        raise ValueError("unknown token")
+
+
+class _BundleManager:
+    """Platform bundle authority: validates the integration access token with its
+    real roles, and REJECTS the stateless web token (no Redis session record)."""
+    async def authenticate(self, token: str):
+        if token == "integration-access":
+            return _IntegrationUser()
+        raise ValueError("no bundle session")
+
+
+async def test_access_token_resolves_feedback_reader_not_empty_roles(monkeypatch):
+    # Regression: the bundle authority is tried first, so the access token keeps its
+    # feedback-reader role instead of the gateway's empty-roles result (-> 403).
+    _patch_managers(monkeypatch, _GreedyGatewayManager(), _BundleManager())
+    authenticate = deps.get_authenticate(_request_without_override())
+    assert await authenticate("integration-access") == {
+        "sub": "integration:claude:google:admin@example.test",
+        "roles": ["kdcube:role:feedback-reader"],
+    }
+
+
+async def test_web_session_falls_through_to_gateway(monkeypatch):
+    _patch_managers(monkeypatch, _GreedyGatewayManager(), _BundleManager())
+    authenticate = deps.get_authenticate(_request_without_override())
+    assert await authenticate("web-session") == {
+        "sub": "google:admin@example.test",
+        "roles": ["kdcube:role:super-admin"],
+    }
+
+
+async def test_unknown_token_fails_closed(monkeypatch):
+    _patch_managers(monkeypatch, _GreedyGatewayManager(), _BundleManager())
+    authenticate = deps.get_authenticate(_request_without_override())
+    assert await authenticate("garbage") is None
+
+
+async def test_app_state_override_takes_precedence():
+    async def _override(token):
+        return {"sub": "overridden", "roles": []}
+
+    state = types.SimpleNamespace(oauth_authenticate=_override)
+    app = types.SimpleNamespace(state=state)
+    request = types.SimpleNamespace(app=app)
+
+    authenticate = deps.get_authenticate(request)
+    assert await authenticate("anything") == {"sub": "overridden", "roles": []}


### PR DESCRIPTION
## Problem

`get_authenticate(request)` in `oauth_mcp/deps.py` hardcoded the platform
`BundleSessionAuthManager` to validate sessions. But oauth_mcp serves **two
endpoints with two distinct token kinds**, and a deployment may run a non-bundle
`AUTH_PROVIDER`:

- **`/mcp`** validates the integration **access token** minted by
  `grants.mint_feedback_reader_access_token`. This is *always* a **stateful**
  platform bundle `kst1`: a real Redis session whose roles live in the user
  record (not the token claims).
- **`/oauth/authorize`** validates the admin's **web-login session**, which is
  provider-specific and resolved from `AUTH_PROVIDER` (e.g. a stateless token
  that carries roles in its claims under `AUTH_PROVIDER=session`).

A single hardcoded manager can only serve one of the two endpoints. With a
non-bundle provider configured, the bundle manager rejects the web-login session
at `/oauth/authorize`; with the bundle manager removed, the access token at
`/mcp` is no longer validated against its Redis record.

## Fix

Chain two validators and accept the first that resolves a user:

1. the platform **bundle authority** (validates the `/mcp` access token), then
2. the gateway's configured session manager from `create_auth_manager()`
   (validates the `/oauth/authorize` web-login session).

### Why bundle MUST come first

The bundle access token and a custom provider's web-login token can share the
same token schema. If the provider's verifier ran first, it would *accept* the
access token but read roles from its (role-less) claims → empty roles → `403
"feedback-reader role required"` at `/mcp`. Putting the strict bundle authority
first means the stateful access token resolves its roles from the Redis user
record, and the stateless web-login token (which has no session record) is
rejected by the bundle manager and falls through to the provider validator.

The `app.state.oauth_authenticate` override (used by tests / custom wiring) still
short-circuits both validators via the existing early return.

## Tests

Adds `oauth_mcp/tests/test_deps_auth_manager.py` covering the two-token ordering
and the empty-roles regression.