### PR TITLE
feat(economics): make wallet USD-native

### DIFF
--- a/app/ai-app/docs/configuration/economics-descriptor-README.md
+++ b/app/ai-app/docs/configuration/economics-descriptor-README.md
@@ -236,10 +236,12 @@ baseline field or to add a chargeable catalog plan.
 
 ## Reference model
 
-The whole token economy (reservation, credits, Stripe, balance) is denominated
-in **reference tokens**: USD↔token conversion always uses one reference model's
-output price. The reference is chosen by the `llm_reference_service` section and
-read live via `llm_reference_service()` in
+The **token-denominated** surfaces — reservation sizing, the per-turn billable-token
+equivalent, and the RL quota — use one reference model's output price for USD↔token
+conversion. The money balances (plan, project, wallet) are stored in **USD** and are
+reference-independent; the reference only sets the token figures displayed for
+credits / Stripe / balance. The reference is chosen by the `llm_reference_service`
+section and read live via `llm_reference_service()` in
 [usage.py](../../src/kdcube-ai-app/kdcube_ai_app/infra/accounting/usage.py),
 falling back to the in-code default `anthropic` / `claude-sonnet-4-5-20250929`.
 Both the economics runtime and bundles read the reference from this single source,
@@ -247,8 +249,8 @@ so a descriptor change re-points the whole economy without code edits.
 
 The reference is a **pricing unit only** — it does not select the models that
 execute a turn. Bundle `role_models` are independent; changing the reference
-re-values the USD↔token unit (reservation, credits, balance, accounting), not
-which model runs.
+re-points the USD↔token unit for reservation sizing and accounting token-equivalents,
+not the stored USD balances and not which model runs.
 
 Consequences:
 
@@ -262,11 +264,11 @@ Consequences:
   by the `model` field, so a duplicate/mislabeled `model` key can shadow the
   intended entry and silently mis-price the whole economy — keep `model` keys
   unique per provider;
-- changing the reference (or its price) re-values previously-accumulated token
-  balances in USD terms, because the balance is stored in reference tokens and
-  the USD figure is reconstructed at the current reference price. Since the
-  reference is read live, this re-valuation applies immediately across every
-  display and settle.
+- money balances do **not** re-value when the reference changes: plan, project,
+  and wallet are all stored in **USD** (cents), so a reference change shifts only
+  their cosmetic token projection, never the stored dollars. The reference change
+  re-points the token-denominated surfaces (reservation sizing, billable-token
+  equivalent, RL quota) live, but the plan/project/wallet dollars are held fixed.
 
 ## Built-in baseline
 

--- a/app/ai-app/docs/economics/eco-admin-README.md
+++ b/app/ai-app/docs/economics/eco-admin-README.md
@@ -235,7 +235,7 @@ Backend: `POST /app-budget/topup`
 
 UI card: **Lifetime Credits**
 
-- Adds token credits based on USD amount and reference model pricing.
+- Adds USD credits (stored in cents); the reference model only sets the displayed token figure.
 
 Backend: `POST /plan-override/add-lifetime-credits`
 

--- a/app/ai-app/docs/economics/economic-README.md
+++ b/app/ai-app/docs/economics/economic-README.md
@@ -79,7 +79,7 @@ Plan is resolved in the entrypoint at request time. The active plan determines b
 Funding sources are money or tokens used to pay for requests:
 
 - Subscription period budget (per‑month balance, USD)
-- Wallet or lifetime credits (USD balance, stored in cents; token figures are display-only)
+- Wallet or lifetime credits (USD balance, stored in cents)
 - Project budget (tenant/project balance, USD)
 
 Role determines which funding sources are allowed, while plan determines rate limits.
