### PR TITLE
feat(chat): inline image rendering for bot-produced artifacts in web chat

### DIFF
--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/react/solution_workspace.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/react/solution_workspace.py
@@ -1490,8 +1490,17 @@ class ApplicationHostingService:
                 payload["logical_path"] = logical_path
                 payload["object_ref"] = logical_path
                 payload["ref"] = logical_path
+            # Web client resolves blobs only via POST /api/cb/resources/by-rn,
+            # which needs the structured rn. The strip below removes `rn` (it would
+            # change Telegram's delivery key). Re-surface it under a field outside
+            # Telegram's key set (_file_item_from_meta/_file_delivery_key never read
+            # `web_resource_rn`) so the browser can fetch the image inline without
+            # affecting Telegram delivery.
+            _web_rn = str(payload.get("rn") or item.get("rn") or "").strip()
             for transport_key in ("hosted_uri", "rn", "key"):
                 payload.pop(transport_key, None)
+            if _web_rn:
+                payload["web_resource_rn"] = _web_rn
             payload.setdefault("timestamp", event_ts_ms)
             payload.setdefault("timestamp_iso", event_ts_iso)
             payload.setdefault("ts", event_ts_ms)

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/tests/test_emit_solver_artifacts_web_rn.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/tests/test_emit_solver_artifacts_web_rn.py
@@ -1,0 +1,24 @@
+# test_emit_solver_artifacts_web_rn.py
+import asyncio
+from kdcube_ai_app.apps.chat.sdk.solutions.react.solution_workspace import ApplicationHostingService
+
+class _Comm:
+    def __init__(self): self.events = []
+    async def event(self, **kw): self.events.append(kw)
+
+def _emit(item):
+    svc = ApplicationHostingService.__new__(ApplicationHostingService)
+    svc.comm = _Comm(); svc.log = __import__("logging").getLogger("t")
+    svc._emitted_artifact_files = []
+    asyncio.run(
+        svc.emit_solver_artifacts(files=[dict(item)], citations=[]))
+    return svc.comm.events[-1]["data"]["items"][0]
+
+def test_web_resource_rn_present_and_telegram_fields_stripped():
+    out = _emit({"rn": "ef:t:p:file:conv:turn:assistant:map.png",
+                 "key": "blobkey123", "hosted_uri": "s3://x",
+                 "physical_path": "turn_t1/files/map.png",
+                 "filename": "map.png", "mime": "image/png",
+                 "logical_path": "fi:turn_t1.files/map.png"})
+    assert out["web_resource_rn"] == "ef:t:p:file:conv:turn:assistant:map.png"
+    assert "rn" not in out and "hosted_uri" not in out   # Telegram-invisible set unchanged

--- a/app/ai-app/ui/chat-web-app/src/components/chat/ChatInterface/assistantMessage/AssistantMessageComponent.tsx
+++ b/app/ai-app/ui/chat-web-app/src/components/chat/ChatInterface/assistantMessage/AssistantMessageComponent.tsx
@@ -1,4 +1,5 @@
 import {RNFile, TurnStep} from "../../../../features/chatController/chatBase.ts";
+import {InlineImageItemsPanel} from "./InlineImageItemsPanel.tsx";
 import {useAppSelector} from "../../../../app/store.ts";
 import {selectCurrentTurn} from "../../../../features/chat/chatStateSlice.ts";
 import React, {ReactNode, useCallback, useMemo, useRef, useState} from "react";
@@ -199,8 +200,19 @@ export const AssistantMessageComponent = ({
         )
     }, [streamedText])
 
