### PR TITLE
feat(conversations): add agent_id ownership to conv_messages

### DIFF
--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/ingress/conversations/conversations.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/ingress/conversations/conversations.py
@@ -222,6 +222,10 @@ async def list_conversations(
             default=None,
             description="If omitted, the default bundle_id from the active bundle registry is used.",
         ),
+        agent_id: Optional[str] = Query(
+            default=None,
+            description="If omitted, not filtered by owning agent.",
+        ),
         session: UserSession = Depends(require_auth(RequireUser())),
 ):
     if not session.user_id:
@@ -244,6 +248,7 @@ async def list_conversations(
         days=days,
         include_titles=include_titles,
         bundle_id=bundle_id,
+        agent_id=agent_id,
     )
     return data
 
@@ -274,6 +279,10 @@ async def conversation_details(
             default=None,
             description="If omitted, conversation details are not filtered by bundle_id and bundle ids are inferred from stored rows.",
         ),
+        agent_id: Optional[str] = Query(
+            default=None,
+            description="If omitted, not filtered by owning agent.",
+        ),
         session: UserSession = Depends(require_auth(RequireUser())),
 ):
     if not session.user_id:
@@ -291,6 +300,7 @@ async def conversation_details(
         conversation_id=conversation_id,
         bundle_id=bundle_id,
         bundle_ids=allowed_bundle_ids,
+        agent_id=agent_id
     )
     if not (out or {}).get("turns"):
         raise HTTPException(status_code=404, detail="Conversation not found")
@@ -318,6 +328,10 @@ async def fetch_conversation(
             default=None,
             description="If omitted, conversation fetch is not filtered by bundle_id and bundle ids are inferred from stored rows.",
         ),
+        agent_id: Optional[str] = Query(
+            default=None,
+            description="If omitted, not filtered by owning agent.",
+        ),
         session: UserSession = Depends(require_auth(RequireUser())),
 ):
     """
@@ -343,6 +357,7 @@ async def fetch_conversation(
         days=int(req.days),
         bundle_id=bundle_id,
         bundle_ids=allowed_bundle_ids,
+        agent_id=agent_id
     )
     if not (data or {}).get("turns"):
         raise HTTPException(status_code=404, detail="Conversation not found")

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/context/retrieval/ctx_rag.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/context/retrieval/ctx_rag.py
@@ -369,6 +369,7 @@ class ContextRAGClient:
             with_payload: bool = False,
             bundle_id: Optional[str] = None,
             bundle_ids: Optional[Sequence[str]] = None,
+            agent_id: Optional[str] = None,
     ) -> dict:
         """
         Pure-recency fetch (no embeddings). Fast path for "last N in track".
@@ -394,6 +395,7 @@ class ContextRAGClient:
             days=days,
             bundle_id=bundle,
             bundle_ids=bundle_ids,
+            agent_id=agent_id,
         )
         items = []
         for r in rows:
@@ -549,6 +551,7 @@ class ContextRAGClient:
             conversation_id: str, user_type: str,
             turn_id: str,
             bundle_id: str,
+            agent_id: Optional[str] = None,
             payload: Optional[Dict[str, Any]] = None,
             extra_tags: Optional[List[str]] = None
     ) -> Dict[str, Any]:
@@ -575,6 +578,7 @@ class ContextRAGClient:
             user_id=user, conversation_id=conversation_id,
             turn_id=turn_id,
             bundle_id=bundle_id,
+            agent_id=agent_id,
             role="artifact",
             text=index_text, hosted_uri=hosted_uri, ts=log.ts,
             tags=tags,
@@ -1761,6 +1765,7 @@ class ContextRAGClient:
             meta: Optional[Dict[str, Any]] = None,
             extra_tags: Optional[List[str]] = None,
             bundle_id: Optional[str] = None,
+            agent_id: Optional[str] = None,
             index_only: bool = False,
             store_only: bool = False,
             embedding: Optional[List[float]] = None,
@@ -1806,7 +1811,7 @@ class ContextRAGClient:
             ttl_days = int(ttl_days or 365)
             await self.idx.add_message(
                 user_id=user_id, conversation_id=conversation_id, turn_id=turn_id,
-                bundle_id=bundle_id, role="artifact",
+                bundle_id=bundle_id, agent_id=agent_id, role="artifact",
                 text=content_str, hosted_uri=hosted_uri, ts=datetime.datetime.utcnow().isoformat()+"Z",
                 tags=tags,
                 ttl_days=ttl_days, user_type=user_type, embedding=embedding, message_id=message_id
@@ -1928,6 +1933,7 @@ class ContextRAGClient:
             days: int = 365,
             include_titles: bool = True,
             bundle_id: Optional[str] = None,
+            agent_id: Optional[str] = None,
             ctx: Optional[dict] = None,
     ) -> Dict[str, Any]:
         """
@@ -1960,6 +1966,7 @@ class ContextRAGClient:
             days=days,
             limit=fetch_limit,
             bundle_id=bundle_id,
+            agent_id=agent_id,
             ctx=ctx,
         )
 
@@ -2013,6 +2020,7 @@ class ContextRAGClient:
         *,
         bundle_id: Optional[str] = None,
         bundle_ids: Optional[Sequence[str]] = None,
+        agent_id: Optional[str] = None,
         ctx: Optional[dict] = None,
     ):
         """
@@ -2040,6 +2048,7 @@ class ContextRAGClient:
                 with_payload=False,
                 bundle_id=bundle_id,
                 bundle_ids=bundle_ids,
+                agent_id=agent_id,
                 ctx=query_ctx,
             )
             ws_items = list(res_ws.get("items") or [])
@@ -2063,6 +2072,7 @@ class ContextRAGClient:
             conversation_id=conversation_id,
             bundle_id=bundle_id,
             bundle_ids=bundle_ids,
+            agent_id=agent_id,
             ctx=query_ctx,
         )
         # 4) Aggregate to first/last timestamps per turn_id, preserving first-seen order
@@ -2201,6 +2211,7 @@ class ContextRAGClient:
         days: int = 365,
         bundle_id: Optional[str] = None,
         bundle_ids: Optional[Sequence[str]] = None,
