### PR TITLE
feat(economics): descriptor-driven, live token-economy reference model

### DIFF
--- a/app/ai-app/deployment/economics.yaml
+++ b/app/ai-app/deployment/economics.yaml
@@ -54,3 +54,301 @@ budget_policies:
 # opt-in. provider ∈ {internal, stripe}; stripe requires stripe_price_id.
 plans:
   free: { provider: internal, monthly_price_cents: 0, active: true }
+
+# The token economy's USD<->token unit: the ONE price-table record that anchors
+# reservation / credits / Stripe / balance (and is the platform's default LLM).
+# Runtime-read (mtime-cached), never seeded. provider + service_name must match a
+# price_tables.llm entry (provider + model); otherwise the reference is invalid
+# and the in-code default is used. Absent = in-code default.
+llm_reference_service:
+  provider: anthropic
+  service_name: claude-sonnet-4-5-20250929
+
+# provider/model price table (USD<->token conversion for the whole economy).
+# Runtime-read, never seeded: read live from this file (mtime-cached). Optional —
+# absent = the in-code baseline (DEFAULT_PRICE_TABLE) is used unchanged. When
+# present it REPLACES the baseline whole (either/or, no merge), so list every
+# model/service you rely on. Must carry the llm_reference_service record above, or
+# the block is treated as invalid and the baseline is used. Sections: llm /
+# embedding / web_search. LLM cache read is priced from cache_read_tokens_1M;
+# cache_pricing.{5m,1h} applies to writes only.
+price_tables:
+  llm:
+  - model: claude-sonnet-4-6
+    provider: anthropic
+    aliases:
+    - sonnet
+    - claude-sonnet
+    - sonnet-4.6
+    - sonnet-4-6
+    - claude-sonnet-4.6
+    - claude-sonnet-4-6
+    input_tokens_1M: 3.0
+    output_tokens_1M: 15.0
+    cache_pricing:
+      5m:
+        write_tokens_1M: 3.75
+        read_tokens_1M: 0.3
+      1h:
+        write_tokens_1M: 6.0
+        read_tokens_1M: 0.3
+    cache_write_tokens_1M: 3.75
+    cache_read_tokens_1M: 0.3
+  - model: claude-opus-4-6
+    provider: anthropic
+    aliases:
+    - best
+    - opus
+    - claude-opus
+    - opus-4.6
+    - opus-4-6
+    - claude-opus-4.6
+    - claude-opus-4-6
+    input_tokens_1M: 5.0
+    output_tokens_1M: 25.0
+    cache_pricing:
+      5m:
+        write_tokens_1M: 6.25
+        read_tokens_1M: 0.5
+      1h:
+        write_tokens_1M: 10.0
+        read_tokens_1M: 0.5
+    cache_write_tokens_1M: 6.25
+    cache_read_tokens_1M: 0.5
+  - model: claude-sonnet-4-5-20250929
+    provider: anthropic
+    input_tokens_1M: 3.0
+    output_tokens_1M: 15.0
+    cache_pricing:
+      5m:
+        write_tokens_1M: 3.0
+        read_tokens_1M: 0.3
+      1h:
+        write_tokens_1M: 3.75
+        read_tokens_1M: 0.3
+    cache_write_tokens_1M: 3.0
+    cache_read_tokens_1M: 0.3
+    vision:
+      enabled: true
+      pricing_mode: token_based
+      notes: Images counted as input tokens, ~1600 tokens max per image
+      max_images_per_request: 20
+      max_image_size_mb: 5
+    documents:
+      enabled: true
+      pricing_mode: token_based
+      formats:
+      - pdf
+      notes: PDFs rendered as images, ~10k token limit per page
+      max_document_size_mb: 10
+  - model: claude-haiku-4-5-20251001
+    provider: anthropic
+    aliases:
+    - haiku
+    - claude-haiku
+    - haiku-4.5
+    - haiku-4-5
+    - claude-haiku-4.5
+    - claude-haiku-4-5
+    input_tokens_1M: 1
+    output_tokens_1M: 5
+    cache_pricing:
+      5m:
+        write_tokens_1M: 1
+        read_tokens_1M: 0.1
+      1h:
+        write_tokens_1M: 2
+        read_tokens_1M: 0.1
+    cache_write_tokens_1M: 2
+    cache_read_tokens_1M: 0.1
+  - model: claude-3-5-haiku-20241022
+    provider: anthropic
+    input_tokens_1M: 0.8
+    output_tokens_1M: 4.0
+    cache_pricing:
+      5m:
+        write_tokens_1M: 0.8
+        read_tokens_1M: 0.08
+      1h:
+        write_tokens_1M: 1.0
+        read_tokens_1M: 0.08
+    cache_write_tokens_1M: 0.8
+    cache_read_tokens_1M: 0.08
+  - model: claude-3-haiku-20240307
+    provider: anthropic
+    input_tokens_1M: 0.25
+    output_tokens_1M: 1.25
+    cache_pricing:
+      5m:
+        write_tokens_1M: 0.25
+        read_tokens_1M: 0.03
+      1h:
+        write_tokens_1M: 0.3
+        read_tokens_1M: 0.03
+    cache_write_tokens_1M: 0.25
+    cache_read_tokens_1M: 0.03
+  - model: gpt-4o
+    provider: openai
+    input_tokens_1M: 2.5
+    output_tokens_1M: 10.0
+    cache_write_tokens_1M: 0.0
+    cache_read_tokens_1M: 1.25
+    vision:
+      enabled: true
+      pricing_mode: detail_based
+      detail_low_tokens: 85
+      detail_high_base_tokens: 85
+      detail_high_tile_tokens: 170
+      notes: 'Low detail: 85 tokens, High detail: 85 + (tiles × 170)'
+      max_images_per_request: 50
+    documents:
+      enabled: false
+      notes: Not natively supported, extract text first
+  - model: gpt-4o-mini
+    provider: openai
+    input_tokens_1M: 0.15
+    output_tokens_1M: 0.6
+    cache_write_tokens_1M: 0.0
+    cache_read_tokens_1M: 0.075
+  - model: o1
+    provider: openai
+    input_tokens_1M: 15.0
+    output_tokens_1M: 60.0
+    cache_write_tokens_1M: 0.0
+    cache_read_tokens_1M: 7.5
+  - model: o3-mini
+    provider: openai
+    input_tokens_1M: 1.1
+    output_tokens_1M: 4.4
+    cache_write_tokens_1M: 0.0
+    cache_read_tokens_1M: 0.55
+  - model: gemini-2.5-pro
+    provider: google
+    input_tokens_1M: 1.25
+    output_tokens_1M: 10.0
+    thinking_output_tokens_1M: 10.0
+    cache_write_tokens_1M: 0.0
+    cache_read_tokens_1M: 0.0
+    vision:
+      enabled: true
+      pricing_mode: token_based
+      notes: Images counted as input tokens based on resolution
+      token_calculation: pixels_div_258
+    documents:
+      enabled: true
+      pricing_mode: token_based
+      formats:
+      - pdf
+      - txt
+      - html
+      - csv
+      notes: Documents counted as input tokens
+  - model: gemini-2.5-pro-long
+    provider: google
+    input_tokens_1M: 2.5
+    output_tokens_1M: 15.0
+    thinking_output_tokens_1M: 15.0
+    cache_write_tokens_1M: 0.0
+    cache_read_tokens_1M: 0.0
+  - model: gemini-2.5-flash
+    provider: google
+    input_tokens_1M: 0.15
+    output_tokens_1M: 0.6
+    thinking_output_tokens_1M: 3.5
+    cache_write_tokens_1M: 0.0
+    cache_read_tokens_1M: 0.0
+  - model: gemini-2.5-flash-lite
+    provider: google
+    input_tokens_1M: 0.1
+    output_tokens_1M: 0.4
+    thinking_output_tokens_1M: 0.4
+    cache_write_tokens_1M: 0.0
+    cache_read_tokens_1M: 0.0
+  - model: anthropic/claude-sonnet-4
+    provider: openrouter
+    input_tokens_1M: 3.0
+    output_tokens_1M: 15.0
+  - model: anthropic/claude-3.5-sonnet
+    provider: openrouter
+    input_tokens_1M: 3.0
+    output_tokens_1M: 15.0
+  - model: anthropic/claude-3.5-haiku
+    provider: openrouter
+    input_tokens_1M: 0.8
+    output_tokens_1M: 4.0
+  - model: google/gemini-2.5-pro-preview
+    provider: openrouter
+    input_tokens_1M: 1.25
+    output_tokens_1M: 10.0
+  - model: google/gemini-2.5-flash-preview
+    provider: openrouter
+    input_tokens_1M: 0.15
+    output_tokens_1M: 0.6
+  - model: openai/gpt-4o
+    provider: openrouter
+    input_tokens_1M: 2.5
+    output_tokens_1M: 10.0
+  - model: openai/gpt-4o-mini
+    provider: openrouter
+    input_tokens_1M: 0.15
+    output_tokens_1M: 0.6
+  - model: meta-llama/llama-3.1-405b-instruct
+    provider: openrouter
+    input_tokens_1M: 2.0
+    output_tokens_1M: 2.0
+  - model: meta-llama/llama-3.1-70b-instruct
+    provider: openrouter
+    input_tokens_1M: 0.4
+    output_tokens_1M: 0.4
+  - model: meta-llama/llama-3.1-8b-instruct
+    provider: openrouter
+    input_tokens_1M: 0.05
+    output_tokens_1M: 0.05
+  - model: deepseek/deepseek-r1
+    provider: openrouter
+    input_tokens_1M: 0.55
+    output_tokens_1M: 2.19
+  - model: deepseek/deepseek-chat-v3-0324
+    provider: openrouter
+    input_tokens_1M: 0.27
+    output_tokens_1M: 1.1
+  - model: mistralai/mistral-large
+    provider: openrouter
+    input_tokens_1M: 2.0
+    output_tokens_1M: 6.0
+  - model: qwen/qwen-2.5-72b-instruct
+    provider: openrouter
+    input_tokens_1M: 0.36
+    output_tokens_1M: 0.4
+  embedding:
+  - model: text-embedding-3-small
+    provider: openai
+    tokens_1M: 0.02
+  - model: text-embedding-3-large
+    provider: openai
+    tokens_1M: 0.13
+  web_search:
+  - provider: brave
+    tier: free
+    cost_per_1k_requests: 0.0
+    limits:
+      requests_per_second: 1
+      requests_per_month: 2000
+  - provider: brave
+    tier: base
+    cost_per_1k_requests: 3.0
+    limits:
+      requests_per_second: 20
+      requests_per_month: 20000000
+  - provider: brave
+    tier: pro
+    cost_per_1k_requests: 5.0
+    limits:
+      requests_per_second: 50
+      requests_per_month: null
+  - provider: duckduckgo
+    tier: free
+    cost_per_1k_requests: 0.0
+    limits:
+      requests_per_second: null
+      requests_per_month: null