+    const isImageFile = (f: RNFile): boolean =>
+        !!(f.mime && f.mime.toLowerCase().startsWith("image/"));
+
     const filesMemo = useMemo(() => {
-        return (<DownloadItemsPanel items={files.map(it => it.content)}/>)
+        const fileContents = files.map(it => it.content);
+        const imageItems = fileContents.filter(isImageFile);
+        const otherItems = fileContents.filter(f => !isImageFile(f));
+        return (
+            <>
+                <InlineImageItemsPanel items={imageItems}/>
+                <DownloadItemsPanel items={otherItems}/>
+            </>
+        );
     }, [files])
 
     const messageMemo = useMemo(() => {

--- a/app/ai-app/ui/chat-web-app/src/components/chat/ChatInterface/assistantMessage/AssistantMessageComponent.tsx
+++ b/app/ai-app/ui/chat-web-app/src/components/chat/ChatInterface/assistantMessage/AssistantMessageComponent.tsx
@@ -1,4 +1,4 @@
-import {RNFile, TurnStep} from "../../../../features/chatController/chatBase.ts";
+import {RNFile, TurnStep, resolveResourceRn} from "../../../../features/chatController/chatBase.ts";
 import {InlineImageItemsPanel} from "./InlineImageItemsPanel.tsx";
 import {useAppSelector} from "../../../../app/store.ts";
 import {selectCurrentTurn} from "../../../../features/chat/chatStateSlice.ts";
@@ -93,7 +93,7 @@ const DownloadItemsPanel = ({items}: DownloadItemsPanelProps) => {
                     <div key={index}>
                         <button
                             className="my-1 mr-2 text-gray-700 flex items-center text-sm cursor-pointer hover:text-black hover:underline"
-                            onClick={() => downloadResourceByRN(item.rn, item.filename, item.mime)}>
+                            onClick={() => downloadResourceByRN(resolveResourceRn(item), item.filename, item.mime)}>
                             <span className="inline-block mr-1">{getFileIcon(item.filename, 24, item.mime)}</span>
                             <span className="inline-block">{item.filename}</span>
                         </button>

--- a/app/ai-app/ui/chat-web-app/src/components/chat/ChatInterface/assistantMessage/InlineImageItemsPanel.tsx
+++ b/app/ai-app/ui/chat-web-app/src/components/chat/ChatInterface/assistantMessage/InlineImageItemsPanel.tsx
@@ -1,0 +1,50 @@
+import { useEffect, useState } from "react";
+import { RNFile, resolveResourceRn } from "../../../../features/chatController/chatBase.ts";
+import { getResourceByRN, downloadBlob } from "../../../../app/api/utils.ts";
+
+const useResourceObjectUrl = (rn: string): string | null => {
+    const [url, setUrl] = useState<string | null>(null);
+    useEffect(() => {
+        if (!rn) return;
+        let cancelled = false;
+        let obj: string | null = null;
+        (async () => {
+            try {
+                const resource = await getResourceByRN(rn);
+                const downloadUrl = resource?.metadata?.download_url;
+                if (!downloadUrl) return;
+                const blob = await downloadBlob(downloadUrl);
+                if (cancelled) return;
+                obj = URL.createObjectURL(blob);
+                setUrl(obj);
+            } catch { /* leave url null; caller shows nothing */ }
+        })();
+        return () => { cancelled = true; if (obj) URL.revokeObjectURL(obj); };
+    }, [rn]);
+    return url;
+};
+
+const InlineImage = ({ item }: { item: RNFile }) => {
+    const rn = resolveResourceRn(item);
+    const url = useResourceObjectUrl(rn);
+    if (!url) return null;
+    return (
+        <figure className="my-2">
+            <a href={url} target="_blank" rel="noreferrer">
+                <img src={url} alt={item.description || item.filename}
+                     title={item.filename} loading="lazy"
+                     className="rounded max-w-full h-auto border border-gray-200" />
+            </a>
+            <figcaption className="text-xs text-gray-500 mt-1">{item.filename}</figcaption>
+        </figure>
+    );
+};
+
+export const InlineImageItemsPanel = ({ items }: { items: RNFile[] }) => {
+    if (!items || !items.length) return null;
+    return (
+        <div className="flex flex-col justify-start mt-2">
+            {items.map((item, i) => <InlineImage key={resolveResourceRn(item) || i} item={item} />)}
+        </div>
+    );
+};

--- a/app/ai-app/ui/chat-web-app/src/features/chat/chatStateSlice.ts
+++ b/app/ai-app/ui/chat-web-app/src/features/chat/chatStateSlice.ts
@@ -8,7 +8,8 @@ import {
     ChatStepEnvelope,
     CitationsStepEnvelope,
     ConvStatusEnvelope,
-    FilesStepEnvelope
+    FilesStepEnvelope,
+    resolveResourceRn
 } from "../chatController/chatBase.ts";
 import {v4 as uuidv4} from "uuid";
 import {
@@ -676,7 +677,9 @@ const chatStateSlice = createSlice({
                         const filesEnv = env as FilesStepEnvelope
                         if (filesEnv.data?.items && filesEnv.data?.items?.length > 0) {
                             filesEnv.data.items.forEach(item => {
-                                const i = turn.artifacts.findIndex(f => f.artifactType === "file" && (f as FileArtifact).content.rn === item.rn)
+                                const key = resolveResourceRn(item);
+                                const i = turn.artifacts.findIndex(f => f.artifactType === "file" &&
+                                    resolveResourceRn((f as FileArtifact).content) === key && key !== "");
                                 const timestamp = itemTimestamp(item, eventTimestamp)
                                 if (i > -1) {
                                     turn.artifacts.splice(i, 1, {content: item, artifactType: "file", timestamp})

--- a/app/ai-app/ui/chat-web-app/src/features/chat/imageArtifact.test.ts
+++ b/app/ai-app/ui/chat-web-app/src/features/chat/imageArtifact.test.ts
@@ -1,0 +1,11 @@
+// imageArtifact.test.ts
+import { describe, it, expect } from "vitest";
+import { resolveResourceRn } from "../chatController/chatBase";
+
+describe("resolveResourceRn", () => {
+  it("prefers rn, falls back to web_resource_rn", () => {
+    expect(resolveResourceRn({ filename: "a", rn: "RN1", timestamp: 0 } as any)).toBe("RN1");
+    expect(resolveResourceRn({ filename: "a", rn: "", web_resource_rn: "RN2", timestamp: 0 } as any)).toBe("RN2");
+    expect(resolveResourceRn({ filename: "a", rn: "", timestamp: 0 } as any)).toBe("");
+  });
+});

--- a/app/ai-app/ui/chat-web-app/src/features/chatController/chatBase.ts
+++ b/app/ai-app/ui/chat-web-app/src/features/chatController/chatBase.ts
@@ -62,9 +62,13 @@ export interface ChatCompactionEnvelope extends BaseEnvelope {
 export interface RNFile extends Timestamped {
     filename: string,
     rn: string,
+    web_resource_rn?: string | null,
     mime?: string | null,
     description?: string | null,
 }
+
+export const resolveResourceRn = (f: RNFile): string =>
+    (f.rn && f.rn.trim()) || (f.web_resource_rn && f.web_resource_rn.trim()) || "";
 
 export interface FilesStepEnvelope extends BaseEnvelope {
     type: "chat.step";


### PR DESCRIPTION
## Inline image rendering for bot-produced artifacts in the web chat

**Problem:** When a solver hosts an image artifact (e.g. a rendered map/dashboard snapshot via `host_files`/`emit_solver_artifacts`), Telegram delivers it as a photo but the **web chat UI shows nothing inline** — at best a non-working download chip. Two gaps:

1. **Reference gap.** `emit_solver_artifacts` strips the transport keys (`hosted_uri`, `rn`) from the emitted `chat.files` item. The web client resolves blobs **only** via `POST /api/cb/resources/by-rn` (needs the structured `rn`), so it has no usable handle.
2. **Render gap.** The web client stores `chat.files` items as `file` artifacts that render as download chips only — there is no inline `<img>` path for image-mime artifacts.

**Fix:**
- **Backend** (`solution_workspace.py` → `emit_solver_artifacts`): re-surface the file's `rn` as a new field **`web_resource_rn`**, captured before the transport-key strip. The name is deliberately **outside Telegram's read set** (`_file_item_from_meta`/`_file_delivery_key` never read it), so Telegram delivery/dedup is provably unaffected.
- **Frontend** (`chat-web-app`): `RNFile` gains optional `web_resource_rn`; `resolveResourceRn()` resolves `rn ?? web_resource_rn`; a new `InlineImageItemsPanel` fetches image-mime artifacts via the existing authenticated path (`getResourceByRN → download_url → downloadBlob → URL.createObjectURL`) and renders `<img>`; non-image files still render as download chips.

**Tests:** `test_emit_solver_artifacts_web_rn.py` (backend contract + Telegram-invisibility); `imageArtifact.test.ts` (`resolveResourceRn`). `vite build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