@@ -214,7 +214,7 @@ Shortfall notes are tagged `shortfall:wallet_subscription`, `shortfall:wallet_pl
 - Rate limiter token reservation (Redis) for the plan part
 - Subscription reservations in `user_plan_period_reservations`
 - Project budget reservations in `tenant_project_budget_reservations`
-- Wallet reservations in `user_token_reservations`
+- Wallet reservations in `user_credit_reservations`
 
 Reservations are committed or released after execution and accounting. Expired reservations are reaped automatically.
 
@@ -266,7 +266,7 @@ Key tables:
 - `plan_quota_policies` — base policy per plan_id
 - `user_plan_overrides` — temporary plan overrides
 - `user_lifetime_credits` — wallet credits (USD-native)
-- `user_token_reservations` — wallet reservations
+- `user_credit_reservations` — wallet reservations (USD-in-cents holds)
 - `tenant_project_budget` — project money balance
 - `tenant_project_budget_reservations` — project budget holds
 - `tenant_project_budget_ledger` — project budget ledger

--- a/app/ai-app/docs/economics/economic-README.md
+++ b/app/ai-app/docs/economics/economic-README.md
@@ -79,7 +79,7 @@ Plan is resolved in the entrypoint at request time. The active plan determines b
 Funding sources are money or tokens used to pay for requests:
 
 - Subscription period budget (per‑month balance, USD)
-- Wallet or lifetime credits (token bucket, USD‑quoted)
+- Wallet or lifetime credits (USD balance, stored in cents; token figures are display-only)
 - Project budget (tenant/project balance, USD)
 
 Role determines which funding sources are allowed, while plan determines rate limits.
@@ -182,8 +182,9 @@ part; the wallet covers the over‑quota/over‑funds remainder.
   token quota, P the primary funds (subscription period budget for external subscribers,
   project budget for everyone else, including internal subscriptions). The primary money
   hold is placed for `plan_part`.
-- `wallet_part = R − plan_part` — reserved against the wallet (lifetime tokens) when a wallet
-  is present and allowed for the surface.
+- `wallet_part = R − plan_part` — reserved against the wallet whenever a wallet is present
+  (balance > 0). The hold is stored in **USD** (`usd_reserved_cents`, the wallet's USD value of
+  `wallet_part` at the live rate); `wallet_part` tokens are only the split unit.
 - Admit succeeds if, and only if the wallet can cover `wallet_part` and any indivisible
   requests/concurrency gate is satisfied (a wallet lifts that gate). Otherwise the request is
   denied and **no money hold is left behind**.
@@ -264,7 +265,7 @@ Key tables:
 
 - `plan_quota_policies` — base policy per plan_id
 - `user_plan_overrides` — temporary plan overrides
-- `user_lifetime_credits` — wallet credits
+- `user_lifetime_credits` — wallet credits (USD-native)
 - `user_token_reservations` — wallet reservations
 - `tenant_project_budget` — project money balance
 - `tenant_project_budget_reservations` — project budget holds
@@ -283,13 +284,15 @@ Key tables:
 Accounting events are emitted by service wrappers (LLM calls, web search, etc.).
 Events are aggregated per turn and priced in USD from **each model's own**
 price-table entry — the actual dollar cost is reference-independent. The reference
-model then converts that USD into the token unit (equivalent / billable tokens)
-for quota consumption, credits, and balance.
+model then converts that USD into the **token unit** for the token-denominated
+surface (the RL quota).
 
 Reference model conversion is used for:
 
-- Wallet credit conversion (USD → tokens)
-- Token balance display (tokens → USD)
-- Estimation of request cost for reservations
+- Estimation of request cost for reservations (reservation floor USD → tokens)
 - Per-turn billable-token equivalent (USD → reference tokens), read live so it
   stays in the same unit as the reservation and quota
+- Wallet admission split and display projections (available USD ↔ tokens). The
+  wallet **balance and holds are stored in USD** (cents) and do **not** re-value
+  when the reference changes; only the transient split unit and the cosmetic token
+  figure use the live rate. Plan and project budgets are likewise USD.

--- a/app/ai-app/docs/economics/economics-descriptor-README.md
+++ b/app/ai-app/docs/economics/economics-descriptor-README.md
@@ -143,9 +143,11 @@ cost calculation and USD↔token conversion. Like `reservation`, it is a pure
 ### `llm_reference_service`
 
 The token-economy reference model — the single model whose `output_tokens_1M`
-defines the USD↔token unit (reservation, credits, Stripe, balance, per-turn
-billable equivalent). Like `price_tables`, a pure **runtime-read** section —
-never seeded, never in the DB.
+defines the USD↔token unit: reservation sizing, the per-turn billable equivalent,
+and the token figures projected for credits / Stripe / balance. Those balances are
+stored in **USD** (plan, project, and wallet are all USD-native) and do not
+re-value when the reference changes — only their token projection does. Like
+`price_tables`, a pure **runtime-read** section — never seeded, never in the DB.
 
 - **Optional.** Absent section/file → the in-code default
   (`anthropic`/`claude-sonnet-4-5-…`) is used.

--- a/app/ai-app/docs/economics/economics-usage.md
+++ b/app/ai-app/docs/economics/economics-usage.md
@@ -48,10 +48,10 @@ Important: changing namespaces changes the Redis key-space (effectively resets u
 ### A) User plan overrides + credits (PostgreSQL)
 **Tables:**
 - `kdcube_control_plane.user_plan_overrides` — temporary plan overrides (expires).
-- `kdcube_control_plane.user_lifetime_credits` — wallet credits (USD-native: `purchased_cents`/`spent_cents` authoritative; `lifetime_tokens_*` display-only).
+- `kdcube_control_plane.user_lifetime_credits` — wallet credits (USD-native: `purchased_cents`, `spent_cents`).
 
 ### B) User credit reservations (PostgreSQL)
-**Table:** `kdcube_control_plane.user_token_reservations`
+**Table:** `kdcube_control_plane.user_credit_reservations`
 
 This is how we prevent concurrent requests from spending the same user credits twice.
 Reservations are short-lived (TTL) and are either:
@@ -202,7 +202,7 @@ python /app/kdcube_ai_app/apps/chat/sdk/infra/economics/profile_user_economics.p
 Notes:
 - Run it inside the processor container or any environment that has the same economics config, Redis, and PostgreSQL access as the running service.
 - `--rl-bundle-id` should usually remain `__project__` because quota counters are global per tenant/project.
-- The script is diagnostic: money balances are USD-native (cents) and authoritative; token counters are display-only, and USD↔token figures are reference-price projections at the live rate.
+- The script is diagnostic: money balances are USD-native (cents); any token figures it prints are reference-price projections at the live rate.
 
 ---
 
@@ -215,15 +215,15 @@ Charging order:
 2) **Project budget** — money-based, deducted from tenant/project balance
 
 ### 2.1 User lifetime credits (USD budget, cents)
-Module: `UserCreditsManager` (USD-native; `usd_cents` args, `tokens` display-only)
+Module: `UserCreditsManager` (USD-native; `usd_cents` args)
 - Reserve before work (optional but strongly recommended):
-    - `reserve_lifetime_credits(usd_cents=..., tokens=...)`
+    - `reserve_lifetime_credits(usd_cents=...)`
 - Commit after we know the actual USD cost:
-    - `commit_reserved_lifetime_credits(usd_cents=..., tokens=...)`
+    - `commit_reserved_lifetime_credits(usd_cents=...)`
 - Any amount not covered becomes the returned **uncovered cents**.
 
 If you skip reservations, use:
-- `consume_lifetime_credits(usd_cents=..., tokens=...)`  
+- `consume_lifetime_credits(usd_cents=...)`  
   which will NOT steal from other active reservations.
 
 ### 2.2 Project budget (money)
@@ -264,11 +264,11 @@ Use cases:
 
 ### 3.3 User lifetime credits (depleting USD bucket, cents)
 Stored in `user_lifetime_credits` (USD-native):
-- purchased_cents / spent_cents — authoritative
-- lifetime_tokens_purchased / lifetime_tokens_consumed — display-only
+- purchased_cents / spent_cents
+- lifetime_usd_purchased — aggregate lifetime purchase (reporting)
 - available = purchased_cents − spent_cents − active `usd_reserved_cents`
 
-Concurrency-safe via `user_token_reservations` (holds `usd_reserved_cents`).
+Concurrency-safe via `user_credit_reservations` (holds `usd_reserved_cents`).
 
 Use cases:
 - one-time purchases (Stripe payments)

--- a/app/ai-app/docs/economics/economics-usage.md
+++ b/app/ai-app/docs/economics/economics-usage.md
@@ -48,7 +48,7 @@ Important: changing namespaces changes the Redis key-space (effectively resets u
 ### A) User plan overrides + credits (PostgreSQL)
 **Tables:**
 - `kdcube_control_plane.user_plan_overrides` — temporary plan overrides (expires).
-- `kdcube_control_plane.user_lifetime_credits` — wallet credits (lifetime tokens).
+- `kdcube_control_plane.user_lifetime_credits` — wallet credits (USD-native: `purchased_cents`/`spent_cents` authoritative; `lifetime_tokens_*` display-only).
 
 ### B) User credit reservations (PostgreSQL)
 **Table:** `kdcube_control_plane.user_token_reservations`
@@ -202,7 +202,7 @@ python /app/kdcube_ai_app/apps/chat/sdk/infra/economics/profile_user_economics.p
 Notes:
 - Run it inside the processor container or any environment that has the same economics config, Redis, and PostgreSQL access as the running service.
 - `--rl-bundle-id` should usually remain `__project__` because quota counters are global per tenant/project.
-- The script is diagnostic: token counters and balances are authoritative, while some USD/token conversions are reference-price estimates.
+- The script is diagnostic: money balances are USD-native (cents) and authoritative; token counters are display-only, and USD↔token figures are reference-price projections at the live rate.
 
 ---
 
@@ -211,19 +211,19 @@ Notes:
 Charging happens after the model run, when we know the actual tokens spent.
 
 Charging order:
-1) **User lifetime credits** (if any) — token-based, depleting
+1) **User lifetime credits** (if any) — USD-native (cents), depleting
 2) **Project budget** — money-based, deducted from tenant/project balance
 
-### 2.1 User lifetime credits (token budget)
-Module: `UserCreditsManager`
+### 2.1 User lifetime credits (USD budget, cents)
+Module: `UserCreditsManager` (USD-native; `usd_cents` args, `tokens` display-only)
 - Reserve before work (optional but strongly recommended):
-    - `reserve_lifetime_tokens(...)`
-- Commit after we know actual token usage:
-    - `commit_reserved_lifetime_tokens(...)`
-- Any amount not covered becomes `overflow_tokens`.
+    - `reserve_lifetime_credits(usd_cents=..., tokens=...)`
+- Commit after we know the actual USD cost:
+    - `commit_reserved_lifetime_credits(usd_cents=..., tokens=...)`
+- Any amount not covered becomes the returned **uncovered cents**.
 
 If you skip reservations, use:
-- `consume_lifetime_tokens(...)`  
+- `consume_lifetime_credits(usd_cents=..., tokens=...)`  
   which will NOT steal from other active reservations.
 
 ### 2.2 Project budget (money)
@@ -262,12 +262,13 @@ Use cases:
 - compensation
 - admin “grant user more limits for N days”
 
-### 3.3 User lifetime credits (depleting token bucket)
-Stored in `user_lifetime_credits`:
-- lifetime_tokens_purchased
-- lifetime_tokens_consumed
+### 3.3 User lifetime credits (depleting USD bucket, cents)
+Stored in `user_lifetime_credits` (USD-native):
+- purchased_cents / spent_cents — authoritative
+- lifetime_tokens_purchased / lifetime_tokens_consumed — display-only
+- available = purchased_cents − spent_cents − active `usd_reserved_cents`
 
-Concurrency-safe via `user_token_reservations`.
+Concurrency-safe via `user_token_reservations` (holds `usd_reserved_cents`).
 
 Use cases:
 - one-time purchases (Stripe payments)
@@ -298,7 +299,7 @@ Common management operations:
     - `/plan-override/grant-trial`
     - `/plan-override/update` (partial updates)
 
-### 4.3 Add user lifetime credits (token budget)
+### 4.3 Add user lifetime credits (USD budget, cents)
 - Admin endpoint: `/plan-override/add-lifetime-credits`
 - Stripe `payment_intent.succeeded` (credits purchase)
 
@@ -313,5 +314,5 @@ See:
 
 Engineers integrating payment systems should treat:
 - Project budget topups as “revenue credited”
-- User lifetime credits as “prepaid token credits”
+- User lifetime credits as “prepaid USD credits” (stored in cents)
 - Tier override as “temporary quota override”

--- a/app/ai-app/docs/economics/operational-README.md
+++ b/app/ai-app/docs/economics/operational-README.md
@@ -25,7 +25,7 @@ Key table groups:
 - Quota policies: `plan_quota_policies`
 - Plan overrides: `user_plan_overrides`
 - Lifetime credits: `user_lifetime_credits`
-- Credit reservations: `user_token_reservations`
+- Credit reservations: `user_credit_reservations`
 - Project budget: `tenant_project_budget`, `tenant_project_budget_reservations`, `tenant_project_budget_ledger`
 - Subscription plans: `plans`
 - Subscriptions: `user_plans`

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/ingress/control_plane/EconomicsDashboard.tsx
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/ingress/control_plane/EconomicsDashboard.tsx
@@ -62,14 +62,11 @@ interface PlanOverride {
 }
 
 interface LifetimeBudget {
-    tokens_purchased: number;
-    tokens_consumed: number;
-    tokens_gross_remaining: number;
-    tokens_reserved: number;
-    tokens_available: number;
+    purchased_usd: number;
+    spent_usd: number;
+    reserved_usd: number;
     available_usd: number;
     purchase_amount_usd: number | null;
-    reference_model?: string;
 }
 
 interface PlanBalance {
@@ -84,14 +81,7 @@ interface PlanBalance {
 interface LifetimeBalance {
     user_id: string;
     has_purchased_credits: boolean;
-    balance_tokens: number;
     balance_usd: number;
-
-    // Backend returns these (NOT minimum_required_usd)
-    minimum_required_tokens: number;
-    can_use_budget: boolean;
-
-    reference_model?: string;
     message?: string;
 }
 
@@ -128,11 +118,11 @@ interface BudgetAbsorptionRow {
     events: number;
 }
 
-interface TokenReservationView {
+interface CreditReservationView {
     reservation_id: string;
     bundle_id: string | null;
-    tokens_reserved: number;
-    tokens_used: number;
+    reserved_usd: number;
+    spent_usd: number | null;
     status: string;
     expires_at: string | null;
     created_at: string | null;
@@ -142,11 +132,9 @@ interface TokenReservationView {
 
 interface LifetimeCreditsBreakdown {
     has_lifetime_credits: boolean;
-    tokens_purchased: number;
-    tokens_consumed: number;
-    tokens_gross_remaining: number;
-    tokens_reserved: number;
-    tokens_available: number;
+    purchased_usd: number;
+    spent_usd: number;
+    reserved_usd: number;
     available_usd: number;
     lifetime_usd_purchased: number | null;
     last_purchase: {
@@ -154,7 +142,6 @@ interface LifetimeCreditsBreakdown {
         amount_usd: number | null;
         notes: string | null;
     };
-    reference_model: string;
 }
 
 interface QuotaBreakdown {
@@ -249,7 +236,7 @@ interface QuotaBreakdown {
 
     lifetime_credits: LifetimeCreditsBreakdown | null;
     subscription_balance?: SubscriptionBalance | null;
-    active_reservations: TokenReservationView[];
+    active_reservations: CreditReservationView[];
     reference_model?: string;
 }
 
@@ -2130,8 +2117,8 @@ const EconomicsAdmin: React.FC = () => {
         const uid = lifetimeUserId.trim();
 
         try {
-            const result = await api.addLifetimeCredits(uid, parseFloat(lifetimeUsdAmount), lifetimeNotes);
-            setSuccess(`Added $${lifetimeUsdAmount} (${Number(result.tokens_added).toLocaleString()} tokens) to ${uid}`);
+            await api.addLifetimeCredits(uid, parseFloat(lifetimeUsdAmount), lifetimeNotes);
+            setSuccess(`Added $${lifetimeUsdAmount} to ${uid}`);
 
             setLifetimeUsdAmount('');
             setLifetimeNotes('');
@@ -2604,16 +2591,6 @@ const EconomicsAdmin: React.FC = () => {
         { id: 'plans', label: 'Plans' },
     ];
 
-    const usdPerToken =
-        lifetimeBalance && lifetimeBalance.balance_tokens > 0
-            ? lifetimeBalance.balance_usd / lifetimeBalance.balance_tokens
-            : null;
-
-    const minUsd =
-        usdPerToken && lifetimeBalance
-            ? usdPerToken * Number(lifetimeBalance.minimum_required_tokens || 0)
-            : null;
-
     return (
         <div className="h-screen overflow-hidden bg-white">
             <div className="mx-auto flex h-full max-w-6xl flex-col gap-3 overflow-hidden px-4 py-4">
@@ -3077,32 +3054,28 @@ const EconomicsAdmin: React.FC = () => {
 
                                                             <div className="mt-4 space-y-2 text-sm">
                                                                 <div className="flex justify-between gap-3">
-                                                                    <span className="text-gray-600">Gross remaining</span>
+                                                                    <span className="text-gray-600">Purchased</span>
                                                                     <span className="font-semibold text-gray-900">
-                                    {planBalance.lifetime_budget.tokens_gross_remaining.toLocaleString()}
+                                    ${Number(planBalance.lifetime_budget.purchased_usd || 0).toFixed(2)}
+                                  </span>
+                                                                </div>
+                                                                <div className="flex justify-between gap-3">
+                                                                    <span className="text-gray-600">Spent</span>
+                                                                    <span className="font-semibold text-gray-900">
+                                    ${Number(planBalance.lifetime_budget.spent_usd || 0).toFixed(2)}
                                   </span>
                                                                 </div>
                                                                 <div className="flex justify-between gap-3">
                                                                     <span className="text-gray-600">Reserved (in-flight)</span>
                                                                     <span className="font-semibold text-gray-900">
-                                    {planBalance.lifetime_budget.tokens_reserved.toLocaleString()}
+                                    ${Number(planBalance.lifetime_budget.reserved_usd || 0).toFixed(2)}
                                   </span>
                                                                 </div>
                                                                 <div className="flex justify-between gap-3">
                                                                     <span className="text-gray-600">Available now</span>
                                                                     <span className="font-semibold text-gray-900">
-                                    {planBalance.lifetime_budget.tokens_available.toLocaleString()}
-                                  </span>
-                                                                </div>
-                                                                <div className="flex justify-between gap-3">
-                                                                    <span className="text-gray-600">Available USD (quoted)</span>
-                                                                    <span className="font-semibold text-gray-900">
                                     ${Number(planBalance.lifetime_budget.available_usd || 0).toFixed(2)}
                                   </span>
-                                                                </div>
-
-                                                                <div className="pt-3 border-t border-gray-200/70 text-xs text-gray-600">
-                                                                    Reference: {planBalance.lifetime_budget.reference_model || (economicsRef ? `${economicsRef.reference_provider}/${economicsRef.reference_model}` : '')}
                                                                 </div>
                                                             </div>
                                                         </div>
@@ -3164,7 +3137,7 @@ const EconomicsAdmin: React.FC = () => {
                                                 value={`$${Number(quotaBreakdown.current_usage.tokens_reserved_usd || 0).toFixed(2)}`}
                                                 hint={`${formatCount(quotaBreakdown.current_usage.tokens_reserved || 0)} tokens held`}
                                             />
-                                            <StatCard label="Wallet available" value={quotaBreakdown.lifetime_credits ? `$${Number(quotaBreakdown.lifetime_credits.available_usd || 0).toFixed(2)}` : '$0.00'} hint={quotaBreakdown.lifetime_credits ? `${formatCount(quotaBreakdown.lifetime_credits.tokens_available)} tokens` : 'no wallet record'} />
+                                            <StatCard label="Wallet available" value={quotaBreakdown.lifetime_credits ? `$${Number(quotaBreakdown.lifetime_credits.available_usd || 0).toFixed(2)}` : '$0.00'} hint={quotaBreakdown.lifetime_credits ? 'available' : 'no wallet record'} />
                                         </div>
 
                                         <div className="rounded-xl border border-gray-200/70 bg-gray-50 p-4">
@@ -3302,25 +3275,21 @@ const EconomicsAdmin: React.FC = () => {
                                             {!quotaBreakdown.lifetime_credits ? (
                                                 <div className="mt-3 text-sm text-emerald-900">No wallet record for this user.</div>
                                             ) : (
-                                                <div className="mt-3 grid grid-cols-1 gap-2 md:grid-cols-5">
+                                                <div className="mt-3 grid grid-cols-1 gap-2 md:grid-cols-4">
                                                     <div className="rounded-lg border border-emerald-100 bg-white px-3 py-2 text-sm">
                                                         <div className="text-xs font-semibold uppercase tracking-wide text-emerald-700">Purchased</div>
-                                                        <div className="mt-1 font-semibold text-emerald-950">{formatCount(quotaBreakdown.lifetime_credits.tokens_purchased)}</div>
+                                                        <div className="mt-1 font-semibold text-emerald-950">${Number(quotaBreakdown.lifetime_credits.purchased_usd || 0).toFixed(2)}</div>
                                                     </div>
                                                     <div className="rounded-lg border border-emerald-100 bg-white px-3 py-2 text-sm">
-                                                        <div className="text-xs font-semibold uppercase tracking-wide text-emerald-700">Consumed</div>
-                                                        <div className="mt-1 font-semibold text-emerald-950">{formatCount(quotaBreakdown.lifetime_credits.tokens_consumed)}</div>
+                                                        <div className="text-xs font-semibold uppercase tracking-wide text-emerald-700">Spent</div>
+                                                        <div className="mt-1 font-semibold text-emerald-950">${Number(quotaBreakdown.lifetime_credits.spent_usd || 0).toFixed(2)}</div>
                                                     </div>
                                                     <div className="rounded-lg border border-emerald-100 bg-white px-3 py-2 text-sm">
                                                         <div className="text-xs font-semibold uppercase tracking-wide text-emerald-700">Reserved</div>
-                                                        <div className="mt-1 font-semibold text-emerald-950">{formatCount(quotaBreakdown.lifetime_credits.tokens_reserved)}</div>
+                                                        <div className="mt-1 font-semibold text-emerald-950">${Number(quotaBreakdown.lifetime_credits.reserved_usd || 0).toFixed(2)}</div>
                                                     </div>
                                                     <div className="rounded-lg border border-emerald-100 bg-white px-3 py-2 text-sm">
                                                         <div className="text-xs font-semibold uppercase tracking-wide text-emerald-700">Available</div>
-                                                        <div className="mt-1 font-semibold text-emerald-950">{formatCount(quotaBreakdown.lifetime_credits.tokens_available)}</div>
-                                                    </div>
-                                                    <div className="rounded-lg border border-emerald-100 bg-white px-3 py-2 text-sm">
-                                                        <div className="text-xs font-semibold uppercase tracking-wide text-emerald-700">Available USD</div>
                                                         <div className="mt-1 font-semibold text-emerald-950">${Number(quotaBreakdown.lifetime_credits.available_usd || 0).toFixed(2)}</div>
                                                     </div>
                                                 </div>
@@ -3451,7 +3420,7 @@ const EconomicsAdmin: React.FC = () => {
                                                         <tr className="text-gray-600">
                                                             <th className="px-4 py-3 text-left font-semibold">Reservation</th>
                                                             <th className="px-4 py-3 text-left font-semibold">Bundle</th>
-                                                            <th className="px-4 py-3 text-right font-semibold">Tokens</th>
+                                                            <th className="px-4 py-3 text-right font-semibold">Reserved (USD)</th>
                                                             <th className="px-4 py-3 text-left font-semibold">Expires</th>
                                                             <th className="px-4 py-3 text-left font-semibold">Notes</th>
                                                         </tr>
@@ -3461,7 +3430,7 @@ const EconomicsAdmin: React.FC = () => {
                                                             <tr key={r.reservation_id} className="hover:bg-white/70 transition-colors">
                                                                 <td className="px-4 py-3 font-semibold text-gray-900">{r.reservation_id}</td>
                                                                 <td className="px-4 py-3 text-gray-700">{r.bundle_id ?? '—'}</td>
-                                                                <td className="px-4 py-3 text-right text-gray-700">{Number(r.tokens_reserved || 0).toLocaleString()}</td>
+                                                                <td className="px-4 py-3 text-right text-gray-700">${Number(r.reserved_usd || 0).toFixed(2)}</td>
                                                                 <td className="px-4 py-3 text-gray-700">{r.expires_at ? new Date(r.expires_at).toLocaleString() : '—'}</td>
                                                                 <td className="px-4 py-3 text-gray-600">{r.notes ?? '—'}</td>
                                                             </tr>
@@ -3977,19 +3946,9 @@ const EconomicsAdmin: React.FC = () => {
                                     <CardBody className="space-y-5">
                                         {lifetimeBalance.has_purchased_credits ? (
                                             <>
-                                                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                                                    <StatCard label="Tokens remaining" value={lifetimeBalance.balance_tokens.toLocaleString()} />
-                                                    <StatCard label="USD equivalent (quoted)" value={`$${Number(lifetimeBalance.balance_usd || 0).toFixed(2)}`} />
+                                                <div className="grid grid-cols-1 gap-4">
+                                                    <StatCard label="Balance" value={`$${Number(lifetimeBalance.balance_usd || 0).toFixed(2)}`} />
                                                 </div>
-
-                                                {!lifetimeBalance.can_use_budget && (
-                                                    <Callout tone="warning" title="Below admission threshold">
-                                                        Needs at least{' '}
-                                                        {Number(lifetimeBalance.minimum_required_tokens || 0).toLocaleString()} tokens
-                                                        {minUsd != null ? ` (≈ $${minUsd.toFixed(2)})` : ''}
-                                                        {' '}to cover wallet-funded shortfall.
-                                                    </Callout>
-                                                )}
                                             </>
                                         ) : (
                                             <EmptyState message="No purchased credits found. This user operates on plan quotas only." icon="💳" />
@@ -4397,8 +4356,8 @@ Shortfall ledger notes:
                                                                         <thead className="text-gray-500 uppercase">
                                                                             <tr>
                                                                                 <th className="py-1 pr-3">Reservation</th>
-                                                                                <th className="py-1 pr-3">Tokens reserved</th>
-                                                                                <th className="py-1 pr-3">Tokens used</th>
+                                                                                <th className="py-1 pr-3">Reserved (USD)</th>
+                                                                                <th className="py-1 pr-3">Spent (USD)</th>
                                                                                 <th className="py-1 pr-3">Status</th>
                                                                                 <th className="py-1 pr-3">Created</th>
                                                                             </tr>
@@ -4407,8 +4366,8 @@ Shortfall ledger notes:
                                                                             {lineageResult.wallet.reservations.map((r: any, i: number) => (
                                                                                 <tr key={`wr-${i}`} className="border-t border-gray-200/70">
                                                                                     <td className="py-1 pr-3">{r.reservation_id}</td>
-                                                                                    <td className="py-1 pr-3">{Number(r.tokens_reserved || 0).toLocaleString()}</td>
-                                                                                    <td className="py-1 pr-3">{Number(r.tokens_used || 0).toLocaleString()}</td>
+                                                                                    <td className="py-1 pr-3">${Number(r.reserved_usd || 0).toFixed(2)}</td>
+                                                                                    <td className="py-1 pr-3">{r.spent_usd == null ? '—' : `$${Number(r.spent_usd).toFixed(2)}`}</td>
                                                                                     <td className="py-1 pr-3">{r.status}</td>
                                                                                     <td className="py-1 pr-3">{formatDate(r.created_at)}</td>
                                                                                 </tr>

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/ingress/control_plane/control_plane.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/ingress/control_plane/control_plane.py
@@ -580,15 +580,18 @@ async def get_user_plan_override_balance(
             consumed = int(plan_override_balance.lifetime_tokens_consumed or 0)
             gross_remaining = max(purchased - consumed, 0)
 
-            available = await mgr.user_credits_mgr.get_lifetime_balance(
+            # USD-native: available_usd is authoritative (cents); the token figure is
+            # a cosmetic projection at the live rate.
+            available_cents = await mgr.user_credits_mgr.get_available_cents(
                 tenant=settings.TENANT, project=settings.PROJECT, user_id=user_id
             )
-            available = int(available or 0)
-
-            reserved = max(gross_remaining - available, 0)
+            available_cents = int(available_cents or 0)
+            available_usd = round(available_cents / 100.0, 2)
 
             usd_per_token = usd_per_reference_token()
-            available_usd = round(available * usd_per_token, 2)
+            available = int((available_cents / 100.0) / usd_per_token) if usd_per_token > 0 else 0
+
+            reserved = max(gross_remaining - available, 0)
 
             lifetime_payload = {
                 "tokens_purchased": purchased,
@@ -708,12 +711,13 @@ async def add_lifetime_credits(
             notes=payload.notes,
         )
 
-        # available balance (excludes reservations)
-        balance_tokens = await mgr.user_credits_mgr.get_lifetime_balance(
+        # available balance (excludes reservations) — USD-native (cents authoritative)
+        balance_cents = await mgr.user_credits_mgr.get_available_cents(
             tenant=settings.TENANT, project=settings.PROJECT, user_id=payload.user_id
         )
-        balance_tokens = int(balance_tokens or 0)
-        balance_usd = round(balance_tokens * usd_per_token, 2)
+        balance_cents = int(balance_cents or 0)
+        balance_usd = round(balance_cents / 100.0, 2)
+        balance_tokens = int((balance_cents / 100.0) / usd_per_token) if usd_per_token > 0 else 0
 
         logger.info(f"[add_lifetime_credits] {payload.user_id}: +${payload.usd_amount} by {session.username}")
 
@@ -745,14 +749,14 @@ async def get_lifetime_balance(
         mgr = _get_control_plane_manager(router)
         settings = get_settings()
 
-        # Get lifetime balance from UserCreditsManager
-        balance_tokens = await mgr.user_credits_mgr.get_lifetime_balance(
+        # USD-native balance (cents authoritative); token figure is a live-rate projection.
+        balance_cents = await mgr.user_credits_mgr.get_available_cents(
             tenant=settings.TENANT,
             project=settings.PROJECT,
             user_id=user_id,
         )
 
-        if balance_tokens is None:
+        if balance_cents is None:
             return {
                 "user_id": user_id,
                 "has_purchased_credits": False,
@@ -761,8 +765,10 @@ async def get_lifetime_balance(
                 "message": "User has no purchased credits"
             }
 
-        # Convert to USD
-        balance_usd = _usd_from_tokens(int(balance_tokens or 0))
+        balance_cents = int(balance_cents or 0)
+        balance_usd = balance_cents / 100.0
+        _rate = usd_per_reference_token()
+        balance_tokens = int((balance_cents / 100.0) / _rate) if _rate > 0 else 0
 
         return {
             "user_id": user_id,

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/ingress/control_plane/control_plane.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/ingress/control_plane/control_plane.py
@@ -576,34 +576,22 @@ async def get_user_plan_override_balance(
 
         lifetime_payload = None
         if plan_override_balance.has_lifetime_budget():
-            purchased = int(plan_override_balance.lifetime_tokens_purchased or 0)
-            consumed = int(plan_override_balance.lifetime_tokens_consumed or 0)
-            gross_remaining = max(purchased - consumed, 0)
-
-            # USD-native: available_usd is authoritative (cents); the token figure is
-            # a cosmetic projection at the live rate.
-            available_cents = await mgr.user_credits_mgr.get_available_cents(
+            # Wallet is USD-native (cents). available = purchased - spent - reserved.
+            purchased_cents = int(plan_override_balance.purchased_cents or 0)
+            spent_cents = int(plan_override_balance.spent_cents or 0)
+            reserved_cents = await mgr.user_credits_mgr.get_active_reserved_cents(
                 tenant=settings.TENANT, project=settings.PROJECT, user_id=user_id
             )
-            available_cents = int(available_cents or 0)
-            available_usd = round(available_cents / 100.0, 2)
-
-            usd_per_token = usd_per_reference_token()
-            available = int((available_cents / 100.0) / usd_per_token) if usd_per_token > 0 else 0
-
-            reserved = max(gross_remaining - available, 0)
+            available_cents = purchased_cents - spent_cents - reserved_cents
 
             lifetime_payload = {
-                "tokens_purchased": purchased,
-                "tokens_consumed": consumed,
-                "tokens_gross_remaining": gross_remaining,   # purchased-consumed
-                "tokens_reserved": reserved,                 # in-flight gates
-                "tokens_available": available,               # spendable now
-                "available_usd": available_usd,
+                "purchased_usd": round(purchased_cents / 100.0, 2),
+                "spent_usd": round(spent_cents / 100.0, 2),
+                "reserved_usd": round(reserved_cents / 100.0, 2),
+                "available_usd": round(available_cents / 100.0, 2),
                 # last purchase snapshot (credits purchase)
                 "purchase_amount_usd": float(plan_override_balance.last_purchase_amount_usd)
                 if plan_override_balance.last_purchase_amount_usd else None,
-                "reference_model": _reference_model_label(),
             }
 
         return {
@@ -689,35 +677,20 @@ async def add_lifetime_credits(
         mgr = _get_control_plane_manager(router)
         settings = get_settings()
 
-        ref_provider = payload.ref_provider
-        ref_model = payload.ref_model
-        if not ref_provider or not ref_model:
-            ref_provider, ref_model = llm_reference_service()
-
-        tokens_added, usd_per_token = quote_tokens_for_usd(
-            usd_amount=payload.usd_amount,
-            ref_provider=ref_provider,
-            ref_model=ref_model,
-        )
-
         await mgr.add_user_credits_usd(
             tenant=settings.TENANT,
             project=settings.PROJECT,
             user_id=payload.user_id,
             usd_amount=payload.usd_amount,
-            ref_provider=ref_provider,
-            ref_model=ref_model,
             purchase_id=payload.purchase_id,
             notes=payload.notes,
         )
 
         # available balance (excludes reservations) — USD-native (cents authoritative)
-        balance_cents = await mgr.user_credits_mgr.get_available_cents(
+        balance_cents = int(await mgr.user_credits_mgr.get_available_cents(
             tenant=settings.TENANT, project=settings.PROJECT, user_id=payload.user_id
-        )
-        balance_cents = int(balance_cents or 0)
+        ) or 0)
         balance_usd = round(balance_cents / 100.0, 2)
-        balance_tokens = int((balance_cents / 100.0) / usd_per_token) if usd_per_token > 0 else 0
 
         logger.info(f"[add_lifetime_credits] {payload.user_id}: +${payload.usd_amount} by {session.username}")
 
@@ -725,10 +698,7 @@ async def add_lifetime_credits(
             "success": True,
             "user_id": payload.user_id,
             "usd_amount": payload.usd_amount,
-            "tokens_added": tokens_added,
-            "new_balance_tokens": balance_tokens,
             "new_balance_usd": balance_usd,
-            "reference_model": f"{ref_provider}/{ref_model}",
         }
 
     except Exception as e:
@@ -743,13 +713,12 @@ async def get_lifetime_balance(
         session: UserSession = Depends(auth_without_pressure())
 ):
     """
-    Get user's lifetime purchased balance (tokens + USD equivalent).
+    Get user's lifetime purchased balance (USD).
     """
     try:
         mgr = _get_control_plane_manager(router)
         settings = get_settings()
 
-        # USD-native balance (cents authoritative); token figure is a live-rate projection.
         balance_cents = await mgr.user_credits_mgr.get_available_cents(
             tenant=settings.TENANT,
             project=settings.PROJECT,
@@ -760,23 +729,16 @@ async def get_lifetime_balance(
             return {
                 "user_id": user_id,
                 "has_purchased_credits": False,
-                "balance_tokens": 0,
                 "balance_usd": 0,
                 "message": "User has no purchased credits"
             }
 
-        balance_cents = int(balance_cents or 0)
-        balance_usd = balance_cents / 100.0
-        _rate = usd_per_reference_token()
-        balance_tokens = int((balance_cents / 100.0) / _rate) if _rate > 0 else 0
+        balance_usd = round(int(balance_cents) / 100.0, 2)
 
         return {
             "user_id": user_id,
             "has_purchased_credits": True,
-            "balance_tokens": balance_tokens,
-            "balance_usd": round(balance_usd, 2),
-            "minimum_required_tokens": 50_000,
-            "can_use_budget": balance_tokens >= 50_000,
+            "balance_usd": balance_usd,
         }
 
     except Exception as e:
@@ -2067,9 +2029,9 @@ async def get_request_lineage(
 
         wallet_resv = await conn.fetch(f"""
             SELECT reservation_id, user_id, bundle_id, notes,
-                   tokens_reserved, tokens_used, status,
+                   usd_reserved_cents, actual_spent_cents, status,
                    created_at, expires_at, committed_at, released_at
-            FROM {schema}.user_token_reservations
+            FROM {schema}.user_credit_reservations
             WHERE tenant=$1 AND project=$2 AND reservation_id=$3
             ORDER BY created_at ASC
         """, settings.TENANT, settings.PROJECT, request_id)
@@ -2099,7 +2061,13 @@ async def get_request_lineage(
             ],
         },
         "wallet": {
-            "reservations": [_row_to_dict(r) for r in wallet_resv],
+            "reservations": [
+                {
+                    **_row_to_dict(r),
+                    "reserved_usd": _usd_from_cents(int(r["usd_reserved_cents"] or 0)),
+                    "spent_usd": _usd_from_cents(int(r["actual_spent_cents"] or 0)),
+                } for r in wallet_resv
+            ],
         },
         "notes": [
             "request_id is the turn_id used across ledger and reservation tables.",

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/ingress/economics/UserBillingDashboard.tsx
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/ingress/economics/UserBillingDashboard.tsx
@@ -92,14 +92,11 @@ interface QuotaBreakdown {
     };
     lifetime_credits: {
         has_lifetime_credits: boolean;
-        tokens_purchased: number;
-        tokens_consumed: number;
-        tokens_gross_remaining?: number;
-        tokens_reserved?: number;
-        tokens_available: number;
+        purchased_usd: number;
+        spent_usd: number;
+        reserved_usd: number;
         available_usd: number;
         lifetime_usd_purchased?: number | null;
-        reference_model?: string;
     } | null;
     subscription_balance?: {
         has_subscription?: boolean;
@@ -634,8 +631,7 @@ const UserBillingDashboard: React.FC = () => {
     const currentPlanId = breakdown?.plan_id || subscription?.plan_id || 'free';
     const personalCredits = breakdown?.lifetime_credits;
     const availablePersonalCreditsUsd = personalCredits?.available_usd || 0;
-    const availablePersonalCreditTokens = personalCredits?.tokens_available || 0;
-    const hasPersonalOverflowCover = availablePersonalCreditTokens > 0;
+    const hasPersonalOverflowCover = availablePersonalCreditsUsd > 0;
 
     return (
         <div className="h-screen overflow-hidden bg-gray-50/50 p-3 md:p-4 font-sans text-gray-900">
@@ -783,7 +779,7 @@ const UserBillingDashboard: React.FC = () => {
                                     <div className={`rounded-xl border px-4 py-3 text-sm ${hasPersonalOverflowCover ? 'border-emerald-200 bg-emerald-50 text-emerald-900' : 'border-amber-200 bg-amber-50 text-amber-900'}`}>
                                         <div className="font-semibold">If one request is larger than your remaining plan tokens</div>
                                         <p className="mt-1">
-                                            The part above your remaining plan quota is covered by personal credits. You currently have {formatUsd(availablePersonalCreditsUsd)} ({formatCount(availablePersonalCreditTokens)} tokens) available.
+                                            The part above your remaining plan quota is covered by personal credits. You currently have {formatUsd(availablePersonalCreditsUsd)} available.
                                         </p>
                                         {!hasPersonalOverflowCover && (
                                             <p className="mt-1">
@@ -832,26 +828,23 @@ const UserBillingDashboard: React.FC = () => {
                                 <div className="text-xl font-bold">
                                     ${(breakdown.lifetime_credits?.available_usd || 0).toFixed(2)}
                                 </div>
-                                <div className="mb-4 text-sm text-gray-500">
-                                    {breakdown.lifetime_credits?.tokens_available.toLocaleString() || 0} tokens available
-                                </div>
+                                <div className="mb-4 text-sm text-gray-500">available</div>
                                 <div className="mb-4 grid grid-cols-1 gap-3 sm:grid-cols-4">
                                     <WalletMetric
                                         label="Purchased"
-                                        value={`${formatCount(personalCredits?.tokens_purchased || 0)} tokens`}
+                                        value={formatUsd(personalCredits?.purchased_usd || 0)}
                                     />
                                     <WalletMetric
-                                        label="Consumed"
-                                        value={`${formatCount(personalCredits?.tokens_consumed || 0)} tokens`}
+                                        label="Spent"
+                                        value={formatUsd(personalCredits?.spent_usd || 0)}
                                     />
                                     <WalletMetric
                                         label="Reserved"
-                                        value={`${formatCount(personalCredits?.tokens_reserved || 0)} tokens`}
+                                        value={formatUsd(personalCredits?.reserved_usd || 0)}
                                     />
                                     <WalletMetric
                                         label="Available"
                                         value={formatUsd(personalCredits?.available_usd || 0)}
-                                        hint={`${formatCount(personalCredits?.tokens_available || 0)} tokens`}
                                     />
                                 </div>
                                 

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/control_plane/manager.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/control_plane/manager.py
@@ -262,7 +262,7 @@ class ControlPlaneManager:
     ) -> UserPlanBalance:
         """
         Add purchased credits in USD (converted to lifetime tokens).
-        Uses plan override balance manager's add_lifetime_tokens method.
+        Uses plan override balance manager's add_lifetime_credits method.
         """
 
 
@@ -280,7 +280,7 @@ class ControlPlaneManager:
         )
 
         # Delegate to plan override balance manager
-        await self.user_credits_mgr.add_lifetime_tokens(
+        await self.user_credits_mgr.add_lifetime_credits(
             tenant=tenant,
             project=project,
             user_id=user_id,
@@ -293,7 +293,7 @@ class ControlPlaneManager:
         # Return the canonical flattened snapshot (single SQL)
         bal = await self.get_user_plan_balance(tenant=tenant, project=project, user_id=user_id, include_expired=True)
         if not bal:
-            # extremely unlikely after add_lifetime_tokens succeeds
+            # extremely unlikely after add_lifetime_credits succeeds
             raise RuntimeError("Failed to load plan override balance after adding credits")
         return bal
 

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/control_plane/manager.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/control_plane/manager.py
@@ -255,39 +255,17 @@ class ControlPlaneManager:
             project: str,
             user_id: str,
             usd_amount: float,
-            ref_provider: str = "anthropic",
-            ref_model: str = "claude-sonnet-4-5-20250929",
             purchase_id: Optional[str] = None,
             notes: Optional[str] = None,
     ) -> UserPlanBalance:
-        """
-        Add purchased credits in USD (converted to lifetime tokens).
-        Uses plan override balance manager's add_lifetime_credits method.
-        """
-
-
-        # from kdcube_ai_app.infra.accounting.usage import _find_llm_price
-        #
-        # # Convert USD to tokens
-        # pr = _find_llm_price(ref_provider, ref_model)
-        # p_ref_out = float(pr["output_tokens_1M"]) / 1_000_000
-        # tokens = int(usd_amount / p_ref_out)
-
-        tokens, usd_per_token = quote_tokens_for_usd(
-            usd_amount=usd_amount,
-            ref_provider=ref_provider,
-            ref_model=ref_model,
-        )
-
-        # Delegate to plan override balance manager
+        """Add `usd_amount` of purchased credits via add_lifetime_credits."""
         await self.user_credits_mgr.add_lifetime_credits(
             tenant=tenant,
             project=project,
             user_id=user_id,
-            tokens=tokens,
             usd_amount=usd_amount,
             purchase_id=purchase_id,
-            notes=notes or f"USD purchase: ${usd_amount:.2f} → {tokens:,} tokens",
+            notes=notes or f"USD purchase: ${usd_amount:.2f}",
         )
 
         # Return the canonical flattened snapshot (single SQL)

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/economics/funding_flow.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/economics/funding_flow.py
@@ -250,9 +250,12 @@ async def reserve_funding(
 
     # --- wallet hold for the over-quota/over-funds remainder -------------
     if wallet_part > 0 and has_wallet:
-        ok = await ctx.cp_manager.user_credits_mgr.reserve_lifetime_tokens(
+        # Hold the USD value of the wallet_part at the live rate (USD-native); the
+        # token count is display-only. The margin is already baked into est_turn.
+        wallet_hold_cents = int(round(float(wallet_part) * usd_per_token * 100))
+        ok = await ctx.cp_manager.user_credits_mgr.reserve_lifetime_credits(
             tenant=ctx.tenant, project=ctx.project, user_id=ctx.user_id,
-            reservation_id=ctx.scope_id, tokens=int(wallet_part),
+            reservation_id=ctx.scope_id, usd_cents=wallet_hold_cents, tokens=int(wallet_part),
             ttl_sec=int(ttl_sec), bundle_id=ctx.bundle_id,
             notes=f"split wallet reserve: scope={ctx.scope_id}, wallet_part={wallet_part}",
         )
@@ -397,24 +400,32 @@ async def settle_plan_funding(
     plan_quota_commit_tokens = int(alloc.quota_tokens)
     user_target_tokens = int(alloc.wallet_tokens)
 
-    # --- charge wallet (reserved part first, then reservation-free consume) ---
-    user_uncovered_tokens = 0
-    if user_target_tokens > 0:
-        remaining = int(user_target_tokens)
+    # --- charge wallet in USD (reserved hold first, then reservation-free consume) ---
+    # The allocator decides the split in tokens; the wallet is charged its USD share
+    # of the real cost (reference-independent). commit/consume operate on cents; the
+    # token counts passed are display-only.
+    user_target_usd = _cost_for_tokens(tokens=user_target_tokens, ranked_tokens=ranked_tokens, total_cost=total_cost)
+    user_target_cents = int(round(float(user_target_usd) * 100))
+    user_uncovered_cents = 0
+    if user_target_cents > 0:
+        remaining_cents = int(user_target_cents)
+        reserved_display_tokens = min(int(user_target_tokens), int(res.wallet_reserved_tokens or 0))
         if res.wallet_reservation_active and res.wallet_reservation_id and res.wallet_reserved_tokens > 0:
-            reserved_target = min(remaining, int(res.wallet_reserved_tokens))
             try:
-                reserved_uncovered = await ctx.cp_manager.user_credits_mgr.commit_reserved_lifetime_tokens(
+                reserved_uncovered_cents = await ctx.cp_manager.user_credits_mgr.commit_reserved_lifetime_credits(
                     tenant=ctx.tenant, project=ctx.project, user_id=ctx.user_id,
-                    reservation_id=str(res.wallet_reservation_id), tokens=int(reserved_target),
+                    reservation_id=str(res.wallet_reservation_id),
+                    usd_cents=int(remaining_cents), tokens=int(reserved_display_tokens),
                 )
             finally:
                 res.wallet_reservation_active = False
-            reserved_consumed = max(int(reserved_target) - int(reserved_uncovered or 0), 0)
-            remaining = max(remaining - reserved_consumed, 0)
-        if remaining > 0:
-            user_uncovered_tokens = await ctx.cp_manager.user_credits_mgr.consume_lifetime_tokens(
-                tenant=ctx.tenant, project=ctx.project, user_id=ctx.user_id, tokens=int(remaining),
+            # commit caps its charge at the hold; the remainder falls to reservation-free consume.
+            remaining_cents = int(reserved_uncovered_cents or 0)
+        if remaining_cents > 0:
+            consume_display_tokens = max(int(user_target_tokens) - int(reserved_display_tokens), 0)
+            user_uncovered_cents = await ctx.cp_manager.user_credits_mgr.consume_lifetime_credits(
+                tenant=ctx.tenant, project=ctx.project, user_id=ctx.user_id,
+                usd_cents=int(remaining_cents), tokens=int(consume_display_tokens),
             )
     elif res.wallet_reservation_active and res.wallet_reservation_id:
         try:
@@ -425,8 +436,14 @@ async def settle_plan_funding(
         finally:
             res.wallet_reservation_active = False
 
-    user_uncovered_tokens = int(user_uncovered_tokens or 0)
-    user_uncovered_usd = _cost_for_tokens(tokens=user_uncovered_tokens, ranked_tokens=ranked_tokens, total_cost=total_cost)
+    user_uncovered_cents = int(user_uncovered_cents or 0)
+    user_uncovered_usd = float(user_uncovered_cents) / 100.0
+    # Token-equivalent of the uncovered USD via the turn's ranked/total rate (inverse
+    # of _cost_for_tokens) — used only for the token-native RL quota cascade below.
+    user_uncovered_tokens = (
+        int(round(user_uncovered_usd * ranked_tokens / total_cost))
+        if total_cost > 0 else 0
+    )
 
     # wallet shortfall can re-consume any remaining plan quota room
     if user_uncovered_tokens > 0:

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/economics/funding_flow.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/economics/funding_flow.py
@@ -250,12 +250,12 @@ async def reserve_funding(
 
     # --- wallet hold for the over-quota/over-funds remainder -------------
     if wallet_part > 0 and has_wallet:
-        # Hold the USD value of the wallet_part at the live rate (USD-native); the
-        # token count is display-only. The margin is already baked into est_turn.
+        # Hold the USD value of the wallet_part at the live rate. The margin is
+        # already baked into est_turn.
         wallet_hold_cents = int(round(float(wallet_part) * usd_per_token * 100))
         ok = await ctx.cp_manager.user_credits_mgr.reserve_lifetime_credits(
             tenant=ctx.tenant, project=ctx.project, user_id=ctx.user_id,
-            reservation_id=ctx.scope_id, usd_cents=wallet_hold_cents, tokens=int(wallet_part),
+            reservation_id=ctx.scope_id, usd_cents=wallet_hold_cents,
             ttl_sec=int(ttl_sec), bundle_id=ctx.bundle_id,
             notes=f"split wallet reserve: scope={ctx.scope_id}, wallet_part={wallet_part}",
         )
@@ -402,30 +402,27 @@ async def settle_plan_funding(
 
     # --- charge wallet in USD (reserved hold first, then reservation-free consume) ---
     # The allocator decides the split in tokens; the wallet is charged its USD share
-    # of the real cost (reference-independent). commit/consume operate on cents; the
-    # token counts passed are display-only.
+    # of the real cost (reference-independent). commit/consume operate on cents.
     user_target_usd = _cost_for_tokens(tokens=user_target_tokens, ranked_tokens=ranked_tokens, total_cost=total_cost)
     user_target_cents = int(round(float(user_target_usd) * 100))
     user_uncovered_cents = 0
     if user_target_cents > 0:
         remaining_cents = int(user_target_cents)
-        reserved_display_tokens = min(int(user_target_tokens), int(res.wallet_reserved_tokens or 0))
         if res.wallet_reservation_active and res.wallet_reservation_id and res.wallet_reserved_tokens > 0:
             try:
                 reserved_uncovered_cents = await ctx.cp_manager.user_credits_mgr.commit_reserved_lifetime_credits(
                     tenant=ctx.tenant, project=ctx.project, user_id=ctx.user_id,
                     reservation_id=str(res.wallet_reservation_id),
-                    usd_cents=int(remaining_cents), tokens=int(reserved_display_tokens),
+                    usd_cents=int(remaining_cents),
                 )
             finally:
                 res.wallet_reservation_active = False
             # commit caps its charge at the hold; the remainder falls to reservation-free consume.
             remaining_cents = int(reserved_uncovered_cents or 0)
         if remaining_cents > 0:
-            consume_display_tokens = max(int(user_target_tokens) - int(reserved_display_tokens), 0)
             user_uncovered_cents = await ctx.cp_manager.user_credits_mgr.consume_lifetime_credits(
                 tenant=ctx.tenant, project=ctx.project, user_id=ctx.user_id,
-                usd_cents=int(remaining_cents), tokens=int(consume_display_tokens),
+                usd_cents=int(remaining_cents),
             )
     elif res.wallet_reservation_active and res.wallet_reservation_id:
         try:

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/economics/stripe.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/economics/stripe.py
@@ -803,7 +803,7 @@ class StripeEconomicsWebhookHandler:
 
                 try:
                     # APPLY via UserCreditsManager inside SAME transaction
-                    await self.user_credits_mgr.add_lifetime_tokens(
+                    await self.user_credits_mgr.add_lifetime_credits(
                         tenant=tenant,
                         project=project,
                         user_id=user_id,
@@ -1112,7 +1112,7 @@ class StripeEconomicsWebhookHandler:
                         tokens = int(internal["tokens"] or 0)
                         usd_amount = float(int(internal["amount_cents"] or 0)) / 100.0
                         if tokens > 0 and usd_amount > 0:
-                            await self.user_credits_mgr.restore_lifetime_tokens(
+                            await self.user_credits_mgr.restore_lifetime_credits(
                                 tenant=str(internal["tenant"]),
                                 project=str(internal["project"]),
                                 user_id=str(internal["user_id"]),
@@ -1506,7 +1506,7 @@ class StripeEconomicsAdminService:
                 if status == "failed":
                     raise ValueError("Previous refund attempt failed; use a new request or investigate")
 
-                await self.user_credits_mgr.refund_lifetime_tokens(
+                await self.user_credits_mgr.refund_lifetime_credits(
                     tenant=tenant,
                     project=project,
                     user_id=user_id,
@@ -1536,7 +1536,7 @@ class StripeEconomicsAdminService:
             # restore credits + mark failed
             async with self.pg_pool.acquire() as conn:
                 async with conn.transaction():
-                    await self.user_credits_mgr.restore_lifetime_tokens(
+                    await self.user_credits_mgr.restore_lifetime_credits(
                         tenant=tenant,
                         project=project,
                         user_id=user_id,
@@ -1813,7 +1813,7 @@ class StripeEconomicsAdminService:
                     usd_amount = float(row["amount_cents"] or 0) / 100.0
                     async with self.pg_pool.acquire() as conn:
                         async with conn.transaction():
-                            await self.user_credits_mgr.restore_lifetime_tokens(
+                            await self.user_credits_mgr.restore_lifetime_credits(
                                 tenant=row["tenant"],
                                 project=row["project"],
                                 user_id=row["user_id"],

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/economics/stripe.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/economics/stripe.py
@@ -807,7 +807,6 @@ class StripeEconomicsWebhookHandler:
                         tenant=tenant,
                         project=project,
                         user_id=user_id,
-                        tokens=int(tokens_added),
                         usd_amount=float(usd_amount),
                         purchase_id=payment_intent_id,
                         notes=notes,
@@ -1116,7 +1115,6 @@ class StripeEconomicsWebhookHandler:
                                 tenant=str(internal["tenant"]),
                                 project=str(internal["project"]),
                                 user_id=str(internal["user_id"]),
-                                tokens=tokens,
                                 usd_amount=usd_amount,
                                 conn=conn,
                             )
@@ -1510,7 +1508,6 @@ class StripeEconomicsAdminService:
                     tenant=tenant,
                     project=project,
                     user_id=user_id,
-                    tokens=tokens_refund,
                     usd_amount=refund_usd,
                     conn=conn,
                 )
@@ -1540,7 +1537,6 @@ class StripeEconomicsAdminService:
                         tenant=tenant,
                         project=project,
                         user_id=user_id,
-                        tokens=tokens_refund,
                         usd_amount=refund_usd,
                         conn=conn,
                     )
@@ -1817,7 +1813,6 @@ class StripeEconomicsAdminService:
                                 tenant=row["tenant"],
                                 project=row["project"],
                                 user_id=row["user_id"],
-                                tokens=tokens,
                                 usd_amount=usd_amount,
                                 conn=conn,
                             )

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/economics/tests/test_enforcement.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/economics/tests/test_enforcement.py
@@ -65,15 +65,15 @@ class _Credits:
     async def get_lifetime_balance(self, **kw):
         return self.balance
 
-    async def reserve_lifetime_tokens(self, **kw):
+    async def reserve_lifetime_credits(self, **kw):
         self.reserved.append(kw)
         return True
 
-    async def commit_reserved_lifetime_tokens(self, **kw):
+    async def commit_reserved_lifetime_credits(self, **kw):
         self.committed.append(kw)
         return 0
 
-    async def consume_lifetime_tokens(self, **kw):
+    async def consume_lifetime_credits(self, **kw):
         self.consumed.append(kw)
         return 0
 

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/economics/tests/test_funding_flow.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/economics/tests/test_funding_flow.py
@@ -97,15 +97,15 @@ class _Credits:
     async def get_lifetime_balance(self, **kw):
         return self.balance
 
-    async def reserve_lifetime_tokens(self, **kw):
+    async def reserve_lifetime_credits(self, **kw):
         self.reserved.append(kw)
         return self.reserve_ok
 
-    async def commit_reserved_lifetime_tokens(self, **kw):
+    async def commit_reserved_lifetime_credits(self, **kw):
         self.committed.append(kw)
         return self.commit_uncovered
 
-    async def consume_lifetime_tokens(self, **kw):
+    async def consume_lifetime_credits(self, **kw):
         self.consumed.append(kw)
         return self.consume_uncovered
 
@@ -342,7 +342,7 @@ async def test_settle_exposes_wallet_uncovered_intermediates():
     # wallet can't fully cover its target -> the result exposes wallet_consumed /
     # user_uncovered (tokens + usd) for the caller's underfunded event. commit_uncovered
     # leaves a reservation-free remainder that consume_lifetime_tokens reports uncovered.
-    credits = _Credits(balance=10**9, commit_uncovered=2000, consume_uncovered=2000)
+    credits = _Credits(balance=10**9, commit_uncovered=2, consume_uncovered=2)
     budget = _Budget(overdraft=0.0, available_usd=0.05)
     ctx = _ctx(budget=budget, credits=credits)
     res = await _resv(
@@ -367,7 +367,7 @@ async def test_settle_subscription_runtime_shortfall_absorbed_by_subscription_he
     # subscription primary with funds beyond the pre-run plan share (headroom). A
     # runtime wallet shortfall (consume returns fewer tokens than the fresh balance
     # promised) is absorbed by the subscription budget's headroom, NOT the project.
-    credits = _Credits(balance=10**9, commit_uncovered=2000, consume_uncovered=2000)
+    credits = _Credits(balance=10**9, commit_uncovered=2, consume_uncovered=2)
     sub = _SubBudget(available_usd=1.0)                  # plenty of headroom at settle
     ctx = _ctx(sub=sub, credits=credits)
     res = ff.PlanFundingReservation(
@@ -396,7 +396,7 @@ async def test_settle_subscription_runtime_shortfall_absorbed_by_subscription_he
 async def test_settle_subscription_runtime_shortfall_falls_to_project_when_no_headroom():
     # subscription funds exhausted at the plan share (no headroom) -> the runtime
     # wallet shortfall falls through to the project as shortfall:wallet_subscription.
-    credits = _Credits(balance=10**9, commit_uncovered=2000, consume_uncovered=2000)
+    credits = _Credits(balance=10**9, commit_uncovered=2, consume_uncovered=2)
     sub = _SubBudget(available_usd=0.0)                  # nothing beyond the reserved plan share
     ctx = _ctx(sub=sub, credits=credits)
     res = ff.PlanFundingReservation(
@@ -425,7 +425,7 @@ async def test_settle_subscription_no_reservation_charges_subscription_not_proje
     # the wallet was the in-flight primary. A runtime wallet shortfall absorbed by the
     # subscription headroom must debit the SUBSCRIPTION budget directly — never the
     # project (which is the last resort). Regression for the no-reservation settle path.
-    credits = _Credits(balance=10**9, commit_uncovered=2000, consume_uncovered=2000)
+    credits = _Credits(balance=10**9, commit_uncovered=2, consume_uncovered=2)
     sub = _SubBudget(available_usd=1.0)                  # plenty of headroom at settle
     rl = _RL(available_tokens=0)                         # quota fully exhausted
     ctx = _ctx(rl=rl, sub=sub, credits=credits)

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/economics/tests/test_run_economics_characterization.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/economics/tests/test_run_economics_characterization.py
@@ -374,9 +374,9 @@ def _trace(ep) -> dict:
         "budget_committed_usd": [_usd(k) for k in b.committed],
         "budget_forced": [(_usd(k), k.get("note") or k.get("notes")) for k in b.forced],
         "budget_released": len(b.released),
-        "wallet_reserved_tokens": [int(k.get("tokens") or 0) for k in c.reserved],
-        "wallet_committed_tokens": [int(k.get("tokens") or 0) for k in c.committed],
-        "wallet_consumed_tokens": [int(k.get("tokens") or 0) for k in c.consumed],
+        "wallet_reserved_cents": [int(k.get("usd_cents") or 0) for k in c.reserved],
+        "wallet_committed_cents": [int(k.get("usd_cents") or 0) for k in c.committed],
+        "wallet_consumed_cents": [int(k.get("usd_cents") or 0) for k in c.consumed],
         "wallet_released": len(c.released),
         "rl_committed_tokens": [int(k.get("tokens") or 0) for k in r.commits],
         "rl_released": [kind for (kind, _) in r.releases],
@@ -400,7 +400,7 @@ async def test_characterize_registered_project_unlimited(monkeypatch):
     assert _trace(ep) == {
         "budget_reserved_usd": [2.0], "budget_committed_usd": [0.03],
         "budget_forced": [], "budget_released": 0,
-        "wallet_reserved_tokens": [], "wallet_committed_tokens": [], "wallet_consumed_tokens": [],
+        "wallet_reserved_cents": [], "wallet_committed_cents": [], "wallet_consumed_cents": [],
         "wallet_released": 0, "rl_committed_tokens": [1000], "rl_released": [], "events": [],
     }
 
@@ -418,8 +418,8 @@ async def test_characterize_registered_project_finite_plus_wallet_split(monkeypa
     assert _trace(ep) == {
         "budget_reserved_usd": [0.05], "budget_committed_usd": [0.0453],
         "budget_forced": [], "budget_released": 0,
-        "wallet_reserved_tokens": [113045], "wallet_committed_tokens": [13102],
-        "wallet_consumed_tokens": [], "wallet_released": 0,
+        "wallet_reserved_cents": [170], "wallet_committed_cents": [20],
+        "wallet_consumed_cents": [], "wallet_released": 0,
         "rl_committed_tokens": [2898], "rl_released": [], "events": [],
     }
 
@@ -435,7 +435,7 @@ async def test_characterize_project_shortfall_absorption(monkeypatch):
     assert _trace(ep) == {
         "budget_reserved_usd": [2.0], "budget_committed_usd": [1.8116],
         "budget_forced": [(0.6884, "shortfall:free_plan")], "budget_released": 0,
-        "wallet_reserved_tokens": [], "wallet_committed_tokens": [], "wallet_consumed_tokens": [],
+        "wallet_reserved_cents": [], "wallet_committed_cents": [], "wallet_consumed_cents": [],
         "wallet_released": 0, "rl_committed_tokens": [160000], "rl_released": [], "events": [],
     }
 
@@ -449,7 +449,7 @@ async def test_characterize_privileged_bypass(monkeypatch):
     assert _trace(ep) == {
         "budget_reserved_usd": [], "budget_committed_usd": [],
         "budget_forced": [(0.03, "settle: admin bypass")], "budget_released": 0,
-        "wallet_reserved_tokens": [], "wallet_committed_tokens": [], "wallet_consumed_tokens": [],
+        "wallet_reserved_cents": [], "wallet_committed_cents": [], "wallet_consumed_cents": [],
         "wallet_released": 0, "rl_committed_tokens": [1000], "rl_released": [], "events": [],
     }
 
@@ -465,8 +465,8 @@ async def test_characterize_project_exhausted_wallet_covers(monkeypatch):
     assert _trace(ep) == {
         "budget_reserved_usd": [], "budget_committed_usd": [],
         "budget_forced": [], "budget_released": 0,
-        "wallet_reserved_tokens": [115943], "wallet_committed_tokens": [2000],
-        "wallet_consumed_tokens": [], "wallet_released": 0,
+        "wallet_reserved_cents": [174], "wallet_committed_cents": [5],
+        "wallet_consumed_cents": [], "wallet_released": 0,
         # plan_part=0 (no project funds) -> no plan token quota consumed
         "rl_committed_tokens": [0], "rl_released": [], "events": [],
     }
@@ -516,7 +516,7 @@ async def test_characterize_internal_subscription_funds_from_project(monkeypatch
     assert _trace(ep) == {
         "budget_reserved_usd": [2.0], "budget_committed_usd": [0.03],
         "budget_forced": [], "budget_released": 0,
-        "wallet_reserved_tokens": [], "wallet_committed_tokens": [], "wallet_consumed_tokens": [],
+        "wallet_reserved_cents": [], "wallet_committed_cents": [], "wallet_consumed_cents": [],
         "wallet_released": 0, "rl_committed_tokens": [1000], "rl_released": [], "events": [],
     }
 
@@ -559,7 +559,7 @@ async def test_characterize_post_run_warning(monkeypatch):
     assert _trace(ep) == {
         "budget_reserved_usd": [0.0431], "budget_committed_usd": [0.03],
         "budget_forced": [], "budget_released": 0,
-        "wallet_reserved_tokens": [], "wallet_committed_tokens": [], "wallet_consumed_tokens": [],
+        "wallet_reserved_cents": [], "wallet_committed_cents": [], "wallet_consumed_cents": [],
         "wallet_released": 0, "rl_committed_tokens": [1000], "rl_released": [],
         "events": ["rate_limit.warning"],
     }

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/economics/tests/test_run_economics_characterization.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/economics/tests/test_run_economics_characterization.py
@@ -95,15 +95,15 @@ class _Credits:
     async def get_lifetime_balance(self, **kw):
         return self.balance
 
-    async def reserve_lifetime_tokens(self, **kw):
+    async def reserve_lifetime_credits(self, **kw):
         self.reserved.append(kw)
         return self.reserve_ok
 
-    async def commit_reserved_lifetime_tokens(self, **kw):
+    async def commit_reserved_lifetime_credits(self, **kw):
         self.committed.append(kw)
         return 0
 
-    async def consume_lifetime_tokens(self, **kw):
+    async def consume_lifetime_credits(self, **kw):
         self.consumed.append(kw)
         return 0
 

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/economics/user_budget.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/economics/user_budget.py
@@ -24,6 +24,14 @@ from kdcube_ai_app.ops.deployment.sql.db_deployment import project_schema as _pr
 logger = logging.getLogger(__name__)
 
 
+def _usd_to_cents(usd: float) -> int:
+    return int(round(float(usd) * 100))
+
+
+def _cents_to_usd(cents: int) -> float:
+    return float(cents) / 100.0
+
+
 # -----------------------------------------------------------------------------
 # Compatibility snapshot (flattened) used widely by RL / run() today.
 # Backed by TWO tables:
@@ -541,7 +549,7 @@ class UserCreditsManager:
 
     # ---------------- credits mutations ----------------
 
-    async def add_lifetime_tokens(
+    async def add_lifetime_credits(
             self,
             *,
             tenant: str,
@@ -561,19 +569,24 @@ class UserCreditsManager:
                 "lifetime_usd_purchased": 0,
             }
 
+        # purchased_cents is the authoritative USD-native balance side; the token
+        # columns are display-only.
+        purchased_cents = _usd_to_cents(usd_amount)
         sql = f"""
           INSERT INTO {self._schema(tenant, project)}.{self.TABLE} (
             tenant, project, user_id,
             lifetime_tokens_purchased,
             lifetime_tokens_consumed,
+            purchased_cents,
             lifetime_usd_purchased,
             last_purchase_id,
             last_purchase_amount_usd,
             last_purchase_notes
-          ) VALUES ($1,$2,$3,$4,0,$5,$6,$5,$7)
+          ) VALUES ($1,$2,$3,$4,0,$8,$5,$6,$5,$7)
           ON CONFLICT (tenant, project, user_id)
           DO UPDATE SET
             lifetime_tokens_purchased = {self._schema(tenant, project)}.{self.TABLE}.lifetime_tokens_purchased + EXCLUDED.lifetime_tokens_purchased,
+            purchased_cents           = {self._schema(tenant, project)}.{self.TABLE}.purchased_cents + EXCLUDED.purchased_cents,
             lifetime_usd_purchased    = {self._schema(tenant, project)}.{self.TABLE}.lifetime_usd_purchased + EXCLUDED.lifetime_usd_purchased,
             last_purchase_id          = EXCLUDED.last_purchase_id,
             last_purchase_amount_usd  = EXCLUDED.last_purchase_amount_usd,
@@ -584,17 +597,17 @@ class UserCreditsManager:
         """
 
         if conn:
-            row = await conn.fetchrow(sql, tenant, project, user_id, int(tokens), float(usd_amount), purchase_id, notes)
+            row = await conn.fetchrow(sql, tenant, project, user_id, int(tokens), float(usd_amount), purchase_id, notes, int(purchased_cents))
         else:
             if not self._pg_pool:
                 raise RuntimeError("PostgreSQL pool not initialized")
             async with self._pg_pool.acquire() as c:
-                row = await c.fetchrow(sql, tenant, project, user_id, int(tokens), float(usd_amount), purchase_id, notes)
+                row = await c.fetchrow(sql, tenant, project, user_id, int(tokens), float(usd_amount), purchase_id, notes, int(purchased_cents))
 
         await self._invalidate(tenant, project, user_id)
         return dict(row)
 
-    async def refund_lifetime_tokens(
+    async def refund_lifetime_credits(
             self,
             *,
             tenant: str,
@@ -616,11 +629,11 @@ class UserCreditsManager:
                 "lifetime_usd_purchased": 0,
             }
 
+        refund_cents = _usd_to_cents(usd_amount)
+
         async def _apply(c: asyncpg.Connection) -> asyncpg.Record:
             bal = await c.fetchrow(f"""
-                SELECT lifetime_tokens_purchased AS purchased,
-                       lifetime_tokens_consumed AS consumed,
-                       lifetime_usd_purchased AS usd_purchased
+                SELECT purchased_cents, spent_cents
                 FROM {self._schema(tenant, project)}.{self.TABLE}
                 WHERE tenant=$1 AND project=$2 AND user_id=$3
                   AND active=TRUE
@@ -629,21 +642,23 @@ class UserCreditsManager:
             if not bal:
                 raise ValueError("lifetime credits not found")
 
-            purchased = int(bal["purchased"] or 0)
-            consumed = int(bal["consumed"] or 0)
-            reserved = await self._reserved_sum(conn=c, tenant=tenant, project=project, user_id=user_id)
-            available = purchased - consumed - reserved
-            if available < int(tokens):
-                raise ValueError(f"insufficient refundable tokens: available={available}, requested={int(tokens)}")
+            purchased_cents = int(bal["purchased_cents"] or 0)
+            spent_cents = int(bal["spent_cents"] or 0)
+            reserved_cents = await self._reserved_cents_sum(conn=c, tenant=tenant, project=project, user_id=user_id)
+            available_cents = purchased_cents - spent_cents - reserved_cents
+            if available_cents < int(refund_cents):
+                raise ValueError(f"insufficient refundable credits: available_cents={available_cents}, requested_cents={int(refund_cents)}")
 
+            # purchased_cents is authoritative; token columns are display-only.
             row = await c.fetchrow(f"""
                 UPDATE {self._schema(tenant, project)}.{self.TABLE}
-                SET lifetime_tokens_purchased = lifetime_tokens_purchased - $4,
+                SET purchased_cents = GREATEST(purchased_cents - $6, 0),
+                    lifetime_tokens_purchased = lifetime_tokens_purchased - $4,
                     lifetime_usd_purchased = GREATEST(lifetime_usd_purchased - $5, 0),
                     updated_at = NOW()
                 WHERE tenant=$1 AND project=$2 AND user_id=$3
                 RETURNING *
-            """, tenant, project, user_id, int(tokens), float(usd_amount))
+            """, tenant, project, user_id, int(tokens), float(usd_amount), int(refund_cents))
             return row
 
         if conn:
@@ -658,7 +673,7 @@ class UserCreditsManager:
         await self._invalidate(tenant, project, user_id)
         return dict(row)
 
-    async def restore_lifetime_tokens(
+    async def restore_lifetime_credits(
             self,
             *,
             tenant: str,
@@ -680,17 +695,20 @@ class UserCreditsManager:
                 "lifetime_usd_purchased": 0,
             }
 
+        restore_cents = _usd_to_cents(usd_amount)
         sql = f"""
             INSERT INTO {self._schema(tenant, project)}.{self.TABLE} (
                 tenant, project, user_id,
                 lifetime_tokens_purchased,
                 lifetime_tokens_consumed,
+                purchased_cents,
                 lifetime_usd_purchased,
                 active
-            ) VALUES ($1,$2,$3,$4,0,$5,TRUE)
+            ) VALUES ($1,$2,$3,$4,0,$6,$5,TRUE)
             ON CONFLICT (tenant, project, user_id)
             DO UPDATE SET
                 lifetime_tokens_purchased = {self._schema(tenant, project)}.{self.TABLE}.lifetime_tokens_purchased + EXCLUDED.lifetime_tokens_purchased,
+                purchased_cents           = {self._schema(tenant, project)}.{self.TABLE}.purchased_cents + EXCLUDED.purchased_cents,
                 lifetime_usd_purchased    = {self._schema(tenant, project)}.{self.TABLE}.lifetime_usd_purchased + EXCLUDED.lifetime_usd_purchased,
                 active                    = TRUE,
                 updated_at                = NOW()
@@ -698,47 +716,15 @@ class UserCreditsManager:
         """
 
         if conn:
-            row = await conn.fetchrow(sql, tenant, project, user_id, int(tokens), float(usd_amount))
+            row = await conn.fetchrow(sql, tenant, project, user_id, int(tokens), float(usd_amount), int(restore_cents))
         else:
             if not self._pg_pool:
                 raise RuntimeError("PostgreSQL pool not initialized")
             async with self._pg_pool.acquire() as c:
-                row = await c.fetchrow(sql, tenant, project, user_id, int(tokens), float(usd_amount))
+                row = await c.fetchrow(sql, tenant, project, user_id, int(tokens), float(usd_amount), int(restore_cents))
 
         await self._invalidate(tenant, project, user_id)
         return dict(row)
-
-    async def deduct_lifetime_tokens(self, *, tenant: str, project: str, user_id: str, tokens: int) -> int:
-        """
-        Simple deduction (not reservation-aware).
-        Returns overflow tokens not covered by credits.
-        """
-        if tokens <= 0:
-            return 0
-        if not self._pg_pool:
-            return tokens
-
-        async with self._pg_pool.acquire() as conn:
-            row = await conn.fetchrow(f"""
-                UPDATE {self._schema(tenant, project)}.{self.TABLE}
-                SET lifetime_tokens_consumed = LEAST(lifetime_tokens_consumed + $4, lifetime_tokens_purchased),
-                    updated_at = NOW()
-                WHERE tenant=$1 AND project=$2 AND user_id=$3
-                  AND active=TRUE
-                RETURNING lifetime_tokens_purchased AS purchased, lifetime_tokens_consumed AS consumed
-            """, tenant, project, user_id, int(tokens))
-
-        if not row:
-            return tokens
-
-        purchased = int(row["purchased"] or 0)
-        consumed = int(row["consumed"] or 0)
-        old_consumed = max(consumed - int(tokens), 0)
-        actually = min(int(tokens), max(purchased - old_consumed, 0))
-        overflow = int(tokens) - actually
-
-        await self._invalidate(tenant, project, user_id)
-        return max(overflow, 0)
 
     # ---------------- reservation-aware balance ----------------
 
@@ -767,10 +753,35 @@ class UserCreditsManager:
         """, *args)
         return int(v or 0)
 
-    async def get_lifetime_balance(self, *, tenant: str, project: str, user_id: str) -> Optional[int]:
+    async def _reserved_cents_sum(
+            self,
+            *,
+            conn: asyncpg.Connection,
+            tenant: str,
+            project: str,
+            user_id: str,
+            exclude_reservation_id: Optional[str] = None,
+    ) -> int:
+        exclude_sql = ""
+        args = [tenant, project, user_id]
+        if exclude_reservation_id:
+            args.append(exclude_reservation_id)
+            exclude_sql = f"AND reservation_id <> ${len(args)}"
+
+        v = await conn.fetchval(f"""
+            SELECT COALESCE(SUM(usd_reserved_cents), 0)
+            FROM {self._schema(tenant, project)}.{self.RESERVATIONS_TABLE}
+            WHERE tenant=$1 AND project=$2 AND user_id=$3
+              AND status='reserved'
+              AND expires_at > NOW()
+              {exclude_sql}
+        """, *args)
+        return int(v or 0)
+
+    async def get_available_cents(self, *, tenant: str, project: str, user_id: str) -> Optional[int]:
         """
-        Remaining AVAILABLE lifetime tokens:
-          purchased - consumed - active_reservations
+        Remaining AVAILABLE USD balance in cents (authoritative):
+          purchased_cents - spent_cents - active reservations (usd_reserved_cents)
         """
         if not self._pg_pool:
             return None
@@ -778,12 +789,12 @@ class UserCreditsManager:
         async with self._pg_pool.acquire() as conn:
             row = await conn.fetchrow(f"""
                 SELECT
-                    COALESCE(ulc.lifetime_tokens_purchased, 0) AS purchased,
-                    COALESCE(ulc.lifetime_tokens_consumed, 0) AS consumed,
+                    COALESCE(ulc.purchased_cents, 0) AS purchased,
+                    COALESCE(ulc.spent_cents, 0) AS spent,
                     COALESCE(rsv.reserved, 0) AS reserved
                 FROM {self._schema(tenant, project)}.{self.TABLE} ulc
                 LEFT JOIN (
-                    SELECT tenant, project, user_id, COALESCE(SUM(tokens_reserved), 0) AS reserved
+                    SELECT tenant, project, user_id, COALESCE(SUM(usd_reserved_cents), 0) AS reserved
                     FROM {self._schema(tenant, project)}.{self.RESERVATIONS_TABLE}
                     WHERE tenant=$1 AND project=$2 AND user_id=$3
                       AND status='reserved'
@@ -798,22 +809,42 @@ class UserCreditsManager:
         if not row:
             return None
 
-        remaining = int(row["purchased"]) - int(row["consumed"]) - int(row["reserved"])
-        return remaining
+        return int(row["purchased"]) - int(row["spent"]) - int(row["reserved"])
 
-    async def reserve_lifetime_tokens(
+    async def get_lifetime_balance(self, *, tenant: str, project: str, user_id: str) -> Optional[int]:
+        """
+        Available balance expressed in reference tokens at the LIVE rate — for the
+        split-admission feeder only (transient, never stored). Derived from the
+        USD-native balance via get_available_cents(). Money callers should use
+        get_available_cents() directly.
+        """
+        cents = await self.get_available_cents(tenant=tenant, project=project, user_id=user_id)
+        if cents is None:
+            return None
+        from kdcube_ai_app.infra.accounting.usage import usd_per_reference_token
+        rate = usd_per_reference_token()
+        if rate <= 0:
+            return 0
+        return int(_cents_to_usd(cents) / rate)
+
+    async def reserve_lifetime_credits(
             self,
             *,
             tenant: str,
             project: str,
             user_id: str,
             reservation_id: str,
-            tokens: int,
+            usd_cents: int,
+            tokens: int = 0,
             ttl_sec: int = 900,
             bundle_id: Optional[str] = None,
             notes: Optional[str] = None,
     ) -> bool:
-        if tokens <= 0:
+        """
+        Hold `usd_cents` (authoritative) against the wallet for an in-flight turn.
+        `tokens` is display-only. Checks available_cents = purchased - spent - other holds.
+        """
+        if usd_cents <= 0:
             return True
         if not self._pg_pool:
             raise RuntimeError("PostgreSQL pool not initialized")
@@ -822,16 +853,8 @@ class UserCreditsManager:
 
         async with self._pg_pool.acquire() as conn:
             async with conn.transaction():
-                res = await conn.fetchrow(f"""
-                    SELECT tokens_reserved, status
-                    FROM {self._schema(tenant, project)}.{self.RESERVATIONS_TABLE}
-                    WHERE tenant=$1 AND project=$2 AND user_id=$3 AND reservation_id=$4
-                    FOR UPDATE
-                """, tenant, project, user_id, reservation_id)
-
                 bal = await conn.fetchrow(f"""
-                    SELECT lifetime_tokens_purchased AS purchased,
-                           lifetime_tokens_consumed AS consumed
+                    SELECT purchased_cents, spent_cents
                     FROM {self._schema(tenant, project)}.{self.TABLE}
                     WHERE tenant=$1 AND project=$2 AND user_id=$3
                       AND active=TRUE
@@ -841,32 +864,31 @@ class UserCreditsManager:
                 if not bal:
                     return False
 
-                purchased = int(bal["purchased"] or 0)
-                consumed = int(bal["consumed"] or 0)
-                # if purchased <= 0:
-                #     return False
+                purchased_cents = int(bal["purchased_cents"] or 0)
+                spent_cents = int(bal["spent_cents"] or 0)
 
-                reserved = await self._reserved_sum(conn=conn, tenant=tenant, project=project, user_id=user_id)
-                available = purchased - consumed - reserved
-                if available < int(tokens):
+                reserved_cents = await self._reserved_cents_sum(conn=conn, tenant=tenant, project=project, user_id=user_id)
+                available_cents = purchased_cents - spent_cents - reserved_cents
+                if available_cents < int(usd_cents):
                     return False
 
                 await conn.execute(f"""
                     INSERT INTO {self._schema(tenant, project)}.{self.RESERVATIONS_TABLE} (
                         tenant, project, user_id,
                         reservation_id, bundle_id,
-                        tokens_reserved, status, expires_at, notes
+                        tokens_reserved, usd_reserved_cents, status, expires_at, notes
                     )
-                    VALUES ($1,$2,$3,$4,$5,$6,'reserved',$7,$8)
+                    VALUES ($1,$2,$3,$4,$5,$6,$7,'reserved',$8,$9)
                     ON CONFLICT (tenant, project, user_id, reservation_id)
                     DO UPDATE SET
                         tokens_reserved = GREATEST(EXCLUDED.tokens_reserved, {self._schema(tenant, project)}.{self.RESERVATIONS_TABLE}.tokens_reserved),
+                        usd_reserved_cents = GREATEST(EXCLUDED.usd_reserved_cents, {self._schema(tenant, project)}.{self.RESERVATIONS_TABLE}.usd_reserved_cents),
                         status='reserved',
                         expires_at=EXCLUDED.expires_at,
                         bundle_id=EXCLUDED.bundle_id,
                         notes=EXCLUDED.notes,
                         updated_at=NOW()
-                """, tenant, project, user_id, reservation_id, bundle_id, int(tokens), exp, notes)
+                """, tenant, project, user_id, reservation_id, bundle_id, int(tokens), int(usd_cents), exp, notes)
 
         return True
 
@@ -893,29 +915,30 @@ class UserCreditsManager:
                   AND status='reserved'
             """, tenant, project, user_id, reservation_id, reason)
 
-    async def commit_reserved_lifetime_tokens(
+    async def commit_reserved_lifetime_credits(
             self,
             *,
             tenant: str,
             project: str,
             user_id: str,
             reservation_id: str,
-            tokens: int,
+            usd_cents: int,
+            tokens: int = 0,
     ) -> int:
         """
-        Commit actual token spend against a reservation.
-        Returns overflow tokens not covered by credits.
+        Commit actual USD spend (cents) against a reservation. Charges spent_cents;
+        `tokens` is display-only (tokens_used). Returns uncovered cents not covered
+        by the wallet.
         """
-        if tokens <= 0:
+        if usd_cents <= 0:
             return 0
         if not self._pg_pool:
-            return tokens
+            return usd_cents
 
         async with self._pg_pool.acquire() as conn:
             async with conn.transaction():
                 bal = await conn.fetchrow(f"""
-                    SELECT lifetime_tokens_purchased AS purchased,
-                           lifetime_tokens_consumed AS consumed
+                    SELECT purchased_cents, spent_cents
                     FROM {self._schema(tenant, project)}.{self.TABLE}
                     WHERE tenant=$1 AND project=$2 AND user_id=$3
                       AND active=TRUE
@@ -931,67 +954,68 @@ class UserCreditsManager:
                         WHERE tenant=$1 AND project=$2 AND user_id=$3 AND reservation_id=$4
                           AND status='reserved'
                     """, tenant, project, user_id, reservation_id)
-                    return tokens
+                    return usd_cents
 
                 res = await conn.fetchrow(f"""
-                        SELECT status, tokens_reserved
+                        SELECT status, usd_reserved_cents
                         FROM {self._schema(tenant, project)}.{self.RESERVATIONS_TABLE}
                         WHERE tenant=$1 AND project=$2 AND user_id=$3 AND reservation_id=$4
                     """, tenant, project, user_id, reservation_id)
 
                 if not res or res.get("status") != "reserved":
                     # Missing or already finalized reservation; do not consume
-                    return tokens
+                    return usd_cents
 
-                reserved = int(res.get("tokens_reserved") or 0)
+                reserved_cents = int(res.get("usd_reserved_cents") or 0)
 
-                purchased = int(bal["purchased"] or 0)
-                consumed = int(bal["consumed"] or 0)
+                purchased_cents = int(bal["purchased_cents"] or 0)
+                spent_cents = int(bal["spent_cents"] or 0)
 
-                other_reserved = await self._reserved_sum(
+                other_reserved_cents = await self._reserved_cents_sum(
                     conn=conn, tenant=tenant, project=project, user_id=user_id,
                     exclude_reservation_id=reservation_id,
                 )
-                available = max(purchased - consumed - other_reserved, 0)
-                consume = min(int(tokens), int(available), int(reserved))
+                available_cents = max(purchased_cents - spent_cents - other_reserved_cents, 0)
+                charge_cents = min(int(usd_cents), int(available_cents), int(reserved_cents))
 
-                if consume > 0:
+                if charge_cents > 0:
                     await conn.execute(f"""
                         UPDATE {self._schema(tenant, project)}.{self.TABLE}
-                        SET lifetime_tokens_consumed = LEAST(lifetime_tokens_consumed + $4, lifetime_tokens_purchased),
+                        SET spent_cents = spent_cents + $4,
+                            lifetime_tokens_consumed = LEAST(lifetime_tokens_consumed + $5, lifetime_tokens_purchased),
                             updated_at=NOW()
                         WHERE tenant=$1 AND project=$2 AND user_id=$3
-                    """, tenant, project, user_id, int(consume))
+                    """, tenant, project, user_id, int(charge_cents), int(tokens))
 
                 await conn.execute(f"""
                     UPDATE {self._schema(tenant, project)}.{self.RESERVATIONS_TABLE}
                     SET status='committed',
-                        tokens_used=$5,
+                        actual_spent_cents=$5,
+                        tokens_used=$6,
                         committed_at=NOW(),
                         expires_at=NOW(),
                         updated_at=NOW()
                     WHERE tenant=$1 AND project=$2 AND user_id=$3 AND reservation_id=$4
-                """, tenant, project, user_id, reservation_id, int(consume))
+                """, tenant, project, user_id, reservation_id, int(charge_cents), int(tokens))
 
         await self._invalidate(tenant, project, user_id)
-        return max(int(tokens) - int(consume), 0)
+        return max(int(usd_cents) - int(charge_cents), 0)
 
-    async def consume_lifetime_tokens(self, *, tenant: str, project: str, user_id: str, tokens: int) -> int:
+    async def consume_lifetime_credits(self, *, tenant: str, project: str, user_id: str, usd_cents: int, tokens: int = 0) -> int:
         """
-        Reservation-aware consumption WITHOUT a reservation_id.
-        Will NOT steal tokens reserved by other in-flight requests.
-        Returns overflow tokens.
+        Reservation-free USD consumption (cents) WITHOUT a reservation_id.
+        Will NOT steal credits reserved by other in-flight requests.
+        `tokens` is display-only. Returns uncovered cents.
         """
-        if tokens <= 0:
+        if usd_cents <= 0:
             return 0
         if not self._pg_pool:
-            return tokens
+            return usd_cents
 
         async with self._pg_pool.acquire() as conn:
             async with conn.transaction():
                 bal = await conn.fetchrow(f"""
-                    SELECT lifetime_tokens_purchased AS purchased,
-                           lifetime_tokens_consumed AS consumed
+                    SELECT purchased_cents, spent_cents
                     FROM {self._schema(tenant, project)}.{self.TABLE}
                     WHERE tenant=$1 AND project=$2 AND user_id=$3
                       AND active=TRUE
@@ -999,25 +1023,26 @@ class UserCreditsManager:
                 """, tenant, project, user_id)
 
                 if not bal:
-                    return tokens
+                    return usd_cents
 
-                purchased = int(bal["purchased"] or 0)
-                consumed = int(bal["consumed"] or 0)
+                purchased_cents = int(bal["purchased_cents"] or 0)
+                spent_cents = int(bal["spent_cents"] or 0)
 
-                reserved = await self._reserved_sum(conn=conn, tenant=tenant, project=project, user_id=user_id)
-                available = max(purchased - consumed - reserved, 0)
+                reserved_cents = await self._reserved_cents_sum(conn=conn, tenant=tenant, project=project, user_id=user_id)
+                available_cents = max(purchased_cents - spent_cents - reserved_cents, 0)
 
-                consume = min(int(tokens), int(available))
-                if consume > 0:
+                charge_cents = min(int(usd_cents), int(available_cents))
+                if charge_cents > 0:
                     await conn.execute(f"""
                         UPDATE {self._schema(tenant, project)}.{self.TABLE}
-                        SET lifetime_tokens_consumed = LEAST(lifetime_tokens_consumed + $4, lifetime_tokens_purchased),
+                        SET spent_cents = spent_cents + $4,
+                            lifetime_tokens_consumed = LEAST(lifetime_tokens_consumed + $5, lifetime_tokens_purchased),
                             updated_at=NOW()
                         WHERE tenant=$1 AND project=$2 AND user_id=$3
-                    """, tenant, project, user_id, int(consume))
+                    """, tenant, project, user_id, int(charge_cents), int(tokens))
 
         await self._invalidate(tenant, project, user_id)
-        return max(int(tokens) - int(consume), 0)
+        return max(int(usd_cents) - int(charge_cents), 0)
 
     async def get_active_reserved_sum(
             self,

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/economics/user_budget.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/infra/economics/user_budget.py
@@ -62,9 +62,9 @@ class UserPlanBalance:
     grant_amount_usd: Optional[float] = None
     grant_notes: Optional[str] = None
 
-    # Lifetime tokens (personal credits)
-    lifetime_tokens_purchased: Optional[int] = None
-    lifetime_tokens_consumed: Optional[int] = None
+    # Personal credits (USD-native, cents)
+    purchased_cents: Optional[int] = None
+    spent_cents: Optional[int] = None
 
     # Lifetime USD aggregate + last purchase snapshot (personal credits)
     lifetime_usd_purchased: Optional[float] = None
@@ -100,8 +100,8 @@ class UserPlanBalance:
     def has_lifetime_budget(self) -> bool:
         # "Budget info exists" (can be positive, zero, or negative)
         return (
-                self.lifetime_tokens_purchased is not None
-                or self.lifetime_tokens_consumed is not None
+                self.purchased_cents is not None
+                or self.spent_cents is not None
                 or self.lifetime_usd_purchased is not None
         )
 
@@ -114,16 +114,16 @@ class UserPlanBalance:
 
 
 @dataclass
-class TokenReservation:
+class CreditReservation:
     tenant: str
     project: str
     user_id: str
     reservation_id: str
-    tokens_reserved: int
+    usd_reserved_cents: int
     status: str
     expires_at: datetime
     bundle_id: Optional[str] = None
-    tokens_used: Optional[int] = None
+    actual_spent_cents: Optional[int] = None
     created_at: Optional[datetime] = None
     updated_at: Optional[datetime] = None
     committed_at: Optional[datetime] = None
@@ -206,8 +206,8 @@ class UserPlanBalanceSnapshotManager:
           CASE WHEN $4 OR o.expires_at IS NULL OR o.expires_at > NOW() THEN o.grant_amount_usd END   AS grant_amount_usd,
           CASE WHEN $4 OR o.expires_at IS NULL OR o.expires_at > NOW() THEN o.grant_notes END        AS grant_notes,
 
-          c.lifetime_tokens_purchased AS lifetime_tokens_purchased,
-          c.lifetime_tokens_consumed  AS lifetime_tokens_consumed,
+          c.purchased_cents           AS purchased_cents,
+          c.spent_cents               AS spent_cents,
           c.lifetime_usd_purchased    AS lifetime_usd_purchased,
           c.last_purchase_id          AS last_purchase_id,
           c.last_purchase_amount_usd  AS last_purchase_amount_usd,
@@ -441,11 +441,11 @@ class PlanOverrideManager:
 
 
 # -----------------------------------------------------------------------------
-# UserCreditsManager  (table: user_lifetime_credits + user_token_reservations)
+# UserCreditsManager  (table: user_lifetime_credits + user_credit_reservations)
 # -----------------------------------------------------------------------------
 class UserCreditsManager:
     TABLE = "user_lifetime_credits"
-    RESERVATIONS_TABLE = "user_token_reservations"
+    RESERVATIONS_TABLE = "user_credit_reservations"
 
     @staticmethod
     def _schema(tenant: str, project: str) -> str:
@@ -555,37 +555,32 @@ class UserCreditsManager:
             tenant: str,
             project: str,
             user_id: str,
-            tokens: int,
             usd_amount: float,
             purchase_id: Optional[str] = None,
             notes: Optional[str] = None,
             conn: Optional[asyncpg.Connection] = None,
     ) -> dict:
-        if tokens <= 0:
+        """Add `usd_amount` of credits. Increments purchased_cents (authoritative)
+        and lifetime_usd_purchased (reporting)."""
+        if usd_amount <= 0:
             existing = await self.get_user_credits(tenant=tenant, project=project, user_id=user_id)
             return existing or {
                 "tenant": tenant, "project": project, "user_id": user_id,
-                "lifetime_tokens_purchased": 0, "lifetime_tokens_consumed": 0,
-                "lifetime_usd_purchased": 0,
+                "purchased_cents": 0, "spent_cents": 0, "lifetime_usd_purchased": 0,
             }
 
-        # purchased_cents is the authoritative USD-native balance side; the token
-        # columns are display-only.
         purchased_cents = _usd_to_cents(usd_amount)
         sql = f"""
           INSERT INTO {self._schema(tenant, project)}.{self.TABLE} (
             tenant, project, user_id,
-            lifetime_tokens_purchased,
-            lifetime_tokens_consumed,
             purchased_cents,
             lifetime_usd_purchased,
             last_purchase_id,
             last_purchase_amount_usd,
             last_purchase_notes
-          ) VALUES ($1,$2,$3,$4,0,$8,$5,$6,$5,$7)
+          ) VALUES ($1,$2,$3,$5,$4,$6,$4,$7)
           ON CONFLICT (tenant, project, user_id)
           DO UPDATE SET
-            lifetime_tokens_purchased = {self._schema(tenant, project)}.{self.TABLE}.lifetime_tokens_purchased + EXCLUDED.lifetime_tokens_purchased,
             purchased_cents           = {self._schema(tenant, project)}.{self.TABLE}.purchased_cents + EXCLUDED.purchased_cents,
             lifetime_usd_purchased    = {self._schema(tenant, project)}.{self.TABLE}.lifetime_usd_purchased + EXCLUDED.lifetime_usd_purchased,
             last_purchase_id          = EXCLUDED.last_purchase_id,
@@ -597,12 +592,12 @@ class UserCreditsManager:
         """
 
         if conn:
-            row = await conn.fetchrow(sql, tenant, project, user_id, int(tokens), float(usd_amount), purchase_id, notes, int(purchased_cents))
+            row = await conn.fetchrow(sql, tenant, project, user_id, float(usd_amount), int(purchased_cents), purchase_id, notes)
         else:
             if not self._pg_pool:
                 raise RuntimeError("PostgreSQL pool not initialized")
             async with self._pg_pool.acquire() as c:
-                row = await c.fetchrow(sql, tenant, project, user_id, int(tokens), float(usd_amount), purchase_id, notes, int(purchased_cents))
+                row = await c.fetchrow(sql, tenant, project, user_id, float(usd_amount), int(purchased_cents), purchase_id, notes)
 
         await self._invalidate(tenant, project, user_id)
         return dict(row)
@@ -613,20 +608,18 @@ class UserCreditsManager:
             tenant: str,
             project: str,
             user_id: str,
-            tokens: int,
             usd_amount: float,
             conn: Optional[asyncpg.Connection] = None,
     ) -> dict:
         """
-        Refund (remove) lifetime tokens/amount.
-        Ensures refundable = purchased - consumed - reserved >= tokens.
+        Refund (remove) `usd_amount` of credits. Requires available_cents
+        (purchased - spent - reserved) >= the refund amount.
         """
-        if tokens <= 0 or usd_amount <= 0:
+        if usd_amount <= 0:
             existing = await self.get_user_credits(tenant=tenant, project=project, user_id=user_id)
             return existing or {
                 "tenant": tenant, "project": project, "user_id": user_id,
-                "lifetime_tokens_purchased": 0, "lifetime_tokens_consumed": 0,
-                "lifetime_usd_purchased": 0,
+                "purchased_cents": 0, "spent_cents": 0, "lifetime_usd_purchased": 0,
             }
 
         refund_cents = _usd_to_cents(usd_amount)
@@ -649,16 +642,14 @@ class UserCreditsManager:
             if available_cents < int(refund_cents):
                 raise ValueError(f"insufficient refundable credits: available_cents={available_cents}, requested_cents={int(refund_cents)}")
 
-            # purchased_cents is authoritative; token columns are display-only.
             row = await c.fetchrow(f"""
                 UPDATE {self._schema(tenant, project)}.{self.TABLE}
-                SET purchased_cents = GREATEST(purchased_cents - $6, 0),
-                    lifetime_tokens_purchased = lifetime_tokens_purchased - $4,
-                    lifetime_usd_purchased = GREATEST(lifetime_usd_purchased - $5, 0),
+                SET purchased_cents = GREATEST(purchased_cents - $5, 0),
+                    lifetime_usd_purchased = GREATEST(lifetime_usd_purchased - $4, 0),
                     updated_at = NOW()
                 WHERE tenant=$1 AND project=$2 AND user_id=$3
                 RETURNING *
-            """, tenant, project, user_id, int(tokens), float(usd_amount), int(refund_cents))
+            """, tenant, project, user_id, float(usd_amount), int(refund_cents))
             return row
 
         if conn:
@@ -679,35 +670,30 @@ class UserCreditsManager:
             tenant: str,
             project: str,
             user_id: str,
-            tokens: int,
             usd_amount: float,
             conn: Optional[asyncpg.Connection] = None,
     ) -> dict:
         """
-        Restore (add back) lifetime tokens/amount after a failed refund.
+        Restore (add back) `usd_amount` of credits after a failed refund.
         Does not alter last_purchase_* fields.
         """
-        if tokens <= 0 or usd_amount <= 0:
+        if usd_amount <= 0:
             existing = await self.get_user_credits(tenant=tenant, project=project, user_id=user_id)
             return existing or {
                 "tenant": tenant, "project": project, "user_id": user_id,
-                "lifetime_tokens_purchased": 0, "lifetime_tokens_consumed": 0,
-                "lifetime_usd_purchased": 0,
+                "purchased_cents": 0, "spent_cents": 0, "lifetime_usd_purchased": 0,
             }
 
         restore_cents = _usd_to_cents(usd_amount)
         sql = f"""
             INSERT INTO {self._schema(tenant, project)}.{self.TABLE} (
                 tenant, project, user_id,
-                lifetime_tokens_purchased,
-                lifetime_tokens_consumed,
                 purchased_cents,
                 lifetime_usd_purchased,
                 active
-            ) VALUES ($1,$2,$3,$4,0,$6,$5,TRUE)
+            ) VALUES ($1,$2,$3,$5,$4,TRUE)
             ON CONFLICT (tenant, project, user_id)
             DO UPDATE SET
-                lifetime_tokens_purchased = {self._schema(tenant, project)}.{self.TABLE}.lifetime_tokens_purchased + EXCLUDED.lifetime_tokens_purchased,
                 purchased_cents           = {self._schema(tenant, project)}.{self.TABLE}.purchased_cents + EXCLUDED.purchased_cents,
                 lifetime_usd_purchased    = {self._schema(tenant, project)}.{self.TABLE}.lifetime_usd_purchased + EXCLUDED.lifetime_usd_purchased,
                 active                    = TRUE,
@@ -716,42 +702,17 @@ class UserCreditsManager:
         """
 
         if conn:
-            row = await conn.fetchrow(sql, tenant, project, user_id, int(tokens), float(usd_amount), int(restore_cents))
+            row = await conn.fetchrow(sql, tenant, project, user_id, float(usd_amount), int(restore_cents))
         else:
             if not self._pg_pool:
                 raise RuntimeError("PostgreSQL pool not initialized")
             async with self._pg_pool.acquire() as c:
-                row = await c.fetchrow(sql, tenant, project, user_id, int(tokens), float(usd_amount), int(restore_cents))
+                row = await c.fetchrow(sql, tenant, project, user_id, float(usd_amount), int(restore_cents))
 
         await self._invalidate(tenant, project, user_id)
         return dict(row)
 
     # ---------------- reservation-aware balance ----------------
-
-    async def _reserved_sum(
-            self,
-            *,
-            conn: asyncpg.Connection,
-            tenant: str,
-            project: str,
-            user_id: str,
-            exclude_reservation_id: Optional[str] = None,
-    ) -> int:
-        exclude_sql = ""
-        args = [tenant, project, user_id]
-        if exclude_reservation_id:
-            args.append(exclude_reservation_id)
-            exclude_sql = f"AND reservation_id <> ${len(args)}"
-
-        v = await conn.fetchval(f"""
-            SELECT COALESCE(SUM(tokens_reserved), 0)
-            FROM {self._schema(tenant, project)}.{self.RESERVATIONS_TABLE}
-            WHERE tenant=$1 AND project=$2 AND user_id=$3
-              AND status='reserved'
-              AND expires_at > NOW()
-              {exclude_sql}
-        """, *args)
-        return int(v or 0)
 
     async def _reserved_cents_sum(
             self,
@@ -835,14 +796,13 @@ class UserCreditsManager:
             user_id: str,
             reservation_id: str,
             usd_cents: int,
-            tokens: int = 0,
             ttl_sec: int = 900,
             bundle_id: Optional[str] = None,
             notes: Optional[str] = None,
     ) -> bool:
         """
-        Hold `usd_cents` (authoritative) against the wallet for an in-flight turn.
-        `tokens` is display-only. Checks available_cents = purchased - spent - other holds.
+        Hold `usd_cents` against the wallet for an in-flight turn. Checks
+        available_cents = purchased - spent - other active holds.
         """
         if usd_cents <= 0:
             return True
@@ -876,19 +836,18 @@ class UserCreditsManager:
                     INSERT INTO {self._schema(tenant, project)}.{self.RESERVATIONS_TABLE} (
                         tenant, project, user_id,
                         reservation_id, bundle_id,
-                        tokens_reserved, usd_reserved_cents, status, expires_at, notes
+                        usd_reserved_cents, status, expires_at, notes
                     )
-                    VALUES ($1,$2,$3,$4,$5,$6,$7,'reserved',$8,$9)
+                    VALUES ($1,$2,$3,$4,$5,$6,'reserved',$7,$8)
                     ON CONFLICT (tenant, project, user_id, reservation_id)
                     DO UPDATE SET
-                        tokens_reserved = GREATEST(EXCLUDED.tokens_reserved, {self._schema(tenant, project)}.{self.RESERVATIONS_TABLE}.tokens_reserved),
                         usd_reserved_cents = GREATEST(EXCLUDED.usd_reserved_cents, {self._schema(tenant, project)}.{self.RESERVATIONS_TABLE}.usd_reserved_cents),
                         status='reserved',
                         expires_at=EXCLUDED.expires_at,
                         bundle_id=EXCLUDED.bundle_id,
                         notes=EXCLUDED.notes,
                         updated_at=NOW()
-                """, tenant, project, user_id, reservation_id, bundle_id, int(tokens), int(usd_cents), exp, notes)
+                """, tenant, project, user_id, reservation_id, bundle_id, int(usd_cents), exp, notes)
 
         return True
 
@@ -923,12 +882,11 @@ class UserCreditsManager:
             user_id: str,
             reservation_id: str,
             usd_cents: int,
-            tokens: int = 0,
     ) -> int:
         """
-        Commit actual USD spend (cents) against a reservation. Charges spent_cents;
-        `tokens` is display-only (tokens_used). Returns uncovered cents not covered
-        by the wallet.
+        Commit actual USD spend (cents) against a reservation. Charges spent_cents
+        (capped by the hold and available balance). Returns the uncovered cents the
+        wallet could not cover.
         """
         if usd_cents <= 0:
             return 0
@@ -982,30 +940,28 @@ class UserCreditsManager:
                     await conn.execute(f"""
                         UPDATE {self._schema(tenant, project)}.{self.TABLE}
                         SET spent_cents = spent_cents + $4,
-                            lifetime_tokens_consumed = LEAST(lifetime_tokens_consumed + $5, lifetime_tokens_purchased),
                             updated_at=NOW()
                         WHERE tenant=$1 AND project=$2 AND user_id=$3
-                    """, tenant, project, user_id, int(charge_cents), int(tokens))
+                    """, tenant, project, user_id, int(charge_cents))
 
                 await conn.execute(f"""
                     UPDATE {self._schema(tenant, project)}.{self.RESERVATIONS_TABLE}
                     SET status='committed',
                         actual_spent_cents=$5,
-                        tokens_used=$6,
                         committed_at=NOW(),
                         expires_at=NOW(),
                         updated_at=NOW()
                     WHERE tenant=$1 AND project=$2 AND user_id=$3 AND reservation_id=$4
-                """, tenant, project, user_id, reservation_id, int(charge_cents), int(tokens))
+                """, tenant, project, user_id, reservation_id, int(charge_cents))
 
         await self._invalidate(tenant, project, user_id)
         return max(int(usd_cents) - int(charge_cents), 0)
 
-    async def consume_lifetime_credits(self, *, tenant: str, project: str, user_id: str, usd_cents: int, tokens: int = 0) -> int:
+    async def consume_lifetime_credits(self, *, tenant: str, project: str, user_id: str, usd_cents: int) -> int:
         """
         Reservation-free USD consumption (cents) WITHOUT a reservation_id.
-        Will NOT steal credits reserved by other in-flight requests.
-        `tokens` is display-only. Returns uncovered cents.
+        Will NOT steal credits reserved by other in-flight requests. Returns
+        uncovered cents.
         """
         if usd_cents <= 0:
             return 0
@@ -1036,30 +992,27 @@ class UserCreditsManager:
                     await conn.execute(f"""
                         UPDATE {self._schema(tenant, project)}.{self.TABLE}
                         SET spent_cents = spent_cents + $4,
-                            lifetime_tokens_consumed = LEAST(lifetime_tokens_consumed + $5, lifetime_tokens_purchased),
                             updated_at=NOW()
                         WHERE tenant=$1 AND project=$2 AND user_id=$3
-                    """, tenant, project, user_id, int(charge_cents), int(tokens))
+                    """, tenant, project, user_id, int(charge_cents))
 
         await self._invalidate(tenant, project, user_id)
         return max(int(usd_cents) - int(charge_cents), 0)
 
-    async def get_active_reserved_sum(
+    async def get_active_reserved_cents(
             self,
             *,
             tenant: str,
             project: str,
             user_id: str,
     ) -> int:
-        """
-        Sum of currently active reservations.
-        """
+        """Sum of currently active reservation holds, in cents."""
         if not self._pg_pool:
             return 0
 
         async with self._pg_pool.acquire() as conn:
             v = await conn.fetchval(f"""
-                SELECT COALESCE(SUM(tokens_reserved), 0)
+                SELECT COALESCE(SUM(usd_reserved_cents), 0)
                 FROM {self._schema(tenant, project)}.{self.RESERVATIONS_TABLE}
                 WHERE tenant=$1 AND project=$2 AND user_id=$3
                   AND status='reserved'
@@ -1075,7 +1028,7 @@ class UserCreditsManager:
             project: str,
             user_id: str,
             limit: int = 50,
-    ) -> list[TokenReservation]:
+    ) -> list[CreditReservation]:
         """
         List active 'reserved' reservations (not committed/released), newest first.
         """
@@ -1090,8 +1043,8 @@ class UserCreditsManager:
                     tenant, project, user_id,
                     reservation_id,
                     bundle_id,
-                    tokens_reserved,
-                    tokens_used,
+                    usd_reserved_cents,
+                    actual_spent_cents,
                     status,
                     expires_at,
                     created_at,
@@ -1107,10 +1060,9 @@ class UserCreditsManager:
                 LIMIT $4
             """, tenant, project, user_id, int(limit))
 
-        out: list[TokenReservation] = []
+        out: list[CreditReservation] = []
         for r in rows:
-            d = dict(r)
-            out.append(TokenReservation(**d))
+            out.append(CreditReservation(**dict(r)))
         return out
 
 class UserBudgetBreakdownService:
@@ -1330,19 +1282,13 @@ class UserBudgetBreakdownService:
         reservations_payload: list[dict] = []
 
         if plan_full and plan_full.has_lifetime_budget():
-            purchased = int(plan_full.lifetime_tokens_purchased or 0)
-            consumed = int(plan_full.lifetime_tokens_consumed or 0)
-
-            # Do NOT clamp: if later you allow negative credits, UI/API stays truthful.
-            gross_remaining = purchased - consumed
-
-            reserved_sum = await self._credits_mgr.get_active_reserved_sum(
+            # Wallet is USD-native (cents). available = purchased - spent - reserved.
+            purchased_cents = int(plan_full.purchased_cents or 0)
+            spent_cents = int(plan_full.spent_cents or 0)
+            reserved_cents = await self._credits_mgr.get_active_reserved_cents(
                 tenant=tenant, project=project, user_id=user_id
             )
-
-            available = gross_remaining - int(reserved_sum)
-
-            available_usd = round(float(available) * usd_per_token, 2)
+            available_cents = purchased_cents - spent_cents - reserved_cents
 
             # list reservations (limited)
             reservations = await self._credits_mgr.list_active_reservations(
@@ -1352,8 +1298,9 @@ class UserBudgetBreakdownService:
                 reservations_payload.append({
                     "reservation_id": r.reservation_id,
                     "bundle_id": r.bundle_id,
-                    "tokens_reserved": int(r.tokens_reserved),
-                    "tokens_used": int(r.tokens_used or 0),
+                    "reserved_usd": round(int(r.usd_reserved_cents or 0) / 100.0, 2),
+                    "spent_usd": round(int(r.actual_spent_cents) / 100.0, 2)
+                    if r.actual_spent_cents is not None else None,
                     "status": r.status,
                     "expires_at": self._dt(r.expires_at),
                     "created_at": self._dt(r.created_at),
@@ -1363,12 +1310,10 @@ class UserBudgetBreakdownService:
 
             credits_payload = {
                 "has_lifetime_credits": True,
-                "tokens_purchased": purchased,
-                "tokens_consumed": consumed,
-                "tokens_gross_remaining": int(gross_remaining),
-                "tokens_reserved": int(reserved_sum),
-                "tokens_available": int(available),
-                "available_usd": float(available_usd),
+                "purchased_usd": round(purchased_cents / 100.0, 2),
+                "spent_usd": round(spent_cents / 100.0, 2),
+                "reserved_usd": round(reserved_cents / 100.0, 2),
+                "available_usd": round(available_cents / 100.0, 2),
                 "lifetime_usd_purchased": float(plan_full.lifetime_usd_purchased)
                 if plan_full.lifetime_usd_purchased is not None else None,
                 "last_purchase": {
@@ -1377,7 +1322,6 @@ class UserBudgetBreakdownService:
                     if plan_full.last_purchase_amount_usd is not None else None,
                     "notes": plan_full.last_purchase_notes,
                 },
-                "reference_model": f"{reference_provider}/{reference_model}",
             }
 
         # -------- subscription balance (per-user) --------

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/ops/deployment/sql/chatbot/deploy-kdcube-proj-schema.sql
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/ops/deployment/sql/chatbot/deploy-kdcube-proj-schema.sql
@@ -489,6 +489,11 @@ CREATE TABLE IF NOT EXISTS <SCHEMA>.user_lifetime_credits (
     lifetime_tokens_purchased BIGINT NOT NULL DEFAULT 0,
     lifetime_tokens_consumed  BIGINT NOT NULL DEFAULT 0,
 
+    -- USD-native balance (cents). Authoritative; the token columns above are
+    -- display-only. available = purchased_cents - spent_cents - SUM(usd_reserved_cents).
+    purchased_cents BIGINT NOT NULL DEFAULT 0,
+    spent_cents     BIGINT NOT NULL DEFAULT 0,
+
     -- Aggregate lifetime purchase (for reporting)
     lifetime_usd_purchased NUMERIC(10, 2) NOT NULL DEFAULT 0,
 
@@ -504,7 +509,10 @@ CREATE TABLE IF NOT EXISTS <SCHEMA>.user_lifetime_credits (
     PRIMARY KEY (tenant, project, user_id),
 
     CONSTRAINT chk_cp_ulc_consumed_nonneg
-        CHECK (lifetime_tokens_consumed >= 0)
+        CHECK (lifetime_tokens_consumed >= 0),
+
+    CONSTRAINT chk_cp_ulc_cents_nonneg
+        CHECK (purchased_cents >= 0 AND spent_cents >= 0)
 
 --     CONSTRAINT chk_cp_ulc_nonneg
 --       CHECK (lifetime_tokens_purchased >= 0 AND lifetime_tokens_consumed >= 0),
@@ -545,6 +553,11 @@ CREATE TABLE IF NOT EXISTS <SCHEMA>.user_token_reservations (
 
     tokens_reserved BIGINT NOT NULL CHECK (tokens_reserved >= 0),
     tokens_used BIGINT DEFAULT NULL CHECK (tokens_used IS NULL OR tokens_used >= 0),
+
+    -- USD-native hold (cents). Authoritative; the token columns above are
+    -- display-only. usd_reserved_cents = amount held, actual_spent_cents = committed.
+    usd_reserved_cents BIGINT NOT NULL DEFAULT 0 CHECK (usd_reserved_cents >= 0),
+    actual_spent_cents BIGINT DEFAULT NULL CHECK (actual_spent_cents IS NULL OR actual_spent_cents >= 0),
 
     status VARCHAR(32) NOT NULL DEFAULT 'reserved'
       CHECK (status IN ('reserved', 'committed', 'released')),

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/ops/deployment/sql/chatbot/deploy-kdcube-proj-schema.sql
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/ops/deployment/sql/chatbot/deploy-kdcube-proj-schema.sql
@@ -486,11 +486,8 @@ CREATE TABLE IF NOT EXISTS <SCHEMA>.user_lifetime_credits (
     project VARCHAR(255) NOT NULL,
     user_id VARCHAR(255) NOT NULL,
 
-    lifetime_tokens_purchased BIGINT NOT NULL DEFAULT 0,
-    lifetime_tokens_consumed  BIGINT NOT NULL DEFAULT 0,
-
-    -- USD-native balance (cents). Authoritative; the token columns above are
-    -- display-only. available = purchased_cents - spent_cents - SUM(usd_reserved_cents).
+    -- USD-native balance (cents).
+    -- available = purchased_cents - spent_cents - SUM(usd_reserved_cents).
     purchased_cents BIGINT NOT NULL DEFAULT 0,
     spent_cents     BIGINT NOT NULL DEFAULT 0,
 
@@ -508,24 +505,12 @@ CREATE TABLE IF NOT EXISTS <SCHEMA>.user_lifetime_credits (
 
     PRIMARY KEY (tenant, project, user_id),
 
-    CONSTRAINT chk_cp_ulc_consumed_nonneg
-        CHECK (lifetime_tokens_consumed >= 0),
-
     CONSTRAINT chk_cp_ulc_cents_nonneg
         CHECK (purchased_cents >= 0 AND spent_cents >= 0)
-
---     CONSTRAINT chk_cp_ulc_nonneg
---       CHECK (lifetime_tokens_purchased >= 0 AND lifetime_tokens_consumed >= 0),
-
---     CONSTRAINT chk_cp_ulc_consumed_le_purchased
---       CHECK (lifetime_tokens_consumed <= lifetime_tokens_purchased),
-
---     CONSTRAINT chk_cp_ulc_usd_nonneg
---       CHECK (lifetime_usd_purchased >= 0)
 );
 
 COMMENT ON TABLE <SCHEMA>.user_lifetime_credits IS
-  'Personal lifetime credits: purchased tokens that deplete on use. Never expire.';
+  'Personal lifetime credits (USD, cents): purchased_cents deplete via spent_cents on use. Never expire.';
 
 CREATE INDEX IF NOT EXISTS idx_cp_ulc_lookup
   ON <SCHEMA>.user_lifetime_credits(tenant, project, user_id)
@@ -537,11 +522,11 @@ CREATE TRIGGER trg_cp_ulc_updated_at
   FOR EACH ROW EXECUTE FUNCTION <SCHEMA>.update_updated_at();
 
 -- =========================================
--- USER TOKEN RESERVATIONS (Personal Credits)
--- Prevent concurrent overspending of lifetime credits.
+-- USER CREDIT RESERVATIONS (Personal Credits)
+-- Prevent concurrent overspending of lifetime credits. USD-in-cents holds.
 -- FK -> user_lifetime_credits
 -- =========================================
-CREATE TABLE IF NOT EXISTS <SCHEMA>.user_token_reservations (
+CREATE TABLE IF NOT EXISTS <SCHEMA>.user_credit_reservations (
     tenant VARCHAR(255) NOT NULL,
     project VARCHAR(255) NOT NULL,
     user_id VARCHAR(255) NOT NULL,
@@ -551,11 +536,8 @@ CREATE TABLE IF NOT EXISTS <SCHEMA>.user_token_reservations (
     bundle_id VARCHAR(255) DEFAULT NULL,
     notes TEXT DEFAULT NULL,
 
-    tokens_reserved BIGINT NOT NULL CHECK (tokens_reserved >= 0),
-    tokens_used BIGINT DEFAULT NULL CHECK (tokens_used IS NULL OR tokens_used >= 0),
-
-    -- USD-native hold (cents). Authoritative; the token columns above are
-    -- display-only. usd_reserved_cents = amount held, actual_spent_cents = committed.
+    -- USD-native hold (cents). usd_reserved_cents = amount held,
+    -- actual_spent_cents = committed spend.
     usd_reserved_cents BIGINT NOT NULL DEFAULT 0 CHECK (usd_reserved_cents >= 0),
     actual_spent_cents BIGINT DEFAULT NULL CHECK (actual_spent_cents IS NULL OR actual_spent_cents >= 0),
 
@@ -571,8 +553,8 @@ CREATE TABLE IF NOT EXISTS <SCHEMA>.user_token_reservations (
 
     PRIMARY KEY (tenant, project, user_id, reservation_id),
 
-    CONSTRAINT chk_cp_utr_used_le_reserved
-      CHECK (tokens_used IS NULL OR tokens_used <= tokens_reserved),
+    CONSTRAINT chk_cp_utr_actual_le_reserved
+      CHECK (actual_spent_cents IS NULL OR actual_spent_cents <= usd_reserved_cents),
 
     CONSTRAINT fk_cp_utr_user_credits
       FOREIGN KEY (tenant, project, user_id)
@@ -580,23 +562,23 @@ CREATE TABLE IF NOT EXISTS <SCHEMA>.user_token_reservations (
       ON DELETE CASCADE
 );
 
-COMMENT ON TABLE <SCHEMA>.user_token_reservations IS
-  'In-flight reservations for lifetime credits to prevent concurrent overspend.';
+COMMENT ON TABLE <SCHEMA>.user_credit_reservations IS
+  'In-flight USD (cents) reservations for lifetime credits to prevent concurrent overspend.';
 
 CREATE INDEX IF NOT EXISTS idx_cp_utr_active
-  ON <SCHEMA>.user_token_reservations(tenant, project, user_id, expires_at)
+  ON <SCHEMA>.user_credit_reservations(tenant, project, user_id, expires_at)
   WHERE status = 'reserved';
 
 CREATE INDEX IF NOT EXISTS idx_cp_utr_reservation_id
-  ON <SCHEMA>.user_token_reservations(tenant, project, reservation_id);
+  ON <SCHEMA>.user_credit_reservations(tenant, project, reservation_id);
 
 CREATE INDEX IF NOT EXISTS idx_cp_utr_expires
-  ON <SCHEMA>.user_token_reservations(expires_at)
+  ON <SCHEMA>.user_credit_reservations(expires_at)
   WHERE status = 'reserved';
 
-DROP TRIGGER IF EXISTS trg_cp_utr_updated_at ON <SCHEMA>.user_token_reservations;
+DROP TRIGGER IF EXISTS trg_cp_utr_updated_at ON <SCHEMA>.user_credit_reservations;
 CREATE TRIGGER trg_cp_utr_updated_at
-  BEFORE UPDATE ON <SCHEMA>.user_token_reservations
+  BEFORE UPDATE ON <SCHEMA>.user_credit_reservations
   FOR EACH ROW EXECUTE FUNCTION <SCHEMA>.update_updated_at();
 
 -- =========================================

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/ops/deployment/sql/chatbot/drop-kdcube-proj-schema.sql
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/ops/deployment/sql/chatbot/drop-kdcube-proj-schema.sql
@@ -105,7 +105,7 @@ DROP TABLE IF EXISTS <SCHEMA>.tenant_project_budget_reservations CASCADE;
 DROP TABLE IF EXISTS <SCHEMA>.tenant_project_budget CASCADE;
 DROP TABLE IF EXISTS <SCHEMA>.application_budget_policies CASCADE;
 DROP TABLE IF EXISTS <SCHEMA>.plan_quota_policies CASCADE;
-DROP TABLE IF EXISTS <SCHEMA>.user_token_reservations CASCADE;
+DROP TABLE IF EXISTS <SCHEMA>.user_credit_reservations CASCADE;
 DROP TABLE IF EXISTS <SCHEMA>.user_lifetime_credits CASCADE;
 DROP TABLE IF EXISTS <SCHEMA>.user_plan_overrides CASCADE;
 DROP TYPE  IF EXISTS <SCHEMA>.budget_reservation_status;

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/ops/deployment/sql/chatbot/wallet-usd-native.sql
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/ops/deployment/sql/chatbot/wallet-usd-native.sql
@@ -1,73 +1,150 @@
 -- SPDX-License-Identifier: MIT
 -- Copyright (c) 2026 Elena Viter
 --
--- Wallet USD-native (cents) one-time, idempotent migration. Adds the authoritative
--- USD-in-cents columns to a previously-deployed project schema:
---   user_lifetime_credits   -> purchased_cents, spent_cents
---   user_token_reservations -> usd_reserved_cents, actual_spent_cents
--- Replace <SCHEMA> with the project schema (e.g. kdcube_<tenant>_<project>) before
--- applying, mirroring deploy-kdcube-proj-schema.sql.
+-- Wallet USD-native (cents) migration for a previously-deployed (token-native)
+-- project schema. Replace <SCHEMA> with the project schema (e.g.
+-- kdcube_<tenant>_<project>) before applying, mirroring deploy-kdcube-proj-schema.sql.
+-- Runs BEFORE the provision.
 --
--- Runs BEFORE the schema provision (deploy-kdcube-proj-schema.sql). The provision's
--- CREATE TABLE carries these columns for fresh schemas; this migration carries them
--- for existing ones. The back-fill runs ONCE, inside the column guard, converting the
--- legacy token columns at the sonnet-4-5 reference rate (15 USD / 1M output tokens)
--- under which all existing credits were purchased -- keeping the migration
--- balance-neutral. The token columns are kept as display-only.
+-- Target state, per table:
+--   user_lifetime_credits     -> purchased_cents, spent_cents (token columns dropped)
+--   user_token_reservations   -> renamed to user_credit_reservations;
+--                                usd_reserved_cents, actual_spent_cents (token columns dropped)
 --
--- Each block is guarded on table existence AND column absence, so the file is a clean
--- no-op on a fresh schema (tables absent, pre-provision) and on a re-run (columns
--- present).
+-- Self-healing / idempotent. Each step is independently guarded so the file
+-- converges on the target state from ANY intermediate state (fresh schema; the
+-- original token-native schema; a partially-migrated schema that already has the
+-- cents columns and/or the rename but still carries the token columns):
+--   * add-cents-columns + back-fill runs ONLY when the cents columns are absent
+--     (first pass). Back-fill is one-shot: once the cents columns exist they are
+--     authoritative (the running code writes only cents), so it must never re-run
+--     off the now-stale token columns.
+--   * drop-token-columns runs whenever the token columns are still present,
+--     independent of the cents-column state.
+--   * the constraints and the rename are each ensured only if not already applied.
+-- On a fresh schema the tables are absent (migration runs pre-provision), so every
+-- block is a no-op and the CREATE in deploy-kdcube-proj-schema.sql builds the
+-- target shape directly.
+--
+-- Back-fill uses the sonnet-4-5 reference rate (15 USD / 1M output tokens) — the
+-- rate at which every credit to date was priced, so the cutover is balance-neutral.
 --
 -- TEMPORARY: remove this file (and its entry in apply_project_migrations) once every
--- environment has the cents columns.
+-- environment is USD-native.
 
 DO $$
 BEGIN
+    ----------------------------------------------------------------------------
+    -- user_lifetime_credits: USD-in-cents (purchased_cents, spent_cents)
+    ----------------------------------------------------------------------------
     IF EXISTS (
         SELECT 1 FROM information_schema.tables
-        WHERE table_schema = '<SCHEMA>'
-          AND table_name = 'user_lifetime_credits'
-    ) AND NOT EXISTS (
-        SELECT 1 FROM information_schema.columns
-        WHERE table_schema = '<SCHEMA>'
-          AND table_name = 'user_lifetime_credits'
-          AND column_name = 'spent_cents'
+        WHERE table_schema = '<SCHEMA>' AND table_name = 'user_lifetime_credits'
     ) THEN
-        ALTER TABLE <SCHEMA>.user_lifetime_credits
-            ADD COLUMN purchased_cents BIGINT NOT NULL DEFAULT 0,
-            ADD COLUMN spent_cents     BIGINT NOT NULL DEFAULT 0;
+        -- add + back-fill cents columns, one-shot (only when absent)
+        IF NOT EXISTS (
+            SELECT 1 FROM information_schema.columns
+            WHERE table_schema = '<SCHEMA>' AND table_name = 'user_lifetime_credits'
+              AND column_name = 'spent_cents'
+        ) THEN
+            ALTER TABLE <SCHEMA>.user_lifetime_credits
+                ADD COLUMN purchased_cents BIGINT NOT NULL DEFAULT 0,
+                ADD COLUMN spent_cents     BIGINT NOT NULL DEFAULT 0;
 
-        UPDATE <SCHEMA>.user_lifetime_credits
-            SET purchased_cents = ROUND(lifetime_usd_purchased * 100),
-                spent_cents     = ROUND(lifetime_tokens_consumed * 15.0 / 1e6 * 100);
+            UPDATE <SCHEMA>.user_lifetime_credits
+                SET purchased_cents = ROUND(lifetime_usd_purchased * 100),
+                    spent_cents     = ROUND(lifetime_tokens_consumed * 15.0 / 1e6 * 100);
+        END IF;
 
-        ALTER TABLE <SCHEMA>.user_lifetime_credits
-            ADD CONSTRAINT chk_cp_ulc_cents_nonneg
-            CHECK (purchased_cents >= 0 AND spent_cents >= 0);
+        -- ensure cents constraint
+        IF NOT EXISTS (
+            SELECT 1 FROM information_schema.table_constraints
+            WHERE table_schema = '<SCHEMA>' AND table_name = 'user_lifetime_credits'
+              AND constraint_name = 'chk_cp_ulc_cents_nonneg'
+        ) THEN
+            ALTER TABLE <SCHEMA>.user_lifetime_credits
+                ADD CONSTRAINT chk_cp_ulc_cents_nonneg
+                CHECK (purchased_cents >= 0 AND spent_cents >= 0);
+        END IF;
+
+        -- drop token columns whenever still present (independent of cents state)
+        IF EXISTS (
+            SELECT 1 FROM information_schema.columns
+            WHERE table_schema = '<SCHEMA>' AND table_name = 'user_lifetime_credits'
+              AND column_name = 'lifetime_tokens_consumed'
+        ) THEN
+            ALTER TABLE <SCHEMA>.user_lifetime_credits
+                DROP CONSTRAINT IF EXISTS chk_cp_ulc_consumed_nonneg,
+                DROP COLUMN IF EXISTS lifetime_tokens_purchased,
+                DROP COLUMN IF EXISTS lifetime_tokens_consumed;
+        END IF;
+    END IF;
+
+    ----------------------------------------------------------------------------
+    -- user_token_reservations -> user_credit_reservations: USD-in-cents
+    ----------------------------------------------------------------------------
+    -- rename first so every subsequent step operates on the canonical name
+    IF EXISTS (
+        SELECT 1 FROM information_schema.tables
+        WHERE table_schema = '<SCHEMA>' AND table_name = 'user_token_reservations'
+    ) AND NOT EXISTS (
+        SELECT 1 FROM information_schema.tables
+        WHERE table_schema = '<SCHEMA>' AND table_name = 'user_credit_reservations'
+    ) THEN
+        ALTER TABLE <SCHEMA>.user_token_reservations RENAME TO user_credit_reservations;
     END IF;
 
     IF EXISTS (
         SELECT 1 FROM information_schema.tables
-        WHERE table_schema = '<SCHEMA>'
-          AND table_name = 'user_token_reservations'
-    ) AND NOT EXISTS (
-        SELECT 1 FROM information_schema.columns
-        WHERE table_schema = '<SCHEMA>'
-          AND table_name = 'user_token_reservations'
-          AND column_name = 'usd_reserved_cents'
+        WHERE table_schema = '<SCHEMA>' AND table_name = 'user_credit_reservations'
     ) THEN
-        ALTER TABLE <SCHEMA>.user_token_reservations
-            ADD COLUMN usd_reserved_cents BIGINT NOT NULL DEFAULT 0,
-            ADD COLUMN actual_spent_cents BIGINT DEFAULT NULL;
+        -- add + back-fill cents columns, one-shot (only when absent)
+        IF NOT EXISTS (
+            SELECT 1 FROM information_schema.columns
+            WHERE table_schema = '<SCHEMA>' AND table_name = 'user_credit_reservations'
+              AND column_name = 'usd_reserved_cents'
+        ) THEN
+            ALTER TABLE <SCHEMA>.user_credit_reservations
+                ADD COLUMN usd_reserved_cents BIGINT NOT NULL DEFAULT 0,
+                ADD COLUMN actual_spent_cents BIGINT DEFAULT NULL;
 
-        UPDATE <SCHEMA>.user_token_reservations
-            SET usd_reserved_cents = ROUND(tokens_reserved * 15.0 / 1e6 * 100),
-                actual_spent_cents = CASE WHEN tokens_used IS NULL THEN NULL
-                                          ELSE ROUND(tokens_used * 15.0 / 1e6 * 100) END;
+            UPDATE <SCHEMA>.user_credit_reservations
+                SET usd_reserved_cents = ROUND(tokens_reserved * 15.0 / 1e6 * 100),
+                    actual_spent_cents = CASE WHEN tokens_used IS NULL THEN NULL
+                                              ELSE ROUND(tokens_used * 15.0 / 1e6 * 100) END;
+        END IF;
 
-        ALTER TABLE <SCHEMA>.user_token_reservations
-            ADD CONSTRAINT chk_cp_utr_cents_nonneg
-            CHECK (usd_reserved_cents >= 0 AND (actual_spent_cents IS NULL OR actual_spent_cents >= 0));
+        -- ensure cents constraints
+        IF NOT EXISTS (
+            SELECT 1 FROM information_schema.table_constraints
+            WHERE table_schema = '<SCHEMA>' AND table_name = 'user_credit_reservations'
+              AND constraint_name = 'chk_cp_utr_cents_nonneg'
+        ) THEN
+            ALTER TABLE <SCHEMA>.user_credit_reservations
+                ADD CONSTRAINT chk_cp_utr_cents_nonneg
+                CHECK (usd_reserved_cents >= 0 AND (actual_spent_cents IS NULL OR actual_spent_cents >= 0));
+        END IF;
+
+        IF NOT EXISTS (
+            SELECT 1 FROM information_schema.table_constraints
+            WHERE table_schema = '<SCHEMA>' AND table_name = 'user_credit_reservations'
+              AND constraint_name = 'chk_cp_utr_actual_le_reserved'
+        ) THEN
+            ALTER TABLE <SCHEMA>.user_credit_reservations
+                ADD CONSTRAINT chk_cp_utr_actual_le_reserved
+                CHECK (actual_spent_cents IS NULL OR actual_spent_cents <= usd_reserved_cents);
+        END IF;
+
+        -- drop token columns whenever still present (independent of cents state)
+        IF EXISTS (
+            SELECT 1 FROM information_schema.columns
+            WHERE table_schema = '<SCHEMA>' AND table_name = 'user_credit_reservations'
+              AND column_name = 'tokens_reserved'
+        ) THEN
+            ALTER TABLE <SCHEMA>.user_credit_reservations
+                DROP CONSTRAINT IF EXISTS chk_cp_utr_used_le_reserved,
+                DROP COLUMN IF EXISTS tokens_reserved,
+                DROP COLUMN IF EXISTS tokens_used;
+        END IF;
     END IF;
 END $$;

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/ops/deployment/sql/chatbot/wallet-usd-native.sql
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/ops/deployment/sql/chatbot/wallet-usd-native.sql
@@ -1,0 +1,73 @@
+-- SPDX-License-Identifier: MIT
+-- Copyright (c) 2026 Elena Viter
+--
+-- Wallet USD-native (cents) one-time, idempotent migration. Adds the authoritative
+-- USD-in-cents columns to a previously-deployed project schema:
+--   user_lifetime_credits   -> purchased_cents, spent_cents
+--   user_token_reservations -> usd_reserved_cents, actual_spent_cents
+-- Replace <SCHEMA> with the project schema (e.g. kdcube_<tenant>_<project>) before
+-- applying, mirroring deploy-kdcube-proj-schema.sql.
+--
+-- Runs BEFORE the schema provision (deploy-kdcube-proj-schema.sql). The provision's
+-- CREATE TABLE carries these columns for fresh schemas; this migration carries them
+-- for existing ones. The back-fill runs ONCE, inside the column guard, converting the
+-- legacy token columns at the sonnet-4-5 reference rate (15 USD / 1M output tokens)
+-- under which all existing credits were purchased -- keeping the migration
+-- balance-neutral. The token columns are kept as display-only.
+--
+-- Each block is guarded on table existence AND column absence, so the file is a clean
+-- no-op on a fresh schema (tables absent, pre-provision) and on a re-run (columns
+-- present).
+--
+-- TEMPORARY: remove this file (and its entry in apply_project_migrations) once every
+-- environment has the cents columns.
+
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM information_schema.tables
+        WHERE table_schema = '<SCHEMA>'
+          AND table_name = 'user_lifetime_credits'
+    ) AND NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = '<SCHEMA>'
+          AND table_name = 'user_lifetime_credits'
+          AND column_name = 'spent_cents'
+    ) THEN
+        ALTER TABLE <SCHEMA>.user_lifetime_credits
+            ADD COLUMN purchased_cents BIGINT NOT NULL DEFAULT 0,
+            ADD COLUMN spent_cents     BIGINT NOT NULL DEFAULT 0;
+
+        UPDATE <SCHEMA>.user_lifetime_credits
+            SET purchased_cents = ROUND(lifetime_usd_purchased * 100),
+                spent_cents     = ROUND(lifetime_tokens_consumed * 15.0 / 1e6 * 100);
+
+        ALTER TABLE <SCHEMA>.user_lifetime_credits
+            ADD CONSTRAINT chk_cp_ulc_cents_nonneg
+            CHECK (purchased_cents >= 0 AND spent_cents >= 0);
+    END IF;
+
+    IF EXISTS (
+        SELECT 1 FROM information_schema.tables
+        WHERE table_schema = '<SCHEMA>'
+          AND table_name = 'user_token_reservations'
+    ) AND NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = '<SCHEMA>'
+          AND table_name = 'user_token_reservations'
+          AND column_name = 'usd_reserved_cents'
+    ) THEN
+        ALTER TABLE <SCHEMA>.user_token_reservations
+            ADD COLUMN usd_reserved_cents BIGINT NOT NULL DEFAULT 0,
+            ADD COLUMN actual_spent_cents BIGINT DEFAULT NULL;
+
+        UPDATE <SCHEMA>.user_token_reservations
+            SET usd_reserved_cents = ROUND(tokens_reserved * 15.0 / 1e6 * 100),
+                actual_spent_cents = CASE WHEN tokens_used IS NULL THEN NULL
+                                          ELSE ROUND(tokens_used * 15.0 / 1e6 * 100) END;
+
+        ALTER TABLE <SCHEMA>.user_token_reservations
+            ADD CONSTRAINT chk_cp_utr_cents_nonneg
+            CHECK (usd_reserved_cents >= 0 AND (actual_spent_cents IS NULL OR actual_spent_cents >= 0));
+    END IF;
+END $$;

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/ops/deployment/sql/db_deployment.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/ops/deployment/sql/db_deployment.py
@@ -79,6 +79,7 @@ def project_schema(tenant: str, project: str) -> str:
 PROJECT_MIGRATION_FILES = [
     "economics-plans-corrections.sql",   # `plans` rename + new fields
     "conv-messages-agent-id.sql",        # conv_messages.agent_id column
+    "wallet-usd-native.sql",             # USD-native wallet cents columns + back-fill
 ]
 
 


### PR DESCRIPTION
## Make the user wallet USD-native

### Why
The user wallet (lifetime credits) was **token-native**: balance = `tokens_purchased − tokens_consumed`, with USD derived at display time from the live `llm_reference_service` rate. Consequence: changing the reference model **re-valued already-paid credits** in USD. Plan and project budgets were already USD-native and didn't have this problem. This PR makes the wallet USD-native too, so stored value is fixed and the reference only affects the transient token projection used for admission.

### What changed

**Schema**
- `user_lifetime_credits`: balance is now `purchased_cents − spent_cents − Σ active usd_reserved_cents`. Token columns (`lifetime_tokens_purchased/consumed`) removed.
- `user_token_reservations` → **renamed `user_credit_reservations`**; holds are `usd_reserved_cents`/`actual_spent_cents` (homogeneous with the plan reservation's `amount_cents`/`actual_spent_cents`). Token columns removed.
- `CREATE TABLE` builds the target shape for fresh installs; `drop-schema` updated.

**Migration** (`wallet-usd-native.sql`, registered in `PROJECT_MIGRATION_FILES`, runs pre-provision)
- Self-healing and idempotent: each step independently guarded, converges from any intermediate state (fresh / token-native / partially migrated).
- Adds + back-fills cents **once** (only when absent — never re-runs off now-stale token columns), ensures the cents constraints, renames the table, and drops the token columns whenever still present.
- Back-fill uses the sonnet-4-5 rate (the rate every credit to date was priced at) → balance-neutral cutover.

**Backend**
- `UserCreditsManager`: cents are authoritative; `reserve/commit/consume/add/refund/restore` take `usd_cents` only. `get_available_cents()` authoritative; `get_lifetime_balance()` derives tokens from cents only for the admission split feeder. Dead `deduct_lifetime_tokens` removed.
- `funding_flow`: wallet hold and settle in cents — the wallet is charged its **USD share of the real cost** (reference-independent); the allocator stays token-based and the RL-quota cascade converts uncovered USD back to tokens.
- `control_plane` request-lineage reads `user_credit_reservations` and exposes `reserved_usd`/`spent_usd`.

**UI**
- `EconomicsDashboard` + `UserBillingDashboard`: wallet reservations show USD (Reserved/Spent). The RL token-quota display ("tokens held by in-flight requests") is unchanged — it is genuinely token-native (throughput quota).

**Docs**: economics READMEs updated to USD-native wallet, new table name, USD-only manager signatures; removed the stale "balance re-values on reference change" claim.