+        agent_id: Optional[str] = None,
         ctx: Optional[dict] = None,
     ) -> Dict[str, Any]:
         # For this endpoint, missing external bundle_id means "do not filter by bundle".
@@ -2219,6 +2230,7 @@ class ContextRAGClient:
             days=days,
             bundle_id=bundle_id,
             bundle_ids=bundle_ids,
+            agent_id=agent_id,
             turn_ids=turn_ids or None,
             ctx=query_ctx,
         )
@@ -2237,6 +2249,7 @@ class ContextRAGClient:
                 with_payload=False,
                 bundle_id=bundle_id,
                 bundle_ids=bundle_ids,
+                agent_id=agent_id,
                 ctx=query_ctx,
             )
             ws_items = list(res_ws.get("items") or [])
@@ -2932,6 +2945,7 @@ async def search_context(
         with_payload: bool = False,
         timestamp_filters: Optional[List[Dict[str, Any]]] = None,
         include_recovery_sessions: bool = False,
+        agent_id: Optional[str] = None,
         logger = None,
 ) -> tuple[str | None, list[dict]]:
     """
@@ -2977,6 +2991,7 @@ async def search_context(
                 half_life_days=half_life_days,
                 timestamp_filters=timestamp_filters,
                 include_recovery_sessions=include_recovery_sessions,
+                agent_id=agent_id,
             )
             return res or []
         except Exception as e:
@@ -2999,6 +3014,7 @@ async def search_context(
                 half_life_days=half_life_days,
                 timestamp_filters=timestamp_filters,
                 include_recovery_sessions=include_recovery_sessions,
+                agent_id=agent_id,
             )
             return res or []
         except Exception as e:
@@ -3021,6 +3037,7 @@ async def search_context(
                 half_life_days=half_life_days,
                 timestamp_filters=timestamp_filters,
                 include_recovery_sessions=include_recovery_sessions,
+                agent_id=agent_id,
             )
             return res or []
         except Exception as e:

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/context/vector/conv_index.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/context/vector/conv_index.py
@@ -312,6 +312,9 @@ class ConvIndex:
         async with self._pool.acquire() as con:
             if row is None:
                 # INSERT
+                # No agent_id: this is a per-conversation singleton (CAS-updated by
+                # every turn regardless of agent), not an agent's output. Owning it to
+                # the first agent would freeze a stale id; the column stays NULL.
                 tags = list(dict.fromkeys(
                     base_tags + [new_state_tag] + ([turn_tag] if turn_tag else [])
                 ))
@@ -378,6 +381,7 @@ class ConvIndex:
             message_id: Optional[str] = None,
             turn_id: Optional[str] = None,
             bundle_id: Optional[str] = None,
+            agent_id: Optional[str] = None,
             anchors_text: str = "",
     ) -> int:
         ts_dt = _coerce_ts(ts)
@@ -385,8 +389,8 @@ class ConvIndex:
             q = f"""
                 INSERT INTO {self.schema}.conv_messages
                   (user_id, conversation_id, message_id, role, text, hosted_uri, ts,
-                   ttl_days, user_type, tags, embedding, turn_id, bundle_id, anchors_text)
-                VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11::vector,$12,$13,$14)
+                   ttl_days, user_type, tags, embedding, turn_id, bundle_id, agent_id, anchors_text)
+                VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11::vector,$12,$13,$14,$15)
                 RETURNING id
             """
             rec = await con.fetchrow(
@@ -404,6 +408,7 @@ class ConvIndex:
                 convert_embedding_to_string(embedding) if embedding else None,
                 turn_id,
                 bundle_id,
+                agent_id,
                 (anchors_text or ""),
             )
             return int(rec["id"])
@@ -818,6 +823,7 @@ class ConvIndex:
             limit: int = 30,
             days: int = 30,
             bundle_id: Optional[str] = None,
+            agent_id: Optional[str] = None,
             bundle_ids: Optional[Sequence[str]] = None,
             turn_id: Optional[str] = None,
             ctx: Optional[dict] = None,
@@ -851,6 +857,9 @@ class ConvIndex:
         )
         if bundle_scope:
             where.append(bundle_scope)
+        if agent_id:
+            args.append(agent_id)
+            where.append(f"agent_id = ${len(args)}")
         if any_tags:
             args.append(list(any_tags))
             where.append(f"tags && ${len(args)}::text[]")
@@ -862,7 +871,7 @@ class ConvIndex:
             where.append(f"NOT (tags && ${len(args)}::text[])")
 
         q = f"""
-          SELECT id, message_id, role, text, hosted_uri, ts, tags, turn_id, bundle_id, conversation_id
+          SELECT id, message_id, role, text, hosted_uri, ts, tags, turn_id, bundle_id, agent_id, conversation_id
           FROM {self.schema}.conv_messages
           WHERE {' AND '.join(where)}
           ORDER BY ts DESC
@@ -1142,6 +1151,7 @@ class ConvIndex:
             from_ts: Optional[Union[str, datetime]] = None,
             to_ts: Optional[Union[str, datetime]] = None,
             bundle_id: Optional[str] = None,