--- a/app/ai-app/docs/configuration/economics-descriptor-README.md
+++ b/app/ai-app/docs/configuration/economics-descriptor-README.md
@@ -189,7 +189,7 @@ the USD↔token unit (see [Reference model](#reference-model)). `provider` and
 |---|---|
 | optional | absent section/file → the in-code default (`anthropic` / `claude-sonnet-4-5-20250929`) is used |
 | live | read straight from the file (mtime-cached); a change is picked up without a restart |
-| must be priced | the reference must resolve in the effective `price_tables`; its `output_tokens_1M` is the conversion rate |
+| priced or default | if the reference resolves in the effective `price_tables`, its `output_tokens_1M` is the conversion rate; if it does not resolve, the reference is treated as invalid and the in-code default is used |
 
 Runtime consumers:
 - [config_scopes.py](../../src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/config_scopes.py) — `economics_llm_reference_service()`
@@ -245,11 +245,19 @@ falling back to the in-code default `anthropic` / `claude-sonnet-4-5-20250929`.
 Both the economics runtime and bundles read the reference from this single source,
 so a descriptor change re-points the whole economy without code edits.
 
+The reference is a **pricing unit only** — it does not select the models that
+execute a turn. Bundle `role_models` are independent; changing the reference
+re-values the USD↔token unit (reservation, credits, balance, accounting), not
+which model runs.
+
 Consequences:
 
-- the reference model **must** resolve in the effective `price_tables`; a
-  `price_tables` block that omits it is treated as invalid and the baseline is
-  used instead;
+- the reference model must resolve in the effective `price_tables`. This is a
+  two-way guard: a `price_tables` block that omits the reference is treated as
+  invalid and the baseline is used instead; and an `llm_reference_service` that
+  does not resolve in the effective table is treated as invalid and the in-code
+  default reference is used — a malformed / partially-updated descriptor degrades
+  gracefully instead of raising;
 - the rate is the reference entry's `output_tokens_1M`. The reference is matched
   by the `model` field, so a duplicate/mislabeled `model` key can shadow the
   intended entry and silently mis-price the whole economy — keep `model` keys

--- a/app/ai-app/docs/configuration/economics-descriptor-README.md
+++ b/app/ai-app/docs/configuration/economics-descriptor-README.md
@@ -1,0 +1,335 @@
+---
+id: repo:kdcube-ai-app/app/ai-app/docs/configuration/economics-descriptor-README.md
+title: "Economics Descriptor"
+summary: "Per tenant/project economics configuration in economics.yaml: reservation floor, project overdraft, quota policies, provider budget policies, the plan catalog, the price table, and the token-economy reference model. Seeded into the economics tables at deploy time and read live for the reservation floor, price table, and reference model."
+tags: ["service", "configuration", "economics", "deployment", "descriptor", "seeding"]
+keywords: ["economics.yaml", "reservation floor", "price tables", "quota policies", "budget policies", "plan catalog", "project overdraft", "reference model", "deploy-time seeding", "runtime write-back"]
+see_also:
+  - repo:kdcube-ai-app/app/ai-app/docs/service/cicd/descriptors-README.md
+  - repo:kdcube-ai-app/app/ai-app/docs/configuration/service-runtime-configuration-mapping-README.md
+  - repo:kdcube-ai-app/app/ai-app/docs/economics/economics-descriptor-README.md
+  - repo:kdcube-ai-app/app/ai-app/docs/economics/economic-README.md
+---
+# Economics Descriptor
+
+`economics.yaml` is the per tenant/project economics descriptor.
+
+It defines:
+
+- the per-surface reservation floor (USD)
+- the project budget overdraft limit
+- per-plan quota policies (RL token/request windows)
+- per-provider spending budget policies
+- the plan catalog (provider, price, active state, subscribe/grant behaviour)
+- the provider/model price table (USD↔token conversion for the whole economy)
+- the token-economy reference model (the USD↔token unit of account)
+
+This descriptor has **two runtime roles**:
+
+- **seeded into the economics tables at deploy time** — quota policies, budget
+  policies, the plan catalog, and the overdraft limit are written to Postgres
+  once; Postgres is then the live authority for those sections;
+- **read live from the file** — the `reservation`, `price_tables`, and
+  `llm_reference_service` sections are never stored in the database; the runtime
+  reads them live from the file (mtime-cached), so an edit is picked up without a
+  restart. An admin mutation triggers a descriptor write-back that regenerates the
+  seeded sections from the DB and preserves these live sections verbatim.
+
+It does not provide values through `get_settings()`; the two live sections are
+read through dedicated helpers in
+[config_scopes.py](../../src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/config_scopes.py),
+and the seeded sections are read from the economics tables each turn.
+
+The descriptor is **per tenant/project**. Tenant and project are not declared in
+the file — they are resolved from settings (`TENANT_ID` / `PROJECT_ID`).
+
+For the economics semantics behind these sections (funding split, plan
+resolution, reservation model), see the economics docs:
+
+- [economics-descriptor-README.md](../economics/economics-descriptor-README.md)
+- [economic-README.md](../economics/economic-README.md)
+
+## Direct runtime contract
+
+### Supported access path
+
+| Need | Supported mechanism | Notes |
+|---|---|---|
+| explicit descriptor file path | `ECONOMICS_YAML_DESCRIPTOR_PATH` | highest precedence; supports `file://` URIs; used by both the runtime reader and the deploy-time seeder |
+| descriptor directory fallback | `PLATFORM_DESCRIPTORS_DIR/economics.yaml` | used when `ECONOMICS_YAML_DESCRIPTOR_PATH` is unset |
+| default mount path | `/config/economics.yaml` | used when neither of the above is set |
+
+There is no `get_settings()`, `read_plain(...)`, or `get_secret(...)` surface for
+individual `economics.yaml` fields. The seeded sections are reached through the
+economics tables; the live sections through `config_scopes` helpers.
+
+### Loader precedence
+
+The descriptor path is resolved, in order, by both the runtime reader and the
+seeder:
+
+1. `ECONOMICS_YAML_DESCRIPTOR_PATH` (supports `file://`)
+2. `PLATFORM_DESCRIPTORS_DIR/economics.yaml`
+3. `/config/economics.yaml`
+
+A missing file is **not** an error: the seeder still seeds the built-in baseline
+(see [Built-in baseline](#built-in-baseline)), and the runtime falls back to its
+defensive defaults (in-code reservation/price defaults).
+
+## YAML shape
+
+The supported descriptor shape is:
+
+```yaml
+version: 1
+enforce: false
+
+reservation:
+  chat: 2.0
+
+project_budget:
+  overdraft_limit_usd: 0.0
+
+quota_policies:
+  anonymous:  { max_concurrent: 1, requests_per_day: 2,   requests_per_month: 60, ... }
+  free:       { max_concurrent: 2, requests_per_day: 100, requests_per_month: 30000, ... }
+  wallet:     { max_concurrent: 4, requests_per_day: 200, requests_per_month: 6000 }
+  admin:      { max_concurrent: 10 }
+
+budget_policies:
+  anthropic:  { usd_per_hour: 10.0, usd_per_day: 200.0, usd_per_month: 5000.0 }
+  duckduckgo: { usd_per_hour: null, usd_per_day: null,  usd_per_month: null }
+
+plans:
+  free: { provider: internal, monthly_price_cents: 0, active: true }
+  pro:  { provider: stripe, monthly_price_cents: 2000, active: true, stripe_price_id: price_xxx }
+
+price_tables:            # optional; whole-table replacement of the in-code baseline
+  llm:                   # must include the reference model, else the baseline is used
+    - { provider: anthropic, model: claude-sonnet-4-5-20250929, input_tokens_1M: 3.0, output_tokens_1M: 15.0 }
+  embedding: [ ... ]
+  web_search: [ ... ]
+
+llm_reference_service:   # optional; the USD↔token unit of account (defaults to the in-code reference)
+  provider: anthropic
+  service_name: claude-sonnet-4-5-20250929
+```
+
+## What each section does
+
+For each section below: **seeded** means written to Postgres at deploy time
+(Postgres is then the live authority); **runtime-read** means read live from the
+file (mtime-cached) and never stored.
+
+### `version`
+
+Descriptor schema version. Currently `1`.
+
+### `enforce`
+
+Controls how each **seeded** entity is reconciled into the database:
+
+| Value | Behaviour |
+|---|---|
+| `false` | seed only what is missing (`INSERT ... ON CONFLICT DO NOTHING`); existing rows are left untouched |
+| `true` | realign every listed entity to the descriptor values (`INSERT ... ON CONFLICT DO UPDATE SET ...`), including lowering a field back to `null` / unlimited |
+
+`enforce` has no effect on the runtime-read sections (`reservation`,
+`price_tables`, `llm_reference_service`), which are always the file's live value.
+
+### `reservation` (runtime-read)
+
+Per-surface reservation floor defaults, in USD. Only `chat` is consumed by the
+runtime.
+
+| Rule | Effect |
+|---|---|
+| positive number | enables the floor at that USD amount |
+| value `<= 0` | disables the floor (the reservation falls back to a token-based estimate) |
+| surface omitted | no platform default for that surface |
+
+The floor is converted to a token hold using the **reference model** output
+price (see [Reference model](#reference-model)); it is **not** seeded into any
+table. A bundle may override it through `config.economics.reservation.<floor>`;
+the descriptor value is the default when the bundle is silent.
+
+Runtime consumers:
+- [config_scopes.py](../../src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/config_scopes.py) — `economics_reservation_default(floor)`
+- [entrypoint_with_economic.py](../../src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/chatbot/entrypoint_with_economic.py) — effective floor resolution (bundle prop over descriptor default)
+
+### `price_tables` (runtime-read)
+
+Provider/model pricing catalog (`llm`, `embedding`, `web_search`) used for cost
+calculation and USD↔token conversion. Like `reservation`, it is read straight
+from the file and never stored.
+
+| Property | Behaviour |
+|---|---|
+| optional | absent section/file → the in-code baseline `DEFAULT_PRICE_TABLE` is used unchanged |
+| either/or, no merge | when present, it is used as the **whole** table; the baseline is not consulted, so it must list every model/service you rely on |
+| reference-model guard | the `llm` section must carry the reference model; if it does not, the block is treated as **invalid** and the baseline is used in full |
+
+Per-model LLM fields include `input_tokens_1M`, `output_tokens_1M`,
+`cache_read_tokens_1M`, `cache_write_tokens_1M`, and a `cache_pricing.{5m,1h}`
+block. Note: cache **read** is priced from the flat `cache_read_tokens_1M`; the
+`cache_pricing.<ttl>` block is only consulted for cache **writes**
+(`write_tokens_1M`).
+
+Runtime consumers:
+- [config_scopes.py](../../src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/config_scopes.py) — `economics_price_tables()`
+- [usage.py](../../src/kdcube-ai-app/kdcube_ai_app/infra/accounting/usage.py) — `price_table()` selects descriptor-or-baseline
+
+### `llm_reference_service` (runtime-read)
+
+The token-economy reference model: the single model whose output price defines
+the USD↔token unit (see [Reference model](#reference-model)). `provider` and
+`service_name` name the model.
+
+| Property | Behaviour |
+|---|---|
+| optional | absent section/file → the in-code default (`anthropic` / `claude-sonnet-4-5-20250929`) is used |
+| live | read straight from the file (mtime-cached); a change is picked up without a restart |
+| must be priced | the reference must resolve in the effective `price_tables`; its `output_tokens_1M` is the conversion rate |
+
+Runtime consumers:
+- [config_scopes.py](../../src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/config_scopes.py) — `economics_llm_reference_service()`
+- [usage.py](../../src/kdcube-ai-app/kdcube_ai_app/infra/accounting/usage.py) — `llm_reference_service()` / `usd_per_reference_token()`
+
+### `project_budget` (seeded)
+
+Only `overdraft_limit_usd` is seeded (into `tenant_project_budget`):
+
+| Value | Meaning |
+|---|---|
+| number | overdraft ceiling in USD |
+| `null` | unlimited overdraft |
+
+The running **balance is never written** by the descriptor; it is funded
+separately (admin UI / app-budget top-up).
+
+### `quota_policies` (seeded)
+
+`plan_id -> quota policy`. Each policy carries `max_concurrent`,
+`requests_per_day`, `requests_per_month`, `total_requests`, `tokens_per_hour`,
+`tokens_per_day`, `tokens_per_month`. An omitted or `null` dimension means
+unlimited for that window. Seeded into `plan_quota_policies`.
+
+### `budget_policies` (seeded)
+
+`provider -> budget policy`. Spending limits in USD: `usd_per_hour`,
+`usd_per_day`, `usd_per_month`; `null` means unlimited for that window. Seeded
+into `application_budget_policies`. Opt-in — there is no baseline, so only the
+providers listed here are seeded.
+
+### `plans` (seeded)
+
+`plan_id -> catalog entry`: `provider` (`internal` or `stripe`),
+`monthly_price_cents`, `active`, optional `stripe_price_id` (required when
+`provider: stripe`), optional `metadata`. Seeded into the `plans` table.
+
+`quota_policies.<plan_id>` defines the limits for a plan; `plans.<plan_id>`
+defines its catalog entry (price, provider, active state). Most plans are
+subscribable; `wallet` and `anonymous` are built-in non-subscribable plans;
+`admin` is operator-assigned. `anonymous`/`free`/`admin`/`wallet` are seeded
+from the built-in baseline automatically — list a plan here only to override a
+baseline field or to add a chargeable catalog plan.
+
+## Reference model
+
+The whole token economy (reservation, credits, Stripe, balance) is denominated
+in **reference tokens**: USD↔token conversion always uses one reference model's
+output price. The reference is chosen by the `llm_reference_service` section and
+read live via `llm_reference_service()` in
+[usage.py](../../src/kdcube-ai-app/kdcube_ai_app/infra/accounting/usage.py),
+falling back to the in-code default `anthropic` / `claude-sonnet-4-5-20250929`.
+Both the economics runtime and bundles read the reference from this single source,
+so a descriptor change re-points the whole economy without code edits.
+
+Consequences:
+
+- the reference model **must** resolve in the effective `price_tables`; a
+  `price_tables` block that omits it is treated as invalid and the baseline is
+  used instead;
+- the rate is the reference entry's `output_tokens_1M`. The reference is matched
+  by the `model` field, so a duplicate/mislabeled `model` key can shadow the
+  intended entry and silently mis-price the whole economy — keep `model` keys
+  unique per provider;
+- changing the reference (or its price) re-values previously-accumulated token
+  balances in USD terms, because the balance is stored in reference tokens and
+  the USD figure is reconstructed at the current reference price. Since the
+  reference is read live, this re-valuation applies immediately across every
+  display and settle.
+
+## Built-in baseline
+
+Some seeded entities are always written from a platform-owned baseline
+([defaults.py](../../src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/economics/defaults.py)),
+even when the descriptor omits them; when the descriptor lists them, its fields
+override the baseline per field.
+
+| Entity | Baseline | Descriptor behaviour |
+|---|---|---|
+| `quota_policies` | `anonymous`, `free`, `wallet`, `admin` | always seeded; descriptor overrides per field; extra plan_ids seeded as-is |
+| `plans` | `anonymous`, `free`, `admin`, `wallet` (internal, `monthly_price_cents: 0`, `active: true`) | always seeded; descriptor overrides per field; extra plan_ids seeded as-is |
+| `budget_policies` | none | opt-in; seeded only for the providers listed |
+
+## Seeding
+
+The seeder
+([economics_seed.py](../../src/kdcube-ai-app/kdcube_ai_app/ops/deployment/economics/economics_seed.py))
+runs in the postgres-setup job after schema provisioning. It is plain
+`psycopg2` raw SQL and is **non-fatal** — a seeding failure logs a warning but
+does not fail the deployment.
+
+It reconciles **per entity** (no global gate); `enforce` decides `DO NOTHING`
+vs `DO UPDATE SET`. It writes `plan_quota_policies`, `application_budget_policies`,
+`plans`, and `tenant_project_budget` (overdraft only). The `reservation` and
+`price_tables` sections are runtime config and are never seeded.
+
+## Runtime write-back
+
+When a project's economics change while it runs (admin mutations), `economics.yaml`
+is rewritten from the live database state
+([descriptor.py](../../src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/economics/descriptor.py)),
+so the next deploy-time seed does not regress the change.
+
+- Rebuilds `quota_policies`, `budget_policies`, `plans`, and
+  `project_budget.overdraft_limit_usd` from the database.
+- **Preserves** the `reservation` and `price_tables` sections verbatim (they are
+  never stored in the DB).
+- Writes atomically (temp file + `os.replace`) under an exclusive `flock`.
+- Best-effort: a write failure logs a warning and never fails the originating
+  admin operation.
+
+## CLI compose descriptor mode
+
+The installer stages `economics.yaml` into the project config directory
+alongside the other descriptors, copying `deployment/economics.yaml` as the
+template when the target does not already exist
+([installer.py](../../src/kdcube-ai-app/kdcube_cli/src/kdcube_cli/installer.py)).
+Service env files point runtime and the postgres-setup job to `/config` via
+`PLATFORM_DESCRIPTORS_DIR`, so the descriptor-source-of-truth path is the staged
+`/config/economics.yaml`.
+
+Because `reservation` and `price_tables` are read straight from that file
+(mtime-cached), editing the staged `/config/economics.yaml` changes the
+reservation floor and the price table live, without a restart, across every proc
+replica sharing the mount. The seeded sections change only on the next deploy-time
+seed or through an admin mutation (which then writes back to the file).
+
+## Direct local service run
+
+For a direct local `proc` or `ingress` run, either:
+
+- set `ECONOMICS_YAML_DESCRIPTOR_PATH=/abs/path/to/economics.yaml`, or
+- set `PLATFORM_DESCRIPTORS_DIR=/abs/path/to/descriptors` (the runtime then reads
+  `economics.yaml` from that directory).
+
+## Inspecting the effective descriptor
+
+- **live reservation / price table** — read straight from the resolved file; a
+  quick check is to confirm the running process sees the intended file:
+  `PLATFORM_DESCRIPTORS_DIR/economics.yaml` (or `ECONOMICS_YAML_DESCRIPTOR_PATH`).
+- **seeded sections** — the live authority is Postgres, not the file. Inspect the
+  `plan_quota_policies`, `application_budget_policies`, `plans`, and
+  `tenant_project_budget` tables, or the economics admin dashboard.

--- a/app/ai-app/docs/configuration/service-runtime-configuration-mapping-README.md
+++ b/app/ai-app/docs/configuration/service-runtime-configuration-mapping-README.md
@@ -33,6 +33,7 @@ The canonical contract tables now live in the per-descriptor pages:
 - [bundles-secrets-descriptor-README.md](bundles-secrets-descriptor-README.md)
 - [secrets-descriptor-README.md](secrets-descriptor-README.md)
 - [gateway-descriptor-README.md](gateway-descriptor-README.md)
+- [economics-descriptor-README.md](economics-descriptor-README.md)
 
 ## Three runtime modes
 
@@ -57,6 +58,12 @@ per-descriptor pages. This section keeps only the cross-descriptor overview.
 | `HOST_BUNDLES_DESCRIPTOR_PATH` | `bundles.yaml` | CLI local compose | Host file mounted into `/config/bundles.yaml`. |
 | `HOST_SECRETS_YAML_DESCRIPTOR_PATH` | `secrets.yaml` | CLI local compose, `secrets-file` only | Host file mounted into `/config/secrets.yaml`. |
 | `HOST_BUNDLES_SECRETS_YAML_DESCRIPTOR_PATH` | `bundles.secrets.yaml` | CLI local compose, `secrets-file` only | Host file mounted into `/config/bundles.secrets.yaml`. |
+| `ECONOMICS_YAML_DESCRIPTOR_PATH` | `economics.yaml` | direct local run | Explicit path for the runtime reader and the deploy-time seeder; supports `file://`. |
+
+`economics.yaml` has no dedicated single-file env var. In CLI local compose it is
+staged into the descriptor directory by the installer and reached through
+`PLATFORM_DESCRIPTORS_DIR/economics.yaml` — see
+[Economics config source](#economics-config-source).
 
 ### Identity, auth, and ports
 
@@ -129,6 +136,43 @@ Gateway runtime policy itself is descriptor-owned by `gateway.yaml`.
 
 There is no separate env-var surface for individual Data Bus publish limits.
 Change them in `gateway.yaml` or through the gateway admin config path.
+
+### Economics config source
+
+`economics.yaml` is descriptor-owned per tenant/project and has two runtime
+roles: some sections are **seeded into the economics tables at deploy time**
+(Postgres is then the live authority); two sections are **read live from the
+file** and never stored. See
+[economics-descriptor-README.md](economics-descriptor-README.md).
+
+| Env var | Descriptor file | Modes | Meaning |
+|---|---|---|---|
+| `ECONOMICS_YAML_DESCRIPTOR_PATH` | `economics.yaml` | direct local run | Explicit path; supports `file://`; consumed by both the runtime reader and the deploy-time seeder |
+| `PLATFORM_DESCRIPTORS_DIR` | `economics.yaml` | CLI local compose, AWS deployment | Descriptor directory fallback; runtime reads `PLATFORM_DESCRIPTORS_DIR/economics.yaml`, default `/config/economics.yaml` |
+
+Path resolution (both reader and seeder): `ECONOMICS_YAML_DESCRIPTOR_PATH` →
+`PLATFORM_DESCRIPTORS_DIR/economics.yaml` → `/config/economics.yaml`.
+
+| Descriptor path | Runtime owner | Purpose |
+|---|---|---|
+| `economics.reservation.<surface>` | live file read (`economics_reservation_default`) | per-surface reservation floor (USD); runtime-read, never seeded |
+| `economics.price_tables` | live file read (`price_table`) | provider/model price table; runtime-read, never seeded; whole-table replacement of the in-code baseline |
+| `economics.quota_policies.<plan_id>` | `plan_quota_policies` table | seeded at deploy; DB is the live authority |
+| `economics.budget_policies.<provider>` | `application_budget_policies` table | seeded at deploy; DB is the live authority |
+| `economics.plans.<plan_id>` | `plans` table | seeded at deploy; DB is the live authority |
+| `economics.project_budget.overdraft_limit_usd` | `tenant_project_budget` table | seeded at deploy (overdraft only; balance never written) |
+
+Notes:
+
+- `economics.yaml` is staged into the descriptor directory by the installer and
+  read through the `PLATFORM_DESCRIPTORS_DIR` (`/config`) directory mount; there
+  is no dedicated single-file env var for it
+- the file must be **writable** at runtime: admin economics mutations write the
+  seeded sections back to `economics.yaml` so the next deploy-time seed does not
+  regress them, while `reservation`/`price_tables` are preserved verbatim
+- editing the staged `/config/economics.yaml` changes the reservation floor and
+  price table live (mtime-cached), without a restart; the seeded sections change
+  only on the next deploy-time seed or via an admin mutation
 
 ### Redis runtime
 
@@ -369,3 +413,4 @@ For deployment-scoped bundle props in cloud:
   - [bundles-secrets-descriptor-README.md](bundles-secrets-descriptor-README.md)
   - [secrets-descriptor-README.md](secrets-descriptor-README.md)
   - [gateway-descriptor-README.md](gateway-descriptor-README.md)
+  - [economics-descriptor-README.md](economics-descriptor-README.md)

--- a/app/ai-app/docs/economics/economic-README.md
+++ b/app/ai-app/docs/economics/economic-README.md
@@ -281,10 +281,15 @@ Key tables:
 ## Accounting and Costing
 
 Accounting events are emitted by service wrappers (LLM calls, web search, etc.).
-Events are aggregated per turn and converted to USD using the reference model.
+Events are aggregated per turn and priced in USD from **each model's own**
+price-table entry — the actual dollar cost is reference-independent. The reference
+model then converts that USD into the token unit (equivalent / billable tokens)
+for quota consumption, credits, and balance.
 
 Reference model conversion is used for:
 
 - Wallet credit conversion (USD → tokens)
 - Token balance display (tokens → USD)
 - Estimation of request cost for reservations
+- Per-turn billable-token equivalent (USD → reference tokens), read live so it
+  stays in the same unit as the reservation and quota

--- a/app/ai-app/docs/economics/economics-descriptor-README.md
+++ b/app/ai-app/docs/economics/economics-descriptor-README.md
@@ -84,6 +84,10 @@ plans:
 price_tables:            # optional; whole-table replacement of the baseline (either/or)
   llm:                   # must include the reference model, else the baseline is used
     - { provider: anthropic, model: claude-sonnet-4-5-20250929, input_tokens_1M: 3.0, output_tokens_1M: 15.0 }
+
+llm_reference_service:   # optional; the USD↔token unit of account
+  provider: anthropic
+  service_name: claude-sonnet-4-5-20250929
 ```
 
 ### `version`
@@ -131,8 +135,25 @@ cost calculation and USD↔token conversion. Like `reservation`, it is a pure
 - **Reference model guard.** The block must carry the reference model
   (`anthropic`/`claude-sonnet-4-5-…`, the currency of the token economy) in its
   `llm` section. If it does not, the block is treated as **invalid** and the
-  baseline is used in full — the economy (reservation/credits/Stripe/balance)
-  can never break on a misconfigured descriptor.
+  baseline is used in full. Symmetrically, an `llm_reference_service` that does
+  not resolve in the effective table is treated as invalid and the in-code default
+  reference is used — the economy (reservation/credits/Stripe/balance) can never
+  break on a misconfigured descriptor.
+
+### `llm_reference_service`
+
+The token-economy reference model — the single model whose `output_tokens_1M`
+defines the USD↔token unit (reservation, credits, Stripe, balance, per-turn
+billable equivalent). Like `price_tables`, a pure **runtime-read** section —
+never seeded, never in the DB.
+
+- **Optional.** Absent section/file → the in-code default
+  (`anthropic`/`claude-sonnet-4-5-…`) is used.
+- **Live.** Read straight from the file (mtime-cached); a change re-points the
+  whole economy without a restart.
+- **Priced or default.** The `provider`/`service_name` must resolve in the
+  effective `price_tables`; if they do not, the reference is invalid and the
+  in-code default is used (see the reference model guard above).
 
 ### `project_budget`
 
@@ -223,14 +244,16 @@ Behaviour:
 
 ## Runtime reads
 
-The **reservation** and **price_tables** sections are read by the runtime from
-the file; quota, budget, and subscription state are read from the economics
-tables each turn.
+The **reservation**, **price_tables**, and **llm_reference_service** sections are
+read by the runtime from the file; quota, budget, and subscription state are read
+from the economics tables each turn.
 
-`config_scopes.economics_reservation_default(floor)` reads `reservation.<floor>`
-and `config_scopes.economics_price_tables()` reads `price_tables`. Both readers
-are cached by file **mtime**, so edits (including write-backs) are picked up
-without a restart, and they propagate to every proc replica over the shared mount.
+`config_scopes.economics_reservation_default(floor)` reads `reservation.<floor>`,
+`config_scopes.economics_price_tables()` reads `price_tables`, and
+`config_scopes.economics_llm_reference_service()` (via `usage.llm_reference_service()`)
+reads `llm_reference_service`. All readers are cached by file **mtime**, so edits
+(including write-backs) are picked up without a restart, and they propagate to
+every proc replica over the shared mount.
 `price_table()` (`infra/accounting/usage.py`) uses the descriptor section in
 full when present and valid, else the in-code baseline (no merge).
 

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/ingress/control_plane/EconomicsDashboard.tsx
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/ingress/control_plane/EconomicsDashboard.tsx
@@ -729,8 +729,6 @@ class EconomicsAPI {
                 body: JSON.stringify({
                     user_id: userId,
                     usd_amount: usdAmount,
-                    ref_provider: 'anthropic',
-                    ref_model: 'claude-sonnet-4-5-20250929',
                     notes
                 })
             }
@@ -3104,7 +3102,7 @@ const EconomicsAdmin: React.FC = () => {
                                                                 </div>
 
                                                                 <div className="pt-3 border-t border-gray-200/70 text-xs text-gray-600">
-                                                                    Reference: {planBalance.lifetime_budget.reference_model || 'anthropic/claude-sonnet-4-5-20250929'}
+                                                                    Reference: {planBalance.lifetime_budget.reference_model || (economicsRef ? `${economicsRef.reference_provider}/${economicsRef.reference_model}` : '')}
                                                                 </div>
                                                             </div>
                                                         </div>
@@ -3437,7 +3435,7 @@ const EconomicsAdmin: React.FC = () => {
                                                     </div>
 
                                                     <div className="pt-2 text-xs text-gray-600">
-                                                        Reference: {quotaBreakdown.subscription_balance.reference_model || 'anthropic/claude-sonnet-4-5-20250929'}
+                                                        Reference: {quotaBreakdown.subscription_balance.reference_model || (economicsRef ? `${economicsRef.reference_provider}/${economicsRef.reference_model}` : '')}
                                                     </div>
                                                 </div>
                                             )}
@@ -3966,7 +3964,7 @@ const EconomicsAdmin: React.FC = () => {
                                                 Check Balance
                                             </Button>
                                             <div className="text-sm text-gray-500 flex items-center">
-                                                Reference model: <span className="ml-1 font-semibold text-gray-800">anthropic/claude-sonnet-4-5-20250929</span>
+                                                Reference model: <span className="ml-1 font-semibold text-gray-800">{economicsRef ? `${economicsRef.reference_provider}/${economicsRef.reference_model}` : '…'}</span>
                                             </div>
                                         </div>
                                     </form>
@@ -4752,7 +4750,7 @@ Shortfall ledger notes:
                                                 <div className="pt-4 border-t border-gray-200/70 space-y-2">
                                                     <div className="text-sm font-semibold text-gray-900">Subscription balance</div>
                                                     <div className="text-xs text-gray-600">
-                                                        Reference: {subscriptionBalance.reference_model || 'anthropic/claude-sonnet-4-5-20250929'}
+                                                        Reference: {subscriptionBalance.reference_model || (economicsRef ? `${economicsRef.reference_provider}/${economicsRef.reference_model}` : '')}
                                                     </div>
                                                     {subscriptionBalance.period_start && subscriptionBalance.period_end && (
                                                         <div className="text-xs text-gray-600">

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/ingress/control_plane/control_plane.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/ingress/control_plane/control_plane.py
@@ -34,8 +34,8 @@ from kdcube_ai_app.infra.accounting.usage import (
     llm_output_price_usd_per_token,
     quote_tokens_for_usd,
     quote_usd_for_tokens,
-    anthropic,
-    sonnet_45,
+    llm_reference_service,
+    usd_per_reference_token,
 )
 
 
@@ -44,8 +44,9 @@ logger = logging.getLogger(__name__)
 # Create router
 router = APIRouter()
 
-REF_PROVIDER = anthropic
-REF_MODEL = sonnet_45
+def _reference_model_label() -> str:
+    p, m = llm_reference_service()
+    return f"{p}/{m}"
 DEFAULT_PLAN_FREE = "free"
 DEFAULT_PLAN_PAYG = "wallet"
 DEFAULT_PLAN_ADMIN = "admin"
@@ -54,22 +55,24 @@ DEFAULT_PLAN_ANON = "anonymous"
 def _tokens_from_usd(usd_amount: Optional[float]) -> Optional[int]:
     if usd_amount is None:
         return None
+    ref_provider, ref_model = llm_reference_service()
     tokens, _ = quote_tokens_for_usd(
         usd_amount=float(usd_amount),
-        ref_provider=REF_PROVIDER,
-        ref_model=REF_MODEL,
+        ref_provider=ref_provider,
+        ref_model=ref_model,
     )
     return int(tokens)
 
 def _usd_from_tokens(tokens: Optional[int]) -> Optional[float]:
     if tokens is None:
         return None
+    ref_provider, ref_model = llm_reference_service()
     return round(
         float(
             quote_usd_for_tokens(
                 tokens=int(tokens),
-                ref_provider=REF_PROVIDER,
-                ref_model=REF_MODEL,
+                ref_provider=ref_provider,
+                ref_model=ref_model,
             )
         ),
         2,
@@ -264,8 +267,8 @@ class AddLifetimeCreditsRequest(BaseModel):
     """
     user_id: str = Field(..., description="User ID")
     usd_amount: float = Field(..., gt=0, description="Amount in USD")
-    ref_provider: str = Field(default="anthropic", description="Reference model provider")
-    ref_model: str = Field(default="claude-sonnet-4-5-20250929", description="Reference model")
+    ref_provider: Optional[str] = Field(default=None, description="Reference model provider; defaults to the live economics descriptor reference")
+    ref_model: Optional[str] = Field(default=None, description="Reference model; defaults to the live economics descriptor reference")
     purchase_id: Optional[str] = Field(None, description="Payment/transaction ID")
     notes: Optional[str] = Field(None, description="Purchase notes")
 
@@ -340,17 +343,51 @@ def _get_control_plane_manager(ctx):
     return mgr
 
 
-async def _sync_economics_descriptor_best_effort(mgr, settings) -> None:
+async def _publish_economics_sync(mgr, settings, *, reservation_overrides=None, reservation_deletes=None) -> None:
+    """
+    Signal proc to write economics.yaml back from live DB state.
+    """
+    try:
+        redis = getattr(mgr, "_redis", None)
+        if redis is None:
+            return
+        import json
+        from kdcube_ai_app.infra import namespaces
+        payload = {}
+        if reservation_overrides:
+            payload["reservation_overrides"] = reservation_overrides
+        if reservation_deletes:
+            payload["reservation_deletes"] = list(reservation_deletes)
+        await redis.publish(
+            namespaces.CONFIG.ECONOMICS.SYNC_CHANNEL.format(tenant=settings.TENANT, project=settings.PROJECT),
+            json.dumps(payload),
+        )
+    except Exception as e:
+        logger.warning(f"[economics.descriptor] sync signal skipped: {e}")
+
+
+async def _sync_economics_descriptor_best_effort(mgr, settings, *, reservation_overrides=None, reservation_deletes=None) -> None:
     """
     Mirror live economics (DB) into economics.yaml after an admin mutation, so a
-    later deploy-time re-seed does not regress runtime changes. Best-effort: the
-    descriptor sync never fails the admin request.
+    later deploy-time re-seed does not regress runtime changes. The local write
+    succeeds where ingress mounts /config writable; a proc sync signal is always
+    published so the write-back also runs where ingress /config is read-only.
+    Best-effort: never fails the admin request.
     """
     try:
         from kdcube_ai_app.apps.chat.sdk.infra.economics.descriptor import sync_economics_descriptor
-        await sync_economics_descriptor(mgr, tenant=settings.TENANT, project=settings.PROJECT)
+        await sync_economics_descriptor(
+            mgr, tenant=settings.TENANT, project=settings.PROJECT,
+            reservation_overrides=reservation_overrides,
+            reservation_deletes=reservation_deletes,
+        )
     except Exception as e:
         logger.warning(f"[economics.descriptor] write-back skipped: {e}")
+    await _publish_economics_sync(
+        mgr, settings,
+        reservation_overrides=reservation_overrides,
+        reservation_deletes=reservation_deletes,
+    )
 
 
 # ============================================================================
@@ -416,7 +453,7 @@ async def grant_trial_bonus(
                 "tokens_per_hour_usd": _usd_from_tokens(plan_override_balance.tokens_per_hour),
                 "tokens_per_day_usd": _usd_from_tokens(plan_override_balance.tokens_per_day),
                 "tokens_per_month_usd": _usd_from_tokens(plan_override_balance.tokens_per_month),
-                "reference_model": f"{REF_PROVIDER}/{REF_MODEL}",
+                "reference_model": _reference_model_label(),
                 "expires_at": plan_override_balance.expires_at.isoformat() if plan_override_balance.expires_at else None,
             }
         }
@@ -488,7 +525,7 @@ async def update_plan_override(
                 "tokens_per_hour_usd": _usd_from_tokens(plan_override_balance.tokens_per_hour),
                 "tokens_per_day_usd": _usd_from_tokens(plan_override_balance.tokens_per_day),
                 "tokens_per_month_usd": _usd_from_tokens(plan_override_balance.tokens_per_month),
-                "reference_model": f"{REF_PROVIDER}/{REF_MODEL}",
+                "reference_model": _reference_model_label(),
                 "expires_at": plan_override_balance.expires_at.isoformat() if plan_override_balance.expires_at else None,
             }
         }
@@ -550,7 +587,7 @@ async def get_user_plan_override_balance(
 
             reserved = max(gross_remaining - available, 0)
 
-            usd_per_token = llm_output_price_usd_per_token(REF_PROVIDER, REF_MODEL)
+            usd_per_token = usd_per_reference_token()
             available_usd = round(available * usd_per_token, 2)
 
             lifetime_payload = {
@@ -563,7 +600,7 @@ async def get_user_plan_override_balance(
                 # last purchase snapshot (credits purchase)
                 "purchase_amount_usd": float(plan_override_balance.last_purchase_amount_usd)
                 if plan_override_balance.last_purchase_amount_usd else None,
-                "reference_model": f"{REF_PROVIDER}/{REF_MODEL}",
+                "reference_model": _reference_model_label(),
             }
 
         return {
@@ -585,7 +622,7 @@ async def get_user_plan_override_balance(
                 # override notes are grant_notes now
                 "notes": plan_override_balance.grant_notes,
                 "is_expired": override_expired,
-                "reference_model": f"{REF_PROVIDER}/{REF_MODEL}",
+                "reference_model": _reference_model_label(),
             } if (override_active or include_expired) else None,
             "lifetime_budget": lifetime_payload,
         }
@@ -649,10 +686,15 @@ async def add_lifetime_credits(
         mgr = _get_control_plane_manager(router)
         settings = get_settings()
 
+        ref_provider = payload.ref_provider
+        ref_model = payload.ref_model
+        if not ref_provider or not ref_model:
+            ref_provider, ref_model = llm_reference_service()
+
         tokens_added, usd_per_token = quote_tokens_for_usd(
             usd_amount=payload.usd_amount,
-            ref_provider=payload.ref_provider,
-            ref_model=payload.ref_model,
+            ref_provider=ref_provider,
+            ref_model=ref_model,
         )
 
         await mgr.add_user_credits_usd(
@@ -660,8 +702,8 @@ async def add_lifetime_credits(
             project=settings.PROJECT,
             user_id=payload.user_id,
             usd_amount=payload.usd_amount,
-            ref_provider=payload.ref_provider,
-            ref_model=payload.ref_model,
+            ref_provider=ref_provider,
+            ref_model=ref_model,
             purchase_id=payload.purchase_id,
             notes=payload.notes,
         )
@@ -682,7 +724,7 @@ async def add_lifetime_credits(
             "tokens_added": tokens_added,
             "new_balance_tokens": balance_tokens,
             "new_balance_usd": balance_usd,
-            "reference_model": f"{payload.ref_provider}/{payload.ref_model}",
+            "reference_model": f"{ref_provider}/{ref_model}",
         }
 
     except Exception as e:
@@ -720,11 +762,7 @@ async def get_lifetime_balance(
             }
 
         # Convert to USD
-        balance_usd = quote_usd_for_tokens(
-            tokens=int(balance_tokens or 0),
-            ref_provider=REF_PROVIDER,
-            ref_model=REF_MODEL,
-        )
+        balance_usd = _usd_from_tokens(int(balance_tokens or 0))
 
         return {
             "user_id": user_id,
@@ -777,7 +815,7 @@ async def get_subscription(user_id: str, session: UserSession = Depends(auth_wit
         subscription_balance["balance_tokens"] = _tokens_from_usd(bal.get("balance_usd"))
         subscription_balance["reserved_tokens"] = _tokens_from_usd(bal.get("reserved_usd"))
         subscription_balance["available_tokens"] = _tokens_from_usd(bal.get("available_usd"))
-        subscription_balance["reference_model"] = f"{REF_PROVIDER}/{REF_MODEL}"
+        subscription_balance["reference_model"] = _reference_model_label()
 
     return {
         "status": "ok",
@@ -1334,7 +1372,7 @@ async def list_quota_policies(
                 "usd_per_hour": _usd_from_tokens(p.tokens_per_hour),
                 "usd_per_day": _usd_from_tokens(p.tokens_per_day),
                 "usd_per_month": _usd_from_tokens(p.tokens_per_month),
-                "reference_model": f"{REF_PROVIDER}/{REF_MODEL}",
+                "reference_model": _reference_model_label(),
                 "notes": p.notes,
             })
 
@@ -1396,7 +1434,7 @@ async def set_quota_policy(
                 "requests_per_day": policy.requests_per_day,
                 "tokens_per_day": policy.tokens_per_day,
                 "tokens_per_day_usd": _usd_from_tokens(policy.tokens_per_day),
-                "reference_model": f"{REF_PROVIDER}/{REF_MODEL}",
+                "reference_model": _reference_model_label(),
             }
         }
     except Exception as e:
@@ -1521,23 +1559,23 @@ async def set_reservation_surface(
     so bundles pick it up live (and a re-seed does not regress it).
     """
     try:
-        from kdcube_ai_app.apps.chat.sdk.infra.economics.descriptor import (
-            sync_economics_descriptor, read_reservation,
-        )
+        from kdcube_ai_app.apps.chat.sdk.infra.economics.descriptor import read_reservation
         mgr = _get_control_plane_manager(router)
         settings = get_settings()
         floor = (payload.floor or "chat").strip() or "chat"
-        ok = await sync_economics_descriptor(
-            mgr, tenant=settings.TENANT, project=settings.PROJECT,
-            reservation_overrides={floor: float(payload.amount)},
+        amount = float(payload.amount)
+        await _sync_economics_descriptor_best_effort(
+            mgr, settings, reservation_overrides={floor: amount},
         )
-        if not ok:
-            raise HTTPException(status_code=500, detail="Failed to write economics descriptor")
         logger.info(
             f"[set_reservation] {settings.TENANT}/{settings.PROJECT} {floor}={payload.amount} "
             f"by {session.username or session.user_id}"
         )
-        return {"status": "ok", "reservation": read_reservation()}
+        # Echo the intended state: proc performs the authoritative file write
+        # asynchronously, so the on-disk value read here may still be catching up.
+        reservation = read_reservation()
+        reservation[floor] = amount
+        return {"status": "ok", "reservation": reservation}
     except HTTPException:
         raise
     except Exception as e:
@@ -1555,25 +1593,23 @@ async def delete_reservation_surface(
     surface then inherits the platform/bundle default (instead of being pinned).
     """
     try:
-        from kdcube_ai_app.apps.chat.sdk.infra.economics.descriptor import (
-            sync_economics_descriptor, read_reservation,
-        )
+        from kdcube_ai_app.apps.chat.sdk.infra.economics.descriptor import read_reservation
         mgr = _get_control_plane_manager(router)
         settings = get_settings()
         floor = (floor or "").strip()
         if not floor:
             raise HTTPException(status_code=400, detail="Reservation floor is required")
-        ok = await sync_economics_descriptor(
-            mgr, tenant=settings.TENANT, project=settings.PROJECT,
-            reservation_deletes=[floor],
+        await _sync_economics_descriptor_best_effort(
+            mgr, settings, reservation_deletes=[floor],
         )
-        if not ok:
-            raise HTTPException(status_code=500, detail="Failed to write economics descriptor")
         logger.info(
             f"[delete_reservation] {settings.TENANT}/{settings.PROJECT} {floor} "
             f"by {session.username or session.user_id}"
         )
-        return {"status": "ok", "reservation": read_reservation()}
+        # Echo the intended state (proc performs the authoritative file write async).
+        reservation = read_reservation()
+        reservation.pop(floor, None)
+        return {"status": "ok", "reservation": reservation}
     except HTTPException:
         raise
     except Exception as e:
@@ -2098,11 +2134,12 @@ async def get_economics_reference(
 ):
     """Return USD/token reference for admin UI conversions."""
     try:
-        usd_per_token = llm_output_price_usd_per_token(REF_PROVIDER, REF_MODEL)
+        reference_provider, reference_model = llm_reference_service()
+        usd_per_token = usd_per_reference_token()
         return {
             "status": "ok",
-            "reference_provider": REF_PROVIDER,
-            "reference_model": REF_MODEL,
+            "reference_provider": reference_provider,
+            "reference_model": reference_model,
             "usd_per_token": float(usd_per_token),
         }
     except Exception as e:

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/ingress/economics/admin.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/ingress/economics/admin.py
@@ -18,7 +18,8 @@ from kdcube_ai_app.apps.chat.sdk.infra.economics.stripe import (
 )
 from kdcube_ai_app.apps.chat.sdk.infra.economics.subscription import PlanChangeNotAllowed
 
-from .stripe_router import router, _get_control_plane_manager, _usd_from_cents, REF_PROVIDER, REF_MODEL
+from .stripe_router import router, _get_control_plane_manager, _usd_from_cents
+from kdcube_ai_app.infra.accounting.usage import llm_reference_service
 from kdcube_ai_app.ops.deployment.sql.db_deployment import project_schema as _project_schema
 
 logger = logging.getLogger(__name__)
@@ -150,12 +151,13 @@ async def refund_wallet(
         raise HTTPException(status_code=503, detail="Dependencies not initialized")
 
     mgr = _get_control_plane_manager(router)
+    ref_provider, ref_model = llm_reference_service()
     svc = StripeEconomicsAdminService(
         pg_pool=pg_pool,
         user_credits_mgr=mgr.user_credits_mgr,
         subscription_mgr=mgr.subscription_mgr,
-        ref_provider=REF_PROVIDER,
-        ref_model=REF_MODEL,
+        ref_provider=ref_provider,
+        ref_model=ref_model,
     )
 
     try:
@@ -207,12 +209,13 @@ async def cancel_subscription(
                 """, settings.TENANT, settings.PROJECT, payload.user_id)
             return {"status": "ok", "action": "applied", "message": "Internal subscription canceled"}
 
+    ref_provider, ref_model = llm_reference_service()
     svc = StripeEconomicsAdminService(
         pg_pool=pg_pool,
         user_credits_mgr=mgr.user_credits_mgr,
         subscription_mgr=mgr.subscription_mgr,
-        ref_provider=REF_PROVIDER,
-        ref_model=REF_MODEL,
+        ref_provider=ref_provider,
+        ref_model=ref_model,
     )
 
     try:
@@ -244,12 +247,13 @@ async def reconcile_stripe_requests(
         raise HTTPException(status_code=503, detail="Dependencies not initialized")
 
     mgr = _get_control_plane_manager(router)
+    ref_provider, ref_model = llm_reference_service()
     svc = StripeEconomicsAdminService(
         pg_pool=pg_pool,
         user_credits_mgr=mgr.user_credits_mgr,
         subscription_mgr=mgr.subscription_mgr,
-        ref_provider=REF_PROVIDER,
-        ref_model=REF_MODEL,
+        ref_provider=ref_provider,
+        ref_model=ref_model,
     )
 
     try:

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/ingress/economics/me.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/ingress/economics/me.py
@@ -14,7 +14,8 @@ from kdcube_ai_app.apps.chat.sdk.config import get_settings, get_secret
 from kdcube_ai_app.apps.chat.sdk.infra.economics.limiter import GLOBAL_BUNDLE_ID
 from kdcube_ai_app.apps.chat.sdk.infra.economics.stripe import StripeEconomicsAdminService
 
-from .stripe_router import router, _get_stripe, _get_control_plane_manager, REF_PROVIDER, REF_MODEL
+from .stripe_router import router, _get_stripe, _get_control_plane_manager
+from kdcube_ai_app.infra.accounting.usage import llm_reference_service
 
 logger = logging.getLogger(__name__)
 
@@ -161,12 +162,13 @@ async def cancel_my_subscription(
             """, settings.TENANT, settings.PROJECT, user_id)
         return {"status": "ok", "action": "applied", "message": "Subscription canceled"}
 
+    ref_provider, ref_model = llm_reference_service()
     svc = StripeEconomicsAdminService(
         pg_pool=pg_pool,
         user_credits_mgr=mgr.user_credits_mgr,
         subscription_mgr=mgr.subscription_mgr,
-        ref_provider=REF_PROVIDER,
-        ref_model=REF_MODEL,
+        ref_provider=ref_provider,
+        ref_model=ref_model,
     )
     try:
         res = await svc.request_subscription_cancel(

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/ingress/economics/routines.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/ingress/economics/routines.py
@@ -108,9 +108,8 @@ async def run_stripe_reconcile_sweep_once(*, actor: str = "scheduler") -> dict:
         last_ts = int(time.time()) - 24 * 3600
 
     try:
-        from kdcube_ai_app.infra.accounting.usage import anthropic, sonnet_45
-        REF_PROVIDER = anthropic
-        REF_MODEL = sonnet_45
+        from kdcube_ai_app.infra.accounting.usage import llm_reference_service
+        REF_PROVIDER, REF_MODEL = llm_reference_service()
 
         subscription_mgr = SubscriptionManager(pg_pool=pg_pool)
         user_credits_mgr = UserCreditsManager(pg_pool=pg_pool)

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/ingress/economics/stripe_router.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/ingress/economics/stripe_router.py
@@ -12,7 +12,6 @@ from fastapi import HTTPException, APIRouter, FastAPI
 import stripe
 
 from kdcube_ai_app.apps.chat.sdk.config import get_settings, get_secret
-from kdcube_ai_app.infra.accounting.usage import anthropic, sonnet_45
 from kdcube_ai_app.ops.deployment.sql.db_deployment import project_schema as _project_schema
 
 logger = logging.getLogger(__name__)
@@ -58,9 +57,6 @@ async def stripe_lifespan(app: FastAPI):
 
 # State holder + lifespan registration
 router = APIRouter(lifespan=stripe_lifespan)
-
-REF_PROVIDER = anthropic
-REF_MODEL = sonnet_45
 
 
 def _usd_from_cents(cents: Optional[int]) -> Optional[float]:

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/processor.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/processor.py
@@ -2486,7 +2486,7 @@ class EnhancedChatRequestProcessor:
             finally:
                 if pubsub:
                     try:
-                        await pubsub.unsubscribe(update_channel, cleanup_channel, props_update_channel, secrets_update_channel)
+                        await pubsub.unsubscribe(update_channel, cleanup_channel, props_update_channel, secrets_update_channel, economics_sync_channel)
                         await pubsub.close()
                     except Exception:
                         pass

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/processor.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/processor.py
@@ -1939,6 +1939,7 @@ class EnhancedChatRequestProcessor:
         cleanup_channel = namespaces.CONFIG.BUNDLES.CLEANUP_CHANNEL.format(tenant=tenant, project=project)
         props_update_channel = namespaces.CONFIG.BUNDLES.PROPS_UPDATE_CHANNEL.format(tenant=tenant, project=project)
         secrets_update_channel = namespaces.CONFIG.BUNDLES.SECRETS_UPDATE_CHANNEL.format(tenant=tenant, project=project)
+        economics_sync_channel = namespaces.CONFIG.ECONOMICS.SYNC_CHANNEL.format(tenant=tenant, project=project)
 
         def _invalidate_config_secret_cache(
                 *,
@@ -2114,10 +2115,11 @@ class EnhancedChatRequestProcessor:
                     cleanup_channel,
                     props_update_channel,
                     secrets_update_channel,
+                    economics_sync_channel,
                 )
                 logger.info(
-                    "Subscribed to bundles channels: "
-                    f"{update_channel}, {cleanup_channel}, {props_update_channel}, {secrets_update_channel}"
+                    "Subscribed to config channels: "
+                    f"{update_channel}, {cleanup_channel}, {props_update_channel}, {secrets_update_channel}, {economics_sync_channel}"
                 )
                 try:
                     await _catch_up_runtime_snapshot("config-listener.subscribe")
@@ -2371,6 +2373,42 @@ class EnhancedChatRequestProcessor:
                             evt.get("updated_by"),
                             evt.get("ts"),
                         )
+                        continue
+
+                    if message.get("channel") in (
+                        economics_sync_channel,
+                        economics_sync_channel.encode(),
+                    ):
+                        # Ingress can mount /config read-only; proc mounts it
+                        # writable, so it performs the economics.yaml write-back
+                        # from live DB state (preserving/applying reservation +
+                        # price_tables) on ingress's behalf.
+                        if not self.pg_pool:
+                            # Without a DB pool the descriptor would rebuild from
+                            # empty reads and clobber the DB-derived sections; skip
+                            # and let a replica that has one handle it.
+                            logger.warning(
+                                "economics.descriptor sync skipped: no pg_pool on this proc (pid=%s)",
+                                os.getpid(),
+                            )
+                            continue
+                        try:
+                            from kdcube_ai_app.apps.chat.sdk.infra.control_plane.manager import ControlPlaneManager
+                            from kdcube_ai_app.apps.chat.sdk.infra.economics.descriptor import sync_economics_descriptor
+                            reservation_overrides = evt.get("reservation_overrides") or None
+                            reservation_deletes = evt.get("reservation_deletes") or None
+                            cp_mgr = ControlPlaneManager(pg_pool=self.pg_pool, redis=self.redis)
+                            ok = await sync_economics_descriptor(
+                                cp_mgr, tenant=tenant, project=project,
+                                reservation_overrides=reservation_overrides,
+                                reservation_deletes=reservation_deletes,
+                            )
+                            logger.info(
+                                "Applied economics.descriptor sync: tenant=%s project=%s pid=%s ok=%s overrides=%s deletes=%s",
+                                tenant, project, os.getpid(), ok, reservation_overrides, reservation_deletes,
+                            )
+                        except Exception:
+                            logger.warning("economics.descriptor sync failed", exc_info=True)
                         continue
 
                     if message.get("channel") in (

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/config_scopes.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/config_scopes.py
@@ -162,6 +162,15 @@ def economics_price_tables() -> dict | None:
     return node if isinstance(node, dict) else None
 
 
+def economics_llm_reference_service() -> dict | None:
+    """`llm_reference_service:` section from economics.yaml — the single
+    provider/service that anchors the token economy's USD<->token unit. Returns
+    the mapping (e.g. {"provider": ..., "service_name": ...}), or None when the
+    section/file is absent. Runtime-read, mtime-cached; never seeded."""
+    node = _load_economics_plain("llm_reference_service")
+    return node if isinstance(node, dict) else None
+
+
 def _load_global_secret_plain(dotted_path: str) -> Any:
     data = _load_plain_yaml(
         _descriptor_path(

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/examples/bundles/versatile@2026-03-31-13-36/entrypoint.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/examples/bundles/versatile@2026-03-31-13-36/entrypoint.py
@@ -1213,15 +1213,17 @@ class VersatileEntrypoint(BaseEntrypointWithEconomics):
     @property
     def configuration(self) -> Dict[str, Any]:
         sonnet_45 = "claude-sonnet-4-5-20250929"
+        from kdcube_ai_app.infra.accounting.usage import llm_reference_service
+        ref_provider, ref_model = llm_reference_service()
         haiku_4 = "claude-haiku-4-5-20251001"
 
         config = dict(super().configuration)
         role_models = dict(config.get("role_models") or {})
         for key, value in {
             "gate.simple": {"provider": "anthropic", "model": haiku_4},
-            "answer.generator.simple": {"provider": "anthropic", "model": sonnet_45},
-            "solver.coordinator.v2": {"provider": "anthropic", "model": sonnet_45},
-            "solver.react.v2.decision.v2.strong": {"provider": "anthropic", "model": sonnet_45},
+            "answer.generator.simple": {"provider": ref_provider, "model": ref_model},
+            "solver.coordinator.v2": {"provider": ref_provider, "model": ref_model},
+            "solver.react.v2.decision.v2.strong": {"provider": ref_provider, "model": ref_model},
             "solver.react.v2.decision.v2.regular": {"provider": "anthropic", "model": haiku_4},
         }.items():
             role_models.setdefault(key, value)

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/examples/bundles/versatile@2026-03-31-13-36/entrypoint.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/examples/bundles/versatile@2026-03-31-13-36/entrypoint.py
@@ -1213,17 +1213,15 @@ class VersatileEntrypoint(BaseEntrypointWithEconomics):
     @property
     def configuration(self) -> Dict[str, Any]:
         sonnet_45 = "claude-sonnet-4-5-20250929"
-        from kdcube_ai_app.infra.accounting.usage import llm_reference_service
-        ref_provider, ref_model = llm_reference_service()
         haiku_4 = "claude-haiku-4-5-20251001"
 
         config = dict(super().configuration)
         role_models = dict(config.get("role_models") or {})
         for key, value in {
             "gate.simple": {"provider": "anthropic", "model": haiku_4},
-            "answer.generator.simple": {"provider": ref_provider, "model": ref_model},
-            "solver.coordinator.v2": {"provider": ref_provider, "model": ref_model},
-            "solver.react.v2.decision.v2.strong": {"provider": ref_provider, "model": ref_model},
+            "answer.generator.simple": {"provider": "anthropic", "model": sonnet_45},
+            "solver.coordinator.v2": {"provider": "anthropic", "model": sonnet_45},
+            "solver.react.v2.decision.v2.strong": {"provider": "anthropic", "model": sonnet_45},
             "solver.react.v2.decision.v2.regular": {"provider": "anthropic", "model": haiku_4},
         }.items():
             role_models.setdefault(key, value)

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/economics/descriptor.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/economics/descriptor.py
@@ -16,10 +16,11 @@ Two distinct purposes:
   - quota / budget / subscription: Postgres is the live runtime authority. The
     descriptor is only a persistence snapshot so the next deploy-time
     `seed_economics` does not regress runtime/admin changes.
-  - reservation / price_tables: the descriptor file IS the live runtime source
-    (read per turn via config_scopes, mtime-cached). These are never stored in the
-    DB, so write-backs preserve them verbatim from the existing file. Writing here
-    lets runtime pick up changes in real time across replicas over the shared mount.
+  - reservation / price_tables / llm_reference_service: the descriptor file IS the
+    live runtime source (read per turn via config_scopes, mtime-cached). These are
+    never stored in the DB, so write-backs preserve them verbatim from the existing
+    file. Writing here lets runtime pick up changes in real time across replicas
+    over the shared mount.
 
 This is best-effort: callers must not fail the admin mutation if the descriptor
 write fails.
@@ -152,6 +153,9 @@ async def build_economics_descriptor(
     price_tables = existing.get("price_tables")
     if isinstance(price_tables, dict):
         payload["price_tables"] = price_tables
+    llm_reference_service = existing.get("llm_reference_service")
+    if isinstance(llm_reference_service, dict):
+        payload["llm_reference_service"] = llm_reference_service
     return payload
 
 

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/economics/enforcement.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/economics/enforcement.py
@@ -303,12 +303,8 @@ class RoleResolver:
 # Engine
 # ----------------------------------------------------------------------------
 def _usd_per_token() -> float:
-    from kdcube_ai_app.infra.accounting.usage import (
-        llm_output_price_usd_per_token,
-        anthropic,
-        sonnet_45,
-    )
-    return float(llm_output_price_usd_per_token(ref_provider=anthropic, ref_model=sonnet_45))
+    from kdcube_ai_app.infra.accounting.usage import usd_per_reference_token
+    return float(usd_per_reference_token())
 
 
 def _estimate_tokens(estimate: EconomicsEstimate, usd_per_token: float) -> int:

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/economics/profile_user_economics.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/economics/profile_user_economics.py
@@ -50,7 +50,7 @@ from kdcube_ai_app.apps.chat.sdk.infra.economics.plan_resolution import (
     resolve_plan_id,
     subscription_is_active,
 )
-from kdcube_ai_app.infra.accounting.usage import llm_output_price_usd_per_token
+from kdcube_ai_app.infra.accounting.usage import llm_output_price_usd_per_token, llm_reference_service
 from kdcube_ai_app.ops.deployment.sql.db_deployment import project_schema as _project_schema
 from kdcube_ai_app.infra.namespaces import REDIS, ns_key
 from kdcube_ai_app.infra.redis.client import get_async_redis_client
@@ -782,6 +782,8 @@ async def _main(args) -> int:
 
         reference_provider = args.reference_provider
         reference_model = args.reference_model
+        if not reference_provider or not reference_model:
+            reference_provider, reference_model = llm_reference_service()
         usd_per_token = float(llm_output_price_usd_per_token(reference_provider, reference_model))
 
         usage_bundle_ids = args.usage_bundle_ids or ["*"]
@@ -990,13 +992,13 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--reference-provider",
-        default="anthropic",
-        help="Reference provider for USD/token conversion.",
+        default=None,
+        help="Reference provider for USD/token conversion. Defaults to the live economics descriptor reference.",
     )
     parser.add_argument(
         "--reference-model",
-        default="claude-sonnet-4-5-20250929",
-        help="Reference model for USD/token conversion.",
+        default=None,
+        help="Reference model for USD/token conversion. Defaults to the live economics descriptor reference.",
     )
     parser.add_argument(
         "--limit",

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/economics/tests/test_enforcement_automation_wiring.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/economics/tests/test_enforcement_automation_wiring.py
@@ -104,7 +104,10 @@ def test_execution_authority_roles_project_budget_bypass_not_user_type():
 
 async def test_automation_subject_does_not_treat_carried_user_type_as_authority():
     ep = _StubEP(pg_pool=None)
-    subj = await ops._automation_econ_subject(ep, target_user="u1", source={"user_type": "privileged"})
+    subj = await ops._automation_econ_subject(
+        ep, target_user="u1",
+        source={"user_type": "privileged", "economics_projection": "platform_user", "platform_user_id": "u1"},
+    )
     assert (subj.tenant, subj.project, subj.user_id) == ("t", "p", "u1")
     assert subj.budget_bypass is None
     assert subj.is_anonymous is False
@@ -117,6 +120,7 @@ async def test_automation_subject_can_use_platform_authority_user():
         target_user="telegram_42",
         source={
             "economics_user_id": "platform-user-1",
+            "platform_user_id": "platform-user-1",
             "platform_roles": ["kdcube:role:super-admin"],
         },
     )
@@ -127,7 +131,10 @@ async def test_automation_subject_can_use_platform_authority_user():
 
 async def test_automation_subject_falls_back_to_registered():
     ep = _StubEP(pg_pool=None)
-    subj = await ops._automation_econ_subject(ep, target_user="u1", source={})
+    subj = await ops._automation_econ_subject(
+        ep, target_user="u1",
+        source={"economics_projection": "platform_user", "platform_user_id": "u1"},
+    )
     assert subj.budget_bypass is None
     assert subj.is_anonymous is False
 
@@ -157,7 +164,10 @@ async def test_verify_economics_preflight_ok(monkeypatch):
 
     monkeypatch.setattr(enf, "economic_preflight", _pf)
     ep = _StubEP(economics=True, reservation=0.5)
-    subj, dec = await ops._automation_verify_economics(ep, target_user="u1", source={"user_type": "paid"})
+    subj, dec = await ops._automation_verify_economics(
+        ep, target_user="u1",
+        source={"user_type": "paid", "economics_projection": "platform_user", "platform_user_id": "u1"},
+    )
     assert subj.budget_bypass is None
     assert subj.is_anonymous is False
     assert dec.funding_source == "project"

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/economics/tests/test_enforcement_memory_search.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/economics/tests/test_enforcement_memory_search.py
@@ -118,7 +118,10 @@ def test_search_reservation_usd_from_config_and_default():
 
 
 def test_search_subject_uses_session_role():
-    subj = M._memory_search_econ_subject(_StubSearchEP(user_type="paid", user_id="u9"))
+    subj = M._memory_search_econ_subject(_StubSearchEP(
+        user_type="paid", user_id="u9",
+        identity_authority={"economics_projection": "platform_user", "platform_user_id": "u9"},
+    ))
     assert (subj.tenant, subj.project, subj.user_id) == ("t", "p", "u9")
     assert subj.budget_bypass is None
     assert subj.is_anonymous is False

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/economics/tests/test_enforcement_memory_wiring.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/economics/tests/test_enforcement_memory_wiring.py
@@ -56,10 +56,25 @@ class _StubMemEP:
         return await M._memory_reconciliation_econ_subject(self, job)
 
 
+def _authority_for_role(role, user_id="u1"):
+    """Projected Connection Hub authority for a carried role. The reconciliation
+    subject resolves is_anonymous/roles/budget_bypass from this envelope (not the
+    legacy user_type field), so the job must carry it."""
+    if str(role or "").lower() == "anonymous":
+        return {}
+    return {
+        "economics_projection": "platform_user",
+        "platform_user_id": user_id,
+        "platform_roles": [role],
+        "economics_budget_bypass": str(role or "").lower() in ("privileged", "admin"),
+    }
+
+
 def _job(role="registered"):
     return {
         "job_id": "memrec_20260604_abc",
         "user_type": role,
+        "identity_authority": _authority_for_role(role),
         "timezone": "Europe/Kyiv",
         "scope": {"tenant": "t", "project": "p", "user_id": "u1", "bundle_id": "b@1"},
     }

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/economics/tests/test_run_economics_characterization.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/economics/tests/test_run_economics_characterization.py
@@ -274,6 +274,20 @@ class _Config:
 # --------------------------------------------------------------------------
 # Entrypoint harness
 # --------------------------------------------------------------------------
+def _authority_for_role(role, user_id="u1"):
+    """Projected Connection Hub authority for a runtime role. Economics resolves
+    is_anonymous/roles/budget_bypass from this envelope, not the legacy user_type
+    field, so the harness must supply it for a non-anonymous subject."""
+    if str(role or "").lower() == "anonymous":
+        return {}
+    return {
+        "economics_projection": "platform_user",
+        "platform_user_id": user_id,
+        "platform_roles": [role],
+        "economics_budget_bypass": str(role or "").lower() in ("privileged", "admin"),
+    }
+
+
 def _make_ep(
     *,
     role: str = "registered",
@@ -310,6 +324,9 @@ def _make_ep(
     ep._turn_id = "turn_char_1"
     ep._app_state = {
         "user": "u1", "tenant": "t", "project": "p", "user_type": role,
+        # Economics authority is projected from identity_authority, not the legacy
+        # user_type field (Connection Hub authority-projection contract).
+        "identity_authority": _authority_for_role(role),
         "conversation_id": "conv1", "session_id": "sess1",
     }
 

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/economics/user_budget.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/economics/user_budget.py
@@ -1154,8 +1154,8 @@ class UserBudgetBreakdownService:
             include_expired_override: bool = True,
             reservations_limit: int = 50,
             bundle_ids: Optional[list[str]] = None,
-            reference_provider: str = "anthropic",
-            reference_model: str = "claude-sonnet-4-5-20250929",
+            reference_provider: Optional[str] = None,
+            reference_model: Optional[str] = None,
     ) -> dict:
         from kdcube_ai_app.apps.chat.sdk.infra.economics.limiter import (
             UserEconomicsRateLimiter,
@@ -1163,10 +1163,17 @@ class UserBudgetBreakdownService:
             _k,
             subject_id_of,
         )
-        from kdcube_ai_app.infra.accounting.usage import llm_output_price_usd_per_token, quote_tokens_for_usd
+        from kdcube_ai_app.infra.accounting.usage import (
+            llm_output_price_usd_per_token,
+            quote_tokens_for_usd,
+            llm_reference_service,
+        )
 
         bundle_ids = bundle_ids or ["*"]
         now = datetime.utcnow().replace(tzinfo=timezone.utc)
+
+        if not reference_provider or not reference_model:
+            reference_provider, reference_model = llm_reference_service()
 
         # -------- plan override snapshots (for display + for effective merge) --------
         plan_full = await self._plan_snapshot.get_user_plan_balance(

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/chatbot/entrypoint.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/chatbot/entrypoint.py
@@ -2101,10 +2101,7 @@ class BaseEntrypoint:
         return [default_html]
 
     def configuration_defaults(self) -> Dict[str, Any]:
-        # Roles that used the reference model read it from the single source
-        # (economics descriptor llm_reference_service, else in-code default).
-        from kdcube_ai_app.infra.accounting.usage import llm_reference_service
-        ref_provider, ref_model = llm_reference_service()
+        sonnet_45 = "claude-sonnet-4-5-20250929"
         sonnet_46 = "claude-sonnet-4-6"
         haiku_3 = "claude-3-5-haiku-20241022"
         haiku_4 = "claude-haiku-4-5-20251001"
@@ -2119,11 +2116,11 @@ class BaseEntrypoint:
 
                 "solver.tool_router": {"provider": "anthropic", "model": haiku_4},
                 "solver.solvability": {"provider": "anthropic", "model": haiku_4},
-                "solver.codegen": {"provider": ref_provider, "model": ref_model},
-                "solver.coordinator": {"provider": ref_provider, "model": ref_model},
-                "solver.unified-planner": {"provider": ref_provider, "model": ref_model},
-                "solver.react.decision": {"provider": ref_provider, "model": ref_model},
-                "solver.react.decision.strong": {"provider": ref_provider, "model": ref_model},
+                "solver.codegen": {"provider": "anthropic", "model": sonnet_45},
+                "solver.coordinator": {"provider": "anthropic", "model": sonnet_45},
+                "solver.unified-planner": {"provider": "anthropic", "model": sonnet_45},
+                "solver.react.decision": {"provider": "anthropic", "model": sonnet_45},
+                "solver.react.decision.strong": {"provider": "anthropic", "model": sonnet_45},
                 "solver.react.decision.regular": {"provider": "anthropic", "model": haiku_4},
                 "solver.react.v2.decision.v2.strong": {"provider": "anthropic", "model": sonnet_46}, # Solver — hard reasoning
                 "solver.react.v2.decision.v2.regular": {"provider": "anthropic", "model": haiku_4},  # Solver — routine steps
@@ -2131,8 +2128,8 @@ class BaseEntrypoint:
                 "context.compaction.summary": {"provider": "anthropic", "model": sonnet_46},
                 "context.compaction.turn_prefix": {"provider": "anthropic", "model": sonnet_46},
 
-                "tool.generator": {"provider": ref_provider, "model": ref_model},
-                "tool.generator.strong": {"provider": ref_provider, "model": ref_model},
+                "tool.generator": {"provider": "anthropic", "model": sonnet_45},
+                "tool.generator.strong": {"provider": "anthropic", "model": sonnet_45},
                 "tool.generator.regular": {"provider": "anthropic", "model": haiku_4},
 
                 "tool.source.reconciler": {"provider": "anthropic", "model": haiku_4},
@@ -2183,8 +2180,8 @@ class BaseEntrypoint:
             f"conversation_id={thread_id};turn_id={turn_id};usage_from={usage_from};"
             f"date_to={date_to};bundle_id={bundle_id};"
         )
-        ref_provider = "anthropic"
-        ref_model = "claude-sonnet-4-5-20250929"
+        from kdcube_ai_app.infra.accounting.usage import llm_reference_service
+        ref_provider, ref_model = llm_reference_service()
 
         result = await calc.calculate_turn_costs(
             tenant_id=tenant,

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/chatbot/entrypoint.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/chatbot/entrypoint.py
@@ -2101,7 +2101,10 @@ class BaseEntrypoint:
         return [default_html]
 
     def configuration_defaults(self) -> Dict[str, Any]:
-        sonnet_45 = "claude-sonnet-4-5-20250929"
+        # Roles that used the reference model read it from the single source
+        # (economics descriptor llm_reference_service, else in-code default).
+        from kdcube_ai_app.infra.accounting.usage import llm_reference_service
+        ref_provider, ref_model = llm_reference_service()
         sonnet_46 = "claude-sonnet-4-6"
         haiku_3 = "claude-3-5-haiku-20241022"
         haiku_4 = "claude-haiku-4-5-20251001"
@@ -2116,11 +2119,11 @@ class BaseEntrypoint:
 
                 "solver.tool_router": {"provider": "anthropic", "model": haiku_4},
                 "solver.solvability": {"provider": "anthropic", "model": haiku_4},
-                "solver.codegen": {"provider": "anthropic", "model": sonnet_45},
-                "solver.coordinator": {"provider": "anthropic", "model": sonnet_45},
-                "solver.unified-planner": {"provider": "anthropic", "model": sonnet_45},
-                "solver.react.decision": {"provider": "anthropic", "model": sonnet_45},
-                "solver.react.decision.strong": {"provider": "anthropic", "model": sonnet_45},
+                "solver.codegen": {"provider": ref_provider, "model": ref_model},
+                "solver.coordinator": {"provider": ref_provider, "model": ref_model},
+                "solver.unified-planner": {"provider": ref_provider, "model": ref_model},
+                "solver.react.decision": {"provider": ref_provider, "model": ref_model},
+                "solver.react.decision.strong": {"provider": ref_provider, "model": ref_model},
                 "solver.react.decision.regular": {"provider": "anthropic", "model": haiku_4},
                 "solver.react.v2.decision.v2.strong": {"provider": "anthropic", "model": sonnet_46}, # Solver — hard reasoning
                 "solver.react.v2.decision.v2.regular": {"provider": "anthropic", "model": haiku_4},  # Solver — routine steps
@@ -2128,8 +2131,8 @@ class BaseEntrypoint:
                 "context.compaction.summary": {"provider": "anthropic", "model": sonnet_46},
                 "context.compaction.turn_prefix": {"provider": "anthropic", "model": sonnet_46},
 
-                "tool.generator": {"provider": "anthropic", "model": sonnet_45},
-                "tool.generator.strong": {"provider": "anthropic", "model": sonnet_45},
+                "tool.generator": {"provider": ref_provider, "model": ref_model},
+                "tool.generator.strong": {"provider": ref_provider, "model": ref_model},
                 "tool.generator.regular": {"provider": "anthropic", "model": haiku_4},
 
                 "tool.source.reconciler": {"provider": "anthropic", "model": haiku_4},

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/chatbot/entrypoint_with_economic.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/chatbot/entrypoint_with_economic.py
@@ -324,7 +324,7 @@ class BaseEntrypointWithEconomics(BaseEntrypoint):
             PlanWalletSettlementInput,
             allocate_plan_wallet_settlement,
         )
-        from kdcube_ai_app.infra.accounting.usage import llm_output_price_usd_per_token, anthropic, sonnet_45
+        from kdcube_ai_app.infra.accounting.usage import usd_per_reference_token
         from kdcube_ai_app.apps.chat.sdk.util import safe_frac, token_count
         from kdcube_ai_app.infra import accounting as acct
 
@@ -686,7 +686,7 @@ class BaseEntrypointWithEconomics(BaseEntrypoint):
             _log("budget.bypass", "Budget bypass enabled from projected authority", user_type=role)
 
         input_text = ""
-        usd_per_token = float(llm_output_price_usd_per_token(ref_provider=anthropic, ref_model=sonnet_45))
+        usd_per_token = float(usd_per_reference_token())
         try:
             input_tokens_est = int(token_count(input_text))
         except Exception:

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/infra/accounting/tests/test_llm_reference_service.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/infra/accounting/tests/test_llm_reference_service.py
@@ -1,0 +1,61 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Elena Viter
+
+"""Reference resolution: a descriptor `llm_reference_service` that does not resolve
+in the effective price table falls back to the in-code default instead of raising
+downstream."""
+
+from __future__ import annotations
+
+import pytest
+
+from kdcube_ai_app.apps.chat.sdk import config_scopes
+from kdcube_ai_app.infra.accounting import usage
+
+
+DEFAULT_REF = (usage.DEFAULT_LLM_REFERENCE_PROVIDER, usage.DEFAULT_LLM_REFERENCE_SERVICE)
+
+
+@pytest.fixture
+def patch_descriptor(monkeypatch):
+    def _apply(reference, price_tables=None):
+        monkeypatch.setattr(config_scopes, "economics_llm_reference_service", lambda: reference)
+        monkeypatch.setattr(config_scopes, "economics_price_tables", lambda: price_tables)
+    return _apply
+
+
+def test_absent_descriptor_reference_uses_default(patch_descriptor):
+    patch_descriptor(None)
+    assert usage.llm_reference_service() == DEFAULT_REF
+
+
+def test_invalid_reference_falls_back_to_default(patch_descriptor):
+    patch_descriptor({"provider": "bogus", "service_name": "missing-model"})
+    assert usage.llm_reference_service() == DEFAULT_REF
+
+
+def test_invalid_reference_does_not_raise_downstream(patch_descriptor):
+    patch_descriptor({"provider": "bogus", "service_name": "missing-model"})
+    # Would raise RuntimeError in _ref_out_price_1m without the fallback.
+    assert usage.usd_per_reference_token() > 0
+
+
+def test_valid_reference_from_baseline_is_used(patch_descriptor):
+    provider, model = DEFAULT_REF
+    patch_descriptor({"provider": provider, "service_name": model})
+    assert usage.llm_reference_service() == (provider, model)
+
+
+def test_valid_reference_from_overlay_is_used(patch_descriptor):
+    overlay = {"llm": [{"provider": "acme", "model": "acme-1", "output_tokens_1M": 20.0}]}
+    patch_descriptor({"provider": "acme", "service_name": "acme-1"}, price_tables=overlay)
+    assert usage.llm_reference_service() == ("acme", "acme-1")
+
+
+def test_reference_absent_from_overlay_but_present_in_baseline_is_used(patch_descriptor):
+    # Overlay does not carry the (default) reference, so the effective table is the
+    # baseline, where the reference does resolve.
+    provider, model = DEFAULT_REF
+    overlay = {"llm": [{"provider": "acme", "model": "acme-1", "output_tokens_1M": 20.0}]}
+    patch_descriptor({"provider": provider, "service_name": model}, price_tables=overlay)
+    assert usage.llm_reference_service() == (provider, model)

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/infra/accounting/usage.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/infra/accounting/usage.py
@@ -427,10 +427,10 @@ DEFAULT_PRICE_TABLE = {
 
 # Reference service — the currency of the token economy (USD<->tokens for
 # reservation, credits, Stripe, balance). Resolved from the economics descriptor
-# `llm_reference_service` section, else the in-code default. It MUST resolve in
-# the effective price table (_ref_out_price_1m raises otherwise); a descriptor
-# price_tables section that omits it is treated as invalid and the baseline is
-# used instead.
+# `llm_reference_service` section, else the in-code default. A descriptor
+# reference absent from the effective price table is treated as invalid and the
+# in-code default is used; a descriptor price_tables section that omits the
+# reference is likewise invalid and the baseline is used instead.
 DEFAULT_LLM_REFERENCE_PROVIDER = anthropic
 DEFAULT_LLM_REFERENCE_SERVICE = sonnet_45
 
@@ -440,12 +440,32 @@ REF_PROVIDER = DEFAULT_LLM_REFERENCE_PROVIDER
 REF_MODEL = DEFAULT_LLM_REFERENCE_SERVICE
 
 
+def _price_table_has_model(table: Dict[str, Any], provider: str, model: str) -> bool:
+    return any(
+        isinstance(e, dict) and e.get("provider") == provider and e.get("model") == model
+        for e in (table.get("llm") or [])
+    )
+
+
+def _reference_resolves(provider: str, service: str) -> bool:
+    """True if `(provider, service)` exists in the effective price table: the
+    descriptor `price_tables` overlay when it carries the model, else the in-code
+    baseline."""
+    try:
+        from kdcube_ai_app.apps.chat.sdk.config_scopes import economics_price_tables
+        overlay = economics_price_tables()
+    except Exception:
+        overlay = None
+    if isinstance(overlay, dict) and overlay and _price_table_has_model(overlay, provider, service):
+        return True
+    return _price_table_has_model(DEFAULT_PRICE_TABLE, provider, service)
+
+
 def llm_reference_service() -> tuple:
-    """`(provider, service_name)` of the token-economy reference, read from the
-    economics descriptor `llm_reference_service` section (mtime-cached), falling
-    back to the in-code default. Single source for the USD<->token unit — both the
-    economics runtime and bundles read from here. Does not consult `price_table()`
-    (which itself selects on this reference), so there is no resolution cycle."""
+    """`(provider, service_name)` of the token-economy reference. Read from the
+    economics descriptor `llm_reference_service` section (mtime-cached), else the
+    in-code default. A descriptor reference absent from the effective price table
+    is treated as invalid and the in-code default is returned."""
     try:
         from kdcube_ai_app.apps.chat.sdk.config_scopes import economics_llm_reference_service
         ref = economics_llm_reference_service()
@@ -455,16 +475,19 @@ def llm_reference_service() -> tuple:
         provider = str(ref.get("provider") or "").strip()
         service = str(ref.get("service_name") or "").strip()
         if provider and service:
-            return provider, service
+            if _reference_resolves(provider, service):
+                return provider, service
+            logger.warning(
+                "[economics] descriptor llm_reference_service %s/%s not found in the "
+                "effective price table; falling back to in-code default %s/%s",
+                provider, service, DEFAULT_LLM_REFERENCE_PROVIDER, DEFAULT_LLM_REFERENCE_SERVICE,
+            )
     return DEFAULT_LLM_REFERENCE_PROVIDER, DEFAULT_LLM_REFERENCE_SERVICE
 
 
 def _has_ref_model(table: Dict[str, Any]) -> bool:
     ref_provider, ref_service = llm_reference_service()
-    return any(
-        isinstance(e, dict) and e.get("provider") == ref_provider and e.get("model") == ref_service
-        for e in (table.get("llm") or [])
-    )
+    return _price_table_has_model(table, ref_provider, ref_service)
 
 
 def _select_price_table(baseline: Dict[str, Any], overlay: Optional[Dict[str, Any]]) -> Dict[str, Any]:

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/infra/accounting/usage.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/infra/accounting/usage.py
@@ -425,17 +425,44 @@ DEFAULT_PRICE_TABLE = {
         ]
     }
 
-# Reference model — the currency of the token economy (USD<->tokens for
-# reservation, credits, Stripe, balance). It MUST resolve in the effective table
-# (_ref_out_price_1m raises otherwise). A descriptor price_tables section that
-# omits it is treated as invalid and the baseline is used instead.
-REF_PROVIDER = anthropic
-REF_MODEL = sonnet_45
+# Reference service — the currency of the token economy (USD<->tokens for
+# reservation, credits, Stripe, balance). Resolved from the economics descriptor
+# `llm_reference_service` section, else the in-code default. It MUST resolve in
+# the effective price table (_ref_out_price_1m raises otherwise); a descriptor
+# price_tables section that omits it is treated as invalid and the baseline is
+# used instead.
+DEFAULT_LLM_REFERENCE_PROVIDER = anthropic
+DEFAULT_LLM_REFERENCE_SERVICE = sonnet_45
+
+# Back-compat aliases for the default reference. Prefer llm_reference_service(),
+# which also honours the descriptor override.
+REF_PROVIDER = DEFAULT_LLM_REFERENCE_PROVIDER
+REF_MODEL = DEFAULT_LLM_REFERENCE_SERVICE
+
+
+def llm_reference_service() -> tuple:
+    """`(provider, service_name)` of the token-economy reference, read from the
+    economics descriptor `llm_reference_service` section (mtime-cached), falling
+    back to the in-code default. Single source for the USD<->token unit — both the
+    economics runtime and bundles read from here. Does not consult `price_table()`
+    (which itself selects on this reference), so there is no resolution cycle."""
+    try:
+        from kdcube_ai_app.apps.chat.sdk.config_scopes import economics_llm_reference_service
+        ref = economics_llm_reference_service()
+    except Exception:
+        ref = None
+    if isinstance(ref, dict):
+        provider = str(ref.get("provider") or "").strip()
+        service = str(ref.get("service_name") or "").strip()
+        if provider and service:
+            return provider, service
+    return DEFAULT_LLM_REFERENCE_PROVIDER, DEFAULT_LLM_REFERENCE_SERVICE
 
 
 def _has_ref_model(table: Dict[str, Any]) -> bool:
+    ref_provider, ref_service = llm_reference_service()
     return any(
-        isinstance(e, dict) and e.get("provider") == REF_PROVIDER and e.get("model") == REF_MODEL
+        isinstance(e, dict) and e.get("provider") == ref_provider and e.get("model") == ref_service
         for e in (table.get("llm") or [])
     )
 
@@ -987,6 +1014,13 @@ def llm_output_price_usd_per_token(ref_provider: str, ref_model: str) -> float:
     """
     out_1m = _ref_out_price_1m(ref_provider, ref_model)  # USD per 1M output tokens
     return float(out_1m) / 1_000_000.0
+
+
+def usd_per_reference_token() -> float:
+    """USD per one reference-service output token, resolving the reference from
+    the descriptor. Zero-arg single-source entry point for the USD<->token unit;
+    equivalent to llm_output_price_usd_per_token(*llm_reference_service())."""
+    return llm_output_price_usd_per_token(*llm_reference_service())
 
 
 def quote_tokens_for_usd(

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/infra/namespaces.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/infra/namespaces.py
@@ -112,3 +112,6 @@ class CONFIG:
         NAMESPACE = "kdcube:config:gateway"
         UPDATE_CHANNEL = "kdcube:config:gateway:update"
         CURRENT_KEY = "current"
+
+    class ECONOMICS:
+        SYNC_CHANNEL = "kdcube:config:economics:sync:{tenant}:{project}"


### PR DESCRIPTION
  Make the reference model — the single model whose output price defines the
  USD<->token unit for the whole economy — descriptor-driven and read live,
  instead of a hardcoded / startup-frozen constant.

  Reference source
  - economics.yaml gains `llm_reference_service` (runtime-read, mtime-cached) and a full `price_tables` section; config_scopes.economics_llm_reference_service() reads it and usage.llm_reference_service() / usd_per_reference_token() resolve it live, falling back to the in-code default. One source for both the economics runtime and bundles.

  Read live everywhere
  - reservation sizing (entrypoint_with_economic), enforcement, scheduler routines, and the chatbot/versatile bundles resolve the reference from the single source;
  - control_plane no longer freezes REF_PROVIDER/REF_MODEL at import — every display/pricing surface, the add-credits write path, and /economics/reference resolve live;
  - user_budget.get_user_budget_breakdown and profile_user_economics default to the live reference (explicit override preserved);
  - EconomicsDashboard shows the live reference and stops sending a hardcoded ref in the add-credits request.

  Descriptor write-back
  - descriptor.py preserves llm_reference_service verbatim (like reservation / price_tables), so an admin mutation no longer drops the section;
  - proc write-back sync channel (namespaces.ECONOMICS.SYNC_CHANNEL, processor listener, control_plane publish). Docs
  - economics-descriptor-README: document llm_reference_service (runtime-read), the live re-valuation semantics, and the unique-model-key gotcha; mapping README refreshed.

  Tests
  - economics enforcement / characterization mocks updated to the authority-projection contract.