+            agent_id: Optional[str] = None,
             ctx: Optional[dict] = None,
     ) -> List[Dict[str, Any]]:
         """
@@ -1174,6 +1184,9 @@ class ConvIndex:
         if bundle_id:
             args.append(bundle_id)
             where.append(f"m.bundle_id = ${len(args)}")
+        if agent_id:
+            args.append(agent_id)
+            where.append(f"m.agent_id = ${len(args)}")
         if from_ts is not None:
             args.append(_coerce_ts(from_ts))
             where.append(f"m.ts >= ${len(args)}::timestamptz")
@@ -1207,6 +1220,7 @@ class ConvIndex:
             m.tags,
             m.turn_id,
             m.bundle_id,
+            m.agent_id,
             m.conversation_id,
             COALESCE(
               m.turn_id,
@@ -1250,6 +1264,7 @@ class ConvIndex:
           o.tags,
           o.turn_key AS turn_id,
           o.bundle_id,
+          o.agent_id,
           o.conversation_id,
           ws.text AS working_summary_text,
           ws.ts AS working_summary_ts,
@@ -1617,6 +1632,7 @@ class ConvIndex:
             conversation_id: Optional[str] = None,
             days: int = 365,
             bundle_id: Optional[str] = None,
+            agent_id: Optional[str] = None,
             bundle_ids: Optional[Sequence[str]] = None,
             turn_ids: Optional[Sequence[str]] = None,
             ctx: Optional[dict] = None,
@@ -1654,6 +1670,10 @@ class ConvIndex:
         if bundle_scope:
             where.append(bundle_scope)
 
+        if agent_id:
+            args.append(agent_id)
+            where.append(f"m.agent_id = ${len(args)}")
+
         turn_ids_cond = "TRUE"
         if turn_ids:
             args.append(list(turn_ids))
@@ -1667,6 +1687,7 @@ class ConvIndex:
                 m.hosted_uri     AS hosted_uri,
                 m.tags       AS tags,
                 m.bundle_id  AS bundle_id,
+                m.agent_id   AS agent_id,
                 t.tag        AS tag,
                 array_position(m.tags, t.tag) AS tag_idx
               FROM {self.schema}.conv_messages m
@@ -1676,7 +1697,7 @@ class ConvIndex:
                 AND {turn_ids_cond}
             )
             SELECT substring(tag FROM '^turn:(.+)$') AS turn_id,
-                   ts, tags, mid, hosted_uri, bundle_id
+                   ts, tags, mid, hosted_uri, bundle_id, agent_id
             FROM exploded
             ORDER BY ts ASC, mid ASC, tag_idx ASC
         """
@@ -1696,6 +1717,7 @@ class ConvIndex:
                 "mid": r.get("mid"),
                 "hosted_uri": r.get("hosted_uri"),
                 "bundle_id": r.get("bundle_id"),
+                "agent_id": r.get("agent_id"),
             })
         return out
 
@@ -1814,6 +1836,7 @@ class ConvIndex:
             days: int = 90,
             scope: str = "conversation",
             bundle_id: Optional[str] = None,
+            agent_id: Optional[str] = None,
             half_life_days: float = 7.0,
             timestamp_filters: Optional[List[Dict[str, Any]]] = None,
             include_recovery_sessions: bool = False,
@@ -1889,6 +1912,10 @@ class ConvIndex:
             args.append(bundle_id)
             where.append(f"m.bundle_id = ${len(args)}")
 
+        if agent_id:
+            args.append(agent_id)
+            where.append(f"m.agent_id = ${len(args)}")
+
         # Optional text filter (ILIKE)
         if query_text:
             args.append(f"%{query_text}%")
@@ -1940,7 +1967,7 @@ class ConvIndex:
         )
         SELECT 
             log.id, log.message_id, log.role, log.text, log.hosted_uri, log.ts, log.tags,
-            log.turn_id, log.conversation_id, log.bundle_id,
+            log.turn_id, log.conversation_id, log.bundle_id, log.agent_id,
             ut.sim,
             ut.rec,
             ut.score,
@@ -1981,6 +2008,7 @@ class ConvIndex:
             days: int = 90,
             scope: str = "conversation",
             bundle_id: Optional[str] = None,
+            agent_id: Optional[str] = None,
             half_life_days: float = 7.0,
             timestamp_filters: Optional[List[Dict[str, Any]]] = None,
             include_recovery_sessions: bool = False,
@@ -2049,6 +2077,10 @@ class ConvIndex:
             args.append(bundle_id)
             where.append(f"m.bundle_id = ${len(args)}")
 
+        if agent_id:
+            args.append(agent_id)
+            where.append(f"m.agent_id = ${len(args)}")
+
         valid_ops = {"<", "<=", "=", ">=", ">", "<>"}
         for tf in (timestamp_filters or []):
             op = str(tf.get("op", "")).strip()
@@ -2097,7 +2129,7 @@ class ConvIndex:
         )
         SELECT
             log.id, log.message_id, log.role, log.text, log.hosted_uri, log.ts, log.tags,
-            log.turn_id, log.conversation_id, log.bundle_id,
+            log.turn_id, log.conversation_id, log.bundle_id, log.agent_id,
             ut.sim,
             ut.rec,
             ut.score,
@@ -2138,6 +2170,7 @@ class ConvIndex:
             days: int = 90,
             scope: str = "conversation",
             bundle_id: Optional[str] = None,
+            agent_id: Optional[str] = None,
             half_life_days: float = 7.0,
             timestamp_filters: Optional[List[Dict[str, Any]]] = None,
             min_word_similarity: float = 0.2,
@@ -2219,6 +2252,10 @@ class ConvIndex:
             args.append(bundle_id)
             where.append(f"m.bundle_id = ${len(args)}")
 
+        if agent_id:
+            args.append(agent_id)
+            where.append(f"m.agent_id = ${len(args)}")
+
         valid_ops = {"<", "<=", "=", ">=", ">", "<>"}
         for tf in (timestamp_filters or []):
             op = str(tf.get("op", "")).strip()
@@ -2274,7 +2311,7 @@ class ConvIndex:
         )
         SELECT
             log.id, log.message_id, log.role, log.text, log.hosted_uri, log.ts, log.tags,
-            log.turn_id, log.conversation_id, log.bundle_id,
+            log.turn_id, log.conversation_id, log.bundle_id, log.agent_id,
             ut.sim,
             ut.rec,
             ut.score,

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/context/vector/conv_index.sql
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/context/vector/conv_index.sql
@@ -10,6 +10,7 @@ CREATE SCHEMA IF NOT EXISTS <SCHEMA>;
 CREATE TABLE IF NOT EXISTS <SCHEMA>.conv_messages (
                                                       id               BIGSERIAL PRIMARY KEY,
                                                       user_id          TEXT NOT NULL,
+                                                      agent_id         TEXT,                           -- owning agent; NULL when no agent_id is provided
                                                       conversation_id  TEXT NOT NULL,
                                                       message_id       TEXT,                           -- ConversationStore id; present for artifacts
                                                       role             TEXT NOT NULL,                  -- 'user' | 'assistant' | 'artifact'

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/context/vector/tests/test_agent_id_filter.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/context/vector/tests/test_agent_id_filter.py
@@ -1,0 +1,201 @@
+# SPDX-License-Identifier: MIT
+
+"""agent_id storage semantics + the optional read-side filter.
+
+Covers the spec rule "if no agent_id filter is given, it is not applied", for the
+two memsearch call sites (ctx_browser.search / ctx_browser.search_turn_catalog)
+and the ConvIndex SQL builders they delegate to.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kdcube_ai_app.apps.chat.sdk.event_identity import index_agent_id
+from kdcube_ai_app.apps.chat.sdk.context.vector.conv_index import ConvIndex
+from kdcube_ai_app.apps.chat.sdk.solutions.react import browser as browser_mod
+from kdcube_ai_app.apps.chat.sdk.solutions.react.browser import ContextBrowser
+
+
+# --------------------------------------------------------------------------- #
+# index_agent_id — storage value is the agent id as-is, None only when absent
+# --------------------------------------------------------------------------- #
+
+def test_index_agent_id_stores_value_as_is():
+    assert index_agent_id("main") == "main"
+    assert index_agent_id("research.react.agent") == "research.react.agent"
+    # the platform default is a real value, NOT collapsed to NULL
+    assert index_agent_id("default.react.agent") == "default.react.agent"
+
+
+def test_index_agent_id_none_only_when_absent():
+    assert index_agent_id(None) is None
+    assert index_agent_id("") is None
+    assert index_agent_id("   ") is None
+
+
+def test_index_agent_id_strips_whitespace():
+    assert index_agent_id("  main  ") == "main"
+
+
+# --------------------------------------------------------------------------- #
+# Fake asyncpg pool: capture the SQL text + bound args of the last query
+# --------------------------------------------------------------------------- #
+
+class _FakeConn:
+    def __init__(self):
+        self.calls: list[tuple[str, list]] = []
+
+    async def fetch(self, q, *args):
+        self.calls.append((q, list(args)))
+        return []
+
+    async def fetchrow(self, q, *args):
+        self.calls.append((q, list(args)))
+        return {"id": 1}
+
+
+class _AcquireCtx:
+    def __init__(self, conn):
+        self._conn = conn
+
+    async def __aenter__(self):
+        return self._conn
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+class _FakePool:
+    def __init__(self):
+        self.conn = _FakeConn()
+
+    def acquire(self):
+        return _AcquireCtx(self.conn)
+
+
+def _make_idx() -> ConvIndex:
+    # Bypass __init__ (it reads settings) and inject only what the SQL builders use.
+    idx = object.__new__(ConvIndex)
+    idx._pool = _FakePool()
+    idx.schema = "kdcube_t_p"
+    idx.shared_pool = True
+    return idx
+
+
+# The WHERE clause is `m.agent_id = $N`; the SELECT lists `m.agent_id,` / `o.agent_id,`
+# unconditionally, so we match the filter form specifically.
+_FILTER = "m.agent_id = $"
+_NAMED = "research.agent"
+
+
+# --------------------------------------------------------------------------- #
+# ConvIndex.fetch_turn_catalog  (backs ctx_browser.search_turn_catalog)
+# --------------------------------------------------------------------------- #
+
+@pytest.mark.asyncio
+async def test_fetch_turn_catalog_no_filter_when_agent_absent():
+    idx = _make_idx()
+    await idx.fetch_turn_catalog(
+        user_id="u", conversation_id="c",
+        ctx={"user_id": "u", "conversation_id": "c"},
+    )
+    q, args = idx._pool.conn.calls[-1]
+    assert _FILTER not in q
+    assert _NAMED not in args
+
+
+@pytest.mark.asyncio
+async def test_fetch_turn_catalog_filters_when_agent_present():
+    idx = _make_idx()
+    await idx.fetch_turn_catalog(
+        user_id="u", conversation_id="c", agent_id=_NAMED,
+        ctx={"user_id": "u", "conversation_id": "c"},
+    )
+    q, args = idx._pool.conn.calls[-1]
+    assert _FILTER in q
+    assert _NAMED in args
+
+
+# --------------------------------------------------------------------------- #
+# ConvIndex.search_turn_logs_via_content  (backs ctx_browser.search)
+# --------------------------------------------------------------------------- #
+
+@pytest.mark.asyncio
+async def test_search_turn_logs_no_filter_when_agent_absent():
+    idx = _make_idx()
+    await idx.search_turn_logs_via_content(user_id="u", conversation_id="c", scope="user")
+    q, args = idx._pool.conn.calls[-1]
+    assert _FILTER not in q
+    assert _NAMED not in args
+
+
+@pytest.mark.asyncio
+async def test_search_turn_logs_filters_when_agent_present():
+    idx = _make_idx()
+    await idx.search_turn_logs_via_content(
+        user_id="u", conversation_id="c", scope="user", agent_id=_NAMED,
+    )
+    q, args = idx._pool.conn.calls[-1]
+    assert _FILTER in q
+    assert _NAMED in args
+
+
+# --------------------------------------------------------------------------- #
+# ContextBrowser delegation — the exact memsearch call sites
+# --------------------------------------------------------------------------- #
+
+class _RecordingIdx:
+    def __init__(self):
+        self.kwargs: dict = {}
+
+    async def fetch_turn_catalog(self, **kwargs):
+        self.kwargs = kwargs
+        return []
+
+
+@pytest.mark.asyncio
+async def test_ctx_browser_search_turn_catalog_defaults_agent_none():
+    idx = _RecordingIdx()
+    cb = ContextBrowser()
+    await cb.search_turn_catalog(user="u", conv="c", conv_idx=idx)
+    assert idx.kwargs["agent_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_ctx_browser_search_turn_catalog_forwards_agent():
+    idx = _RecordingIdx()
+    cb = ContextBrowser()
+    await cb.search_turn_catalog(user="u", conv="c", conv_idx=idx, agent_id=_NAMED)
+    assert idx.kwargs["agent_id"] == _NAMED
+
+
+@pytest.mark.asyncio
+async def test_ctx_browser_search_defaults_agent_none(monkeypatch):
+    recorded: dict = {}
+
+    async def _fake_search_context(**kwargs):
+        recorded.update(kwargs)
+        return (None, [])
+
+    monkeypatch.setattr(browser_mod, "search_context", _fake_search_context)
+    cb = ContextBrowser()
+    await cb.search(targets=[], user="u", conv="c", conv_idx=object(), model_service=object())
+    assert recorded["agent_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_ctx_browser_search_forwards_agent(monkeypatch):
+    recorded: dict = {}
+
+    async def _fake_search_context(**kwargs):
+        recorded.update(kwargs)
+        return (None, [])
+
+    monkeypatch.setattr(browser_mod, "search_context", _fake_search_context)
+    cb = ContextBrowser()
+    await cb.search(
+        targets=[], user="u", conv="c", conv_idx=object(), model_service=object(),
+        agent_id=_NAMED,
+    )
+    assert recorded["agent_id"] == _NAMED

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/event_identity.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/event_identity.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import re
+from typing import Optional
 
 
 DEFAULT_REACT_AGENT_ID = "default.react.agent"
@@ -16,6 +17,12 @@ def normalize_agent_id(value: object, *, default: str = DEFAULT_REACT_AGENT_ID) 
     if not text:
         text = str(default or "").strip()
     return text or DEFAULT_REACT_AGENT_ID
+
+
+def index_agent_id(value: object) -> Optional[str]:
+    """Storage value for conv_messages.agent_id: the agent id as-is, or None when absent."""
+
+    return str(value or "").strip() or None
 
 
 def safe_event_lane_part(value: object, *, default: str = "_") -> str:

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/chatbot/base_workflow.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/chatbot/base_workflow.py
@@ -24,7 +24,7 @@ from kdcube_ai_app.apps.chat.sdk.events.event_bus import (
     EventLaneWakePublisher,
     RedisEventLaneWakeEnqueuer,
 )
-from kdcube_ai_app.apps.chat.sdk.event_identity import DEFAULT_REACT_AGENT_ID, normalize_agent_id
+from kdcube_ai_app.apps.chat.sdk.event_identity import normalize_agent_id, index_agent_id
 # from kdcube_ai_app.apps.chat.sdk.context.memory.conv_memories import ConvMemoriesStore
 from kdcube_ai_app.apps.chat.sdk.context.retrieval.ctx_rag import ContextRAGClient
 
@@ -1388,6 +1388,7 @@ class BaseWorkflow():
                         "request_id": self._ctx["service"]["request_id"],
                     },
                     bundle_id=self.config.ai_bundle_spec.id,
+                    agent_id=self._index_agent_id(),
                 )
             a["summary_persisted"] = True
 
@@ -1498,6 +1499,7 @@ class BaseWorkflow():
                 user_id=user_id,
                 conversation_id=conversation_id,
                 bundle_id=self.config.ai_bundle_spec.id,
+                agent_id=self._index_agent_id(),
                 user_type=user_type,
                 content={"version": "v1", "items": canvas_full},
                 content_str=json.dumps(canvas_idx),
@@ -1731,6 +1733,10 @@ class BaseWorkflow():
         except Exception:
             self.logger.log(traceback.format_exc(), "ERROR")
 
+    def _index_agent_id(self) -> Optional[str]:
+        """Owning-agent id for conv_messages.agent_id, from the runtime context."""
+        return index_agent_id(getattr(getattr(self, "runtime_ctx", None), "agent_id", None))
+
     async def _persist_user_conversation_entry(
         self,
         *,
@@ -1771,6 +1777,7 @@ class BaseWorkflow():
             user_id=user,
             conversation_id=conversation_id,
             bundle_id=self.config.ai_bundle_spec.id,
+            agent_id=self._index_agent_id(),
             turn_id=turn_id,
             role="user",
             text=text_for_index,
@@ -1857,6 +1864,7 @@ class BaseWorkflow():
                 user_id=user,
                 conversation_id=conversation_id,
                 bundle_id=self.config.ai_bundle_spec.id,
+                agent_id=self._index_agent_id(),
                 turn_id=turn_id,
                 role="assistant",
                 text=text,
@@ -1913,6 +1921,7 @@ class BaseWorkflow():
                 user_id=user,
                 conversation_id=conversation_id,
                 bundle_id=self.config.ai_bundle_spec.id,
+                agent_id=self._index_agent_id(),
                 turn_id=turn_id,
                 role="assistant",
                 text=text,
@@ -1957,6 +1966,7 @@ class BaseWorkflow():
                 user_id=user,
                 conversation_id=conversation_id,
                 bundle_id=self.config.ai_bundle_spec.id,
+                agent_id=self._index_agent_id(),
                 turn_id=turn_id,
                 role="artifact",
                 text=text,
@@ -2832,6 +2842,7 @@ class BaseWorkflow():
                         embedding=embedding,
                         ttl_days=_ttl_for(user_type, 365),
                         bundle_id=self.config.ai_bundle_spec.id,
+                        agent_id=self._index_agent_id(),
                         index_only=True,
                     )
                 except Exception:
@@ -3235,6 +3246,7 @@ class BaseWorkflow():
             conversation_id=conversation_id, user_type=user_type,
             turn_id=turn_id,
             bundle_id=self.config.ai_bundle_spec.id,
+            agent_id=self._index_agent_id(),
             payload=payload,
             extra_tags=[],
         )

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/chatbot/entrypoint.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/chatbot/entrypoint.py
@@ -28,7 +28,7 @@ from kdcube_ai_app.apps.chat.emitters import (
     build_relay_from_env,
 )
 from kdcube_ai_app.apps.chat.sdk.config import get_settings
-from kdcube_ai_app.apps.chat.sdk.event_identity import DEFAULT_REACT_AGENT_ID, normalize_agent_id
+from kdcube_ai_app.apps.chat.sdk.event_identity import DEFAULT_REACT_AGENT_ID, normalize_agent_id, index_agent_id
 from kdcube_ai_app.apps.chat.sdk.infra.economics.policy import EconomicsLimitException
 from kdcube_ai_app.apps.chat.sdk.protocol import ExternalEventPayload
 from kdcube_ai_app.apps.chat.sdk.runtime.exec_runtime_config import normalize_exec_runtime_config
@@ -2347,6 +2347,10 @@ class BaseEntrypoint:
             ]
             if not step_items:
                 return
+            agent_id = index_agent_id(
+                getattr(getattr(self, "runtime_ctx", None), "agent_id", None)
+                or state.get("agent_id")
+            )
             await ctx_client.save_artifact(
                 kind="conv.artifacts.events",
                 tenant=tenant, project=project,
@@ -2354,6 +2358,7 @@ class BaseEntrypoint:
                 user_id=user_id,
                 conversation_id=conversation_id,
                 bundle_id=bundle_id,
+                agent_id=agent_id,
                 user_type=user_type,
                 content={"version": "v1", "items": step_items},
                 extra_tags=["conversation", "events"],

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/conversation/api.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/conversation/api.py
@@ -53,6 +53,7 @@ from kdcube_ai_app.apps.chat.sdk.solutions.react.timeline import (
     extract_assistant_completion_blocks,
     extract_user_attachments_from_blocks,
 )
+from kdcube_ai_app.apps.chat.sdk.event_identity import index_agent_id
 
 # Matches the dotted-name convention used by the sibling named-service modules
 # (e.g. "kdcube.sdk.conversation.named_service", "kdcube.sdk.memory.named_service").
@@ -78,7 +79,11 @@ CATALOG_MODES = frozenset({MODE_TEMPORAL, MODE_ORDINAL, MODE_TIMELINE, MODE_CATA
 # --- Scope ---
 SCOPE_CONVERSATION = "conversation"
 SCOPE_USER = "user"
-ALLOWED_SCOPES = frozenset({SCOPE_CONVERSATION, SCOPE_USER})
+# User-wide recall narrowed to the current owning agent. The search backend only
+# knows conversation/user; agent scope maps to user scope plus an agent_id filter
+# at orchestration (see ConversationSearchParams.backend_scope / run_conversation_search).
+SCOPE_AGENT = "agent"
+ALLOWED_SCOPES = frozenset({SCOPE_CONVERSATION, SCOPE_USER, SCOPE_AGENT})
 
 # --- Order ---
 ORDER_ASC = "asc"
@@ -161,6 +166,11 @@ class ConversationSearchContext:
     conversation_id: str = ""
     turn_id: str = ""
     bundle_id: Optional[str] = None
+    # Owning agent of the current turn. A WHERE filter, applied only under
+    # scope="agent" (see run_conversation_search). Same source/normalization as
+    # the value written to conv_messages.agent_id. Old source:
+    # ctx_browser.runtime_ctx.agent_id.
+    agent_id: Optional[str] = None
     tenant: Optional[str] = None
     project: Optional[str] = None
     schema: Optional[str] = None
@@ -177,6 +187,7 @@ class ConversationSearchContext:
             conversation_id=str(getattr(runtime_ctx, "conversation_id", "") or ""),
             turn_id=str(getattr(runtime_ctx, "turn_id", "") or ""),
             bundle_id=getattr(runtime_ctx, "bundle_id", None),
+            agent_id=index_agent_id(getattr(runtime_ctx, "agent_id", None)),
             tenant=getattr(runtime_ctx, "tenant", None),
             project=getattr(runtime_ctx, "project", None),
         )
@@ -238,6 +249,14 @@ class ConversationSearchParams:
             mode=mode,
             include_recovery_sessions=bool(params.get("include_recovery_sessions")),
         )
+
+    def is_agent_scoped(self) -> bool:
+        return self.scope == SCOPE_AGENT
+
+    def backend_scope(self) -> str:
+        """Scope the backend understands (conversation|user). Agent scope is
+        user-wide; the agent narrowing is applied via agent_id, not scope."""
+        return SCOPE_USER if self.scope == SCOPE_AGENT else self.scope
 
     def has_temporal_bounds(self) -> bool:
         return bool(self.from_ts or self.to_ts)
@@ -380,6 +399,11 @@ async def run_conversation_search(
     conversation_id = context.conversation_id
     targets = list(params.targets)
 
+    # Agent scope: search user-wide but narrow to the current owning agent.
+    # Other scopes pass no agent filter (the spec's "not specified -> not applied").
+    backend_scope = params.backend_scope()
+    agent_filter = context.agent_id if params.is_agent_scoped() else None
+
     effective_mode = params.effective_mode()
     catalog_mode = params.is_catalog()
     ignored_catalog_query = bool(catalog_mode and params.query)
@@ -439,7 +463,8 @@ async def run_conversation_search(
             rows = await search_backend.search_turn_catalog(
                 user=user,
                 conv=conversation_id,
-                scope=params.scope,
+                scope=backend_scope,
+                agent_id=agent_filter,
                 top_k=top_k,
                 days=days,
                 order=params.order,
@@ -524,7 +549,8 @@ async def run_conversation_search(
             targets=search_targets,
             user=user,
             conv=conversation_id,
-            scope=params.scope,
+            scope=backend_scope,
+            agent_id=agent_filter,
             scoring_mode="rrf_hybrid",
             half_life_days=7.0,
             top_k=retriever_top_k,
@@ -750,6 +776,7 @@ __all__ = [
     "ORDER_DESC",
     "SCOPE_CONVERSATION",
     "SCOPE_USER",
+    "SCOPE_AGENT",
     "ConversationSearchBackend",
     "ConversationSearchContext",
     "ConversationSearchParams",

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/conversation/tests/test_api.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/conversation/tests/test_api.py
@@ -180,3 +180,70 @@ def test_context_from_runtime_ctx_captures_identity():
     assert ctx.bundle_id == "rb"
     assert ctx.tenant == "rten"
     assert ctx.project == "rproj"
+    assert ctx.agent_id is None  # absent on runtime -> None
+
+
+def test_context_from_runtime_ctx_normalizes_agent_id():
+    class FakeRuntime:
+        user_id = "ru"
+        conversation_id = "rc"
+        turn_id = "rt"
+        agent_id = "  research  "
+
+    ctx = ConversationSearchContext.from_runtime_ctx(FakeRuntime())
+    assert ctx.agent_id == "research"  # index_agent_id strips; value kept as-is
+
+
+@pytest.mark.asyncio
+async def test_agent_scope_maps_to_user_and_forwards_agent_id_hybrid():
+    backend = FakeBackend()
+    backend._turn_logs["turn_prev"] = {"blocks": [], "sources_pool": []}
+    context = ConversationSearchContext(
+        user_id="u1", conversation_id="c1", agent_id="research",
+    )
+    params = ConversationSearchParams(query="PDF", targets=["summary"], scope="agent")
+
+    await run_conversation_search(context=context, params=params, search_backend=backend)
+
+    # agent scope -> backend sees user scope (cross-conversation) + the agent filter
+    assert backend.search_kwargs["scope"] == "user"
+    assert backend.search_kwargs["agent_id"] == "research"
+
+
+@pytest.mark.asyncio
+async def test_agent_scope_forwards_agent_id_catalog():
+    backend = FakeBackend()
+    context = ConversationSearchContext(
+        user_id="u1", conversation_id="c1", agent_id="research",
+    )
+    params = ConversationSearchParams.from_tool_params(
+        {"query": "", "mode": "ordinal", "ordinal": 2, "scope": "agent"}
+    )
+
+    await run_conversation_search(context=context, params=params, search_backend=backend)
+
+    assert backend.catalog_kwargs["scope"] == "user"
+    assert backend.catalog_kwargs["agent_id"] == "research"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("scope", ["conversation", "user"])
+async def test_non_agent_scopes_pass_no_agent_filter(scope):
+    backend = FakeBackend()
+    backend._turn_logs["turn_prev"] = {"blocks": [], "sources_pool": []}
+    # agent_id present on context, but must NOT be forwarded unless scope=="agent"
+    context = ConversationSearchContext(
+        user_id="u1", conversation_id="c1", agent_id="research",
+    )
+    params = ConversationSearchParams(query="PDF", targets=["summary"], scope=scope)
+
+    await run_conversation_search(context=context, params=params, search_backend=backend)
+
+    assert backend.search_kwargs["scope"] == scope
+    assert backend.search_kwargs["agent_id"] is None
+
+
+def test_from_tool_params_accepts_agent_scope():
+    assert ConversationSearchParams.from_tool_params({"scope": "agent"}).scope == "agent"
+    # unknown scope still falls back to conversation
+    assert ConversationSearchParams.from_tool_params({"scope": "bogus"}).scope == "conversation"

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/react/browser.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/react/browser.py
@@ -1893,6 +1893,7 @@ class ContextBrowser:
             with_payload: bool = False,
             timestamp_filters: Optional[List[Dict[str, Any]]] = None,
             include_recovery_sessions: bool = False,
+            agent_id: Optional[str] = None,
             conv_idx: Optional[Any] = None,
             ctx_client: Optional[ContextRAGClient] = None,
             model_service: Optional[Any] = None,
@@ -1923,6 +1924,7 @@ class ContextBrowser:
             with_payload=with_payload,
             timestamp_filters=timestamp_filters,
             include_recovery_sessions=include_recovery_sessions,
+            agent_id=agent_id,
             logger=self.log,
         )
 
@@ -1938,6 +1940,7 @@ class ContextBrowser:
             ordinal: Optional[int] = None,
             from_ts: Optional[Any] = None,
             to_ts: Optional[Any] = None,
+            agent_id: Optional[str] = None,
             conv_idx: Optional[Any] = None,
             ctx_client: Optional[ContextRAGClient] = None,
     ) -> List[Dict[str, Any]]:
@@ -1958,6 +1961,7 @@ class ContextBrowser:
             ordinal=ordinal,
             from_ts=from_ts,
             to_ts=to_ts,
+            agent_id=agent_id,
             ctx={
                 "user_id": user,
                 "conversation_id": conv,
@@ -1979,6 +1983,7 @@ class ContextBrowser:
             meta: Optional[Dict[str, Any]] = None,
             extra_tags: Optional[List[str]] = None,
             bundle_id: Optional[str] = None,
+            agent_id: Optional[str] = None,
             index_only: bool = False,
             store_only: bool = False,
             embedding: Optional[List[float]] = None,
@@ -2002,6 +2007,7 @@ class ContextBrowser:
             meta=meta,
             extra_tags=extra_tags,
             bundle_id=bundle_id,
+            agent_id=agent_id,
             index_only=index_only,
             store_only=store_only,
             embedding=embedding,

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/react/timeline.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/react/timeline.py
@@ -21,6 +21,7 @@ from kdcube_ai_app.apps.chat.sdk.solutions.react.caching import (
     tail_rounds_from_path as cache_tail_rounds_from_path,
 )
 from kdcube_ai_app.apps.chat.sdk.solutions.react.proto import RuntimeCtx
+from kdcube_ai_app.apps.chat.sdk.event_identity import index_agent_id
 
 from kdcube_ai_app.apps.chat.sdk.tools import citations as citations_module
 from kdcube_ai_app.apps.chat.sdk.util import (
@@ -7498,6 +7499,7 @@ class Timeline:
             user_type=self.runtime.user_type or "",
             turn_id=self.runtime.turn_id or "",
             bundle_id=self.runtime.bundle_id,
+            agent_id=index_agent_id(self.runtime.agent_id),
             content=payload,
             content_str=compact_text,
             extra_tags=extra_tags or None,
@@ -7522,6 +7524,7 @@ class Timeline:
                 user_type=self.runtime.user_type or "",
                 turn_id=self.runtime.turn_id or "",
                 bundle_id=self.runtime.bundle_id,
+                agent_id=index_agent_id(self.runtime.agent_id),
                 content=sources_payload,
                 content_str=sources_text,
                 extra_tags=extra_tags or None,

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/tests/test_conversations_bundle_scope.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/tests/test_conversations_bundle_scope.py
@@ -144,6 +144,7 @@ async def test_list_conversations_uses_default_bundle_from_redis(monkeypatch, _r
         days=365,
         include_titles=True,
         bundle_id=None,
+        agent_id=None,
         session=session,
     )
 
@@ -158,6 +159,7 @@ async def test_list_conversations_uses_default_bundle_from_redis(monkeypatch, _r
                 "days": 365,
                 "include_titles": True,
                 "bundle_id": "bundle.default",
+                "agent_id": None,
             },
         )
     ]
@@ -262,6 +264,7 @@ async def test_fetch_conversation_does_not_resolve_default_bundle_and_preserves_
         conversation_id="conv-1",
         req=req,
         bundle_id=None,
+        agent_id=None,
         session=session,
     )
 
@@ -287,6 +290,7 @@ async def test_fetch_conversation_does_not_resolve_default_bundle_and_preserves_
             "days": 365,
             "bundle_id": None,
             "bundle_ids": ["bundle.from.db", "bundle.other"],
+            "agent_id": None,
         },
     )
 

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/ops/deployment/sql/chatbot/conv-messages-agent-id.sql
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/ops/deployment/sql/chatbot/conv-messages-agent-id.sql
@@ -1,0 +1,24 @@
+-- SPDX-License-Identifier: MIT
+-- Copyright (c) 2026 Elena Viter
+--
+-- conv_messages.agent_id (one-time, idempotent migration). Adds the optional
+-- owning-agent column to a previously-deployed project schema. Replace <SCHEMA>
+-- with the project schema (e.g. kdcube_<tenant>_<project>) before applying,
+-- mirroring deploy-kdcube-proj-schema.sql.
+--
+-- Runs BEFORE the schema provision (deploy-kdcube-proj-schema.sql). `CREATE TABLE
+-- IF NOT EXISTS` never retrofits a column onto an existing table, so an
+-- already-deployed conv_messages needs this explicit ALTER. The provision's
+-- CREATE TABLE carries agent_id for fresh schemas; this migration carries it for
+-- existing ones.
+--
+-- Additive and nullable: existing rows get NULL (== single / unspecified agent;
+-- the column reflects what the runtime passes, NULL only when no agent_id is
+-- given). Both guards (ALTER TABLE IF EXISTS / ADD COLUMN IF NOT EXISTS) make the
+-- file a clean no-op on a fresh schema (table absent) and on a re-run.
+--
+-- TEMPORARY: remove this file (and its entry in apply_project_migrations) once
+-- every environment has the agent_id column.
+
+ALTER TABLE IF EXISTS <SCHEMA>.conv_messages
+  ADD COLUMN IF NOT EXISTS agent_id TEXT NULL;

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/ops/deployment/sql/chatbot/deploy-kdcube-proj-schema.sql
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/ops/deployment/sql/chatbot/deploy-kdcube-proj-schema.sql
@@ -12,6 +12,7 @@ CREATE TABLE IF NOT EXISTS <SCHEMA>.conv_messages (
                                                       id               BIGSERIAL PRIMARY KEY,
                                                       user_id          TEXT NOT NULL,
                                                       bundle_id        TEXT,
+                                                      agent_id         TEXT,                           -- owning agent; NULL when no agent_id is provided
                                                       conversation_id  TEXT NOT NULL,
                                                       message_id       TEXT,                           -- ConversationStore id; present for artifacts
                                                       role             TEXT NOT NULL,                  -- 'user' | 'assistant' | 'artifact'
@@ -31,6 +32,8 @@ CREATE TABLE IF NOT EXISTS <SCHEMA>.conv_messages (
     );
 
 -- Idempotent column upgrades for existing deployments
+-- (agent_id retrofit for existing schemas lives in the temporary
+--  conv-messages-agent-id.sql migration, applied before this provision.)
 DO $$
 BEGIN
   IF NOT EXISTS (

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/ops/deployment/sql/db_deployment.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/ops/deployment/sql/db_deployment.py
@@ -70,23 +70,30 @@ def project_schema(tenant: str, project: str) -> str:
     return schema_name
 
 
-# --- TEMPORARY one-time migration -------------------------------------------
+# --- TEMPORARY one-time migrations -------------------------------------------
 # Remove this helper (and its call in deploy_project.py) once every environment
-# has been provisioned with the `plans` schema naming. It applies
-# chatbot/economics-plans-corrections.sql BEFORE provisioning, so an already
-# deployed schema is renamed/extended in place; on a fresh schema every guarded
-# statement is a no-op and the provision creates the new names directly.
+# has been provisioned with the current schema. Each file is applied BEFORE
+# provisioning, so an already-deployed schema is renamed/extended in place; on a
+# fresh schema every guarded statement is a no-op and the provision creates
+# everything directly. Drop a file's entry here once its migration is universal.
+PROJECT_MIGRATION_FILES = [
+    "economics-plans-corrections.sql",   # `plans` rename + new fields
+    "conv-messages-agent-id.sql",        # conv_messages.agent_id column
+]
+
+
 def apply_project_migrations(tenant, project):
     from kdcube_ai_app.infra.relational.psql.psql_base import PostgreSqlDbMgr
 
     schema = project_schema(tenant or "default", project or "default-project")
     substitutions = {"SCHEMA": schema, "SYSTEM_SCHEMA": SYSTEM_SCHEMA}
-    migration_file = os.path.join(sql_location, "chatbot", "economics-plans-corrections.sql")
-    if not os.path.exists(migration_file):
-        return
     mgr = PostgreSqlDbMgr()
-    mgr.execute_sql_file(migration_file, substitutions=substitutions)
-    print(f"Applied economics-plans-corrections migration on schema: {schema}")
+    for name in PROJECT_MIGRATION_FILES:
+        migration_file = os.path.join(sql_location, "chatbot", name)
+        if not os.path.exists(migration_file):
+            continue
+        mgr.execute_sql_file(migration_file, substitutions=substitutions)
+        print(f"Applied {name} migration on schema: {schema}")
 # ---------------------------------------------------------------------------
 
 


### PR DESCRIPTION
  Record the owning agent on each conversation row and let reads scope by it.

  - conv_messages.agent_id column (provision + temporary conv-messages-agent-id.sql migration wired into apply_project_migrations)
  - write-path: thread agent_id through all turn rows (user/assistant/turn.log/ timeline/sources_pool/stream/events) via index_agent_id; conversation.state stays NULL (per-conversation singleton, not an agent's output)
  - optional ?agent_id= filter on list_conversations / conversation_details / fetch_conversation
  - memsearch scope="agent" (user-wide recall narrowed to the owning agent);
  - index_agent_id helper: store value as-is, NULL only when absent
  - tests for the filter plumbing and the new scope mapping