### PR TITLE
fix(chat): consume external queue and fence live turn ownership

### DIFF
--- a/app/ai-app/docs/arch/ingress/events-inception-README.md
+++ b/app/ai-app/docs/arch/ingress/events-inception-README.md
@@ -199,6 +199,12 @@ prevents accepted external events from being unordered relative to each other;
 lane state `T` coordinates the race between ingress wakeups, proc scheduling,
 reader acceptance, and handler close.
 
+The Postgres conversation-state row can describe the conversation as
+`in_progress`, but it does not prove that a processor or ReAct reader is alive.
+Ingress must not infer takeover authority from that row's age. Live ownership
+and stale-owner recovery belong to the processor claim/start markers, Redis
+event-source owner lease, and owner-fenced lane state `T`.
+
 For idle non-reactive authored events, the current implementation records only
 to the Redis external-event source and leaves the conversation state idle. That
 is useful for low-latency event admission, but it is not sufficient as permanent

--- a/app/ai-app/docs/arch/proc/events-orchestration-README.md
+++ b/app/ai-app/docs/arch/proc/events-orchestration-README.md
@@ -56,11 +56,12 @@ Processor
   else:
     validate item directly as ExternalEventPayload
   build communicator/accounting/runtime context
-  invoke bundle @on_reactive_event
+  invoke bundle @on_reactive_event once for this scheduled processor turn
   |
   v
 Bundle / ReAct
-  folds lane events into the timeline before model rendering
+  ContextBrowser performs the initial fold, then its live listener folds later
+  lane events into the same turn before subsequent model renders
 ```
 
 The important boundary is:
@@ -69,6 +70,11 @@ The important boundary is:
 - the Redis event lane owns the ordered event body;
 - lane state `T` synchronizes proc, the handler, and the reader;
 - the bundle/ReAct runtime owns timeline folding.
+
+The processor rotates across every gateway-admitted user type:
+`privileged`, `registered`, `anonymous`, `paid`, and `external`. Here
+`external` names an identity/queue lane. It is unrelated to the
+`external_event` event kind stored in the conversation lane.
 
 ## Queue Item Kinds
 
@@ -128,6 +134,11 @@ When proc claims work:
 8. invoke the bundle through the normal reactive-entrypoint path when the wake
    schedules work.
 
+`@on_reactive_event` is the turn-start entrypoint. It is not called once per
+event accepted during a living turn. After the entrypoint constructs the
+workflow, `ContextBrowser` owns the Redis lane listener and invokes ReAct's
+registered external-event hook for each accepted live batch.
+
 `schedule_consumer_from_wake(...)` may mark `T.consumer.status = scheduled`.
 That is only a duplicate-start reservation for the proc/app-load boundary. It
 does not prove that an old open handler is still alive. When the invoked turn
@@ -147,6 +158,13 @@ The live ReAct handler opens the lane state for its turn. The ContextBrowser
 reader drains the lane and folds accepted events into the in-memory timeline
 only while `T.handler.status == open`. Accepting lane events and advancing
 `T.last_processed_*` happens under the same short state lock.
+
+Both the background listener and ReAct's direct phase watcher enter through
+`ContextBrowser.apply_live_external_events()`. That method calls
+`accept_events_for_open_handler(...)`; neither path may call the raw block
+folding method directly. If `T.handler.turn_id` names a newer turn, the old
+phase is cancelled with `ExternalEventLaneTurnSuperseded` before its fold
+callback runs.
 
 When ReAct has a candidate final answer, its close gate compares the last event
 timestamp it rendered with `T.last_processed_event_timestamp`. If the reader
@@ -180,7 +198,8 @@ Proc does not own:
 - timeline block production details;
 - ReAct projection/announce/compaction behavior;
 - persistent product storage for idle non-reactive events;
-- final model-visible rendering.
+- final model-visible rendering;
+- liveness inferred from the age of a Postgres conversation-state row.
 
 Those live in the SDK event-source subsystem, ReAct `ContextBrowser`, and
 bundle/application code.

--- a/app/ai-app/docs/arch/proc/processor-arch-README.md
+++ b/app/ai-app/docs/arch/proc/processor-arch-README.md
@@ -123,6 +123,13 @@ Current user-type lanes:
 - `registered`
 - `anonymous`
 - `paid`
+- `external`
+
+`external` is the gateway user type used by external identities such as an
+unconnected Telegram user. It is a processor queue lane, not the
+`external_event` conversation-event kind. Every user type admitted by gateway
+backpressure must appear in the processor rotation; otherwise ingress can
+successfully enqueue work that no processor ever claims or reaps.
 
 Ingress enqueues with `LPUSH`.
 Processor claims with `BRPOPLPUSH`.
@@ -260,7 +267,8 @@ Current implementation note:
 
 High-level flow:
 
-1. rotate through user-type lanes in `("privileged", "registered", "anonymous", "paid")`
+1. rotate fairly through user-type lanes in
+   `("privileged", "registered", "anonymous", "paid", "external")`
 2. claim one item with `BRPOPLPUSH(ready -> inflight)`
 3. parse payload and derive `task_id`
 4. acquire the per-task Redis lock
@@ -315,6 +323,11 @@ On terminal completion:
   - ack the inflight claim
   - set conversation state to `error`
   - emit `conv_status` with `completion="error"`
+
+The durable Postgres conversation-state row is an output/admission projection,
+not the running-turn lease. Live ownership and stale-owner reclaim are decided
+from the Redis event-lane handler/consumer state and owner lease. A row being
+old is not, by itself, permission to start a competing turn.
 
 ### 4.4.1 Tool execution inside proc-owned turns
 
@@ -461,6 +474,9 @@ If a running task gets cancelled during shutdown:
 - proc does not ack the inflight claim
 - proc leaves the started marker in place
 - external child runtimes are explicitly terminated
+- ReAct v2/v3 closes its ContextBrowser event handler, which stops and releases
+  the independently running lane-listener lease and performs the fenced
+  handoff check
 - recovery later resolves the task as interrupted rather than replaying it
 
 ---

--- a/app/ai-app/docs/sdk/events/external-events-journey-and-handling-README.md
+++ b/app/ai-app/docs/sdk/events/external-events-journey-and-handling-README.md
@@ -118,6 +118,7 @@ external_events[] from client/widget/webhook/API
          no fresh consumer/start    -> T.consumer = scheduled
   -> bundle-load/on-message fence
        resolve/load bundle, bind request context, invoke bundle turn entrypoint
+       once for this scheduled proc task
   -> ReAct ContextBrowser
        open handler in T for this turn; reclaim stale open handler if there is
        no fresh active consumer heartbeat
@@ -125,6 +126,8 @@ external_events[] from client/widget/webhook/API
        read L after timeline cursor
        accept_events_for_open_handler(...)
        fold events into TL only if still owner
+       later live events stay inside this turn; they do not invoke the bundle
+       entrypoint again
   -> ReAct loop
        consume TL
   -> finish_turn
@@ -178,8 +181,9 @@ with event_id + sequence           batch has reactive work
         |                               v
         |                         chat-proc process
         |                         load/resolve the bundle instance
-        |                         then invoke its on-message turn entrypoint
-        |                         (for ReAct bundles: @on_reactive_event / workflow run)
+        |                         then invoke its on-message turn entrypoint once
+        |                         (for ReAct bundles:
+        |                         @on_reactive_event / workflow run)
         |                               |
         v                               v
 chat-proc process
@@ -264,7 +268,9 @@ matter:
 | Handler open | `T.handler_turn_id` must be this turn after `open_handler(...)`. | Raise `ExternalEventLaneTurnSuperseded`. |
 | Consumer acknowledgement | Consumer heartbeat updates are guarded by handler owner. | The stale turn cannot refresh liveness for a different owner. |
 | Initial and live event fold | `accept_events_for_open_handler(...)` requires `T.handler_turn_id` to still be this turn before calling the fold/materialization callback and advancing processed cursors. | Raise `ExternalEventLaneTurnSuperseded` on handler mismatch. |
+| ReAct decision/tool phase watch | The backup phase watcher calls `ContextBrowser.apply_live_external_events()`, the same owner-fenced path used by the background listener. | Cancel the old active phase; never dispatch or fold the event through an unfenced fallback. |
 | Finish turn | `finish_turn` calls the event-lane current-owner assertion before answer emission and final turn persistence. | Raise `ExternalEventLaneTurnSuperseded`; the normal turn exception path abandons this turn. |
+| Proc-task cancellation | ReAct closes the ContextBrowser handler before propagating `CancelledError`. | Stop/release the independent listener lease and leave the started inflight task to normal interrupted-task recovery. |
 
 This is the idempotence rule: a lane event is folded and cursor-advanced only
 for the turn that still owns the lane, and a superseded turn does not publish
@@ -353,6 +359,7 @@ T.consumer_status                active | scheduled | none
 T.consumer_status_at
 
 T.last_processed_event_timestamp
+T.last_processed_event_id
 T.last_processed_reactive_event_timestamp
 ```
 
@@ -360,6 +367,9 @@ T.last_processed_reactive_event_timestamp
 state was last written. The handler-liveness signal is a fresh
 `T.consumer_status_at` written by an active reader/consumer as an
 acknowledgement that it is still consuming this lane.
+
+`T.last_processed_event_id` is paired with the processed timestamp so the
+close gate can distinguish multiple events accepted with the same timestamp.
 
 ```text
 fresh active consumer_status_at
@@ -433,6 +443,12 @@ normal turn exception path:
 exception path. The important property is that the stale turn is discarded as
 a wrong turn, while the newer owner continues from the last committed turn in
 the index.
+
+Cancellation is a separate path from supersession. The processor may cancel a
+turn because of shutdown or its watchdog. ReAct v2/v3 then closes the
+ContextBrowser handler before re-raising cancellation, so the independently
+scheduled lane listener cannot continue refreshing an owner lease after its
+processor turn has stopped.
 
 This means bundles can use the same SSE/Socket.IO-backed lane for explicit
 conversation events. An event can be useful to the bundle even when it should

--- a/app/ai-app/docs/service/comm/conversation-event-bus-and-data-bus-README.md
+++ b/app/ai-app/docs/service/comm/conversation-event-bus-and-data-bus-README.md
@@ -60,7 +60,8 @@ Data Bus handler explicitly bridges a result back into the conversation bus.
 ```text
 conversation event:
   target.agent_id -> tenant/project/user/conversation/agent_id lane
-  -> @on_reactive_event run(...)
+  -> reactive wake -> one @on_reactive_event run(...)
+  -> ContextBrowser initial/live lane drains inside that running turn
 
 data bus message:
   messages[].subject -> app Data Bus stream
@@ -83,6 +84,16 @@ browser/chat client
   -> timeline blocks / announce / summaries / compaction
   -> ReAct agent
 ```
+
+`@on_reactive_event` starts a scheduled turn; it is not invoked again for each
+event that arrives while that turn is alive. The running `ContextBrowser` owns
+those later lane reads and sends accepted events through the ReAct
+external-event hook under the Redis handler-owner fence.
+
+The durable Postgres conversation-state record is a projection used by UI and
+admission logic. It is not the conversation-event-bus lease. Turn liveness,
+reclaim, and permission to fold an event are determined by the Redis event
+source owner lease and lane state `T`.
 
 Use this bus when the user action should influence the current or next agent
 turn.

--- a/app/ai-app/docs/service/comm/conversation-event-bus-orchestrator-README.md
+++ b/app/ai-app/docs/service/comm/conversation-event-bus-orchestrator-README.md
@@ -51,6 +51,7 @@ T.handler.status                         open | closed
 T.handler.status_at
 
 T.last_processed_event_timestamp
+T.last_processed_event_id
 T.last_processed_reactive_event_timestamp
 
 T.consumer.status                        active | scheduled | none
@@ -61,6 +62,8 @@ T.consumer.status_at
 types. `T.last_processed_reactive_event_timestamp` is the same cursor for
 reactive events only. Both values come from event-envelope timestamps. They
 are not Redis Stream ids, sequence numbers, or wall-clock timestamps.
+`T.last_processed_event_id` disambiguates two accepted events that carry the
+same timestamp.
 
 `T.consumer.status_at` is a real lane-local acknowledgement timestamp written
 by proc or the Reader/Consumer. It is not derived from processor heartbeat.
@@ -73,6 +76,7 @@ by proc or the Reader/Consumer. It is not derived from processor heartbeat.
 | Stream | Store accepted lane events. |
 | Wake queue | Carry a nudge for the lane, including the first reactive event timestamp. |
 | Proc | Read a wake and, under `lock(T)`, decide whether to set `T.consumer.status = scheduled`. |
+| Bundle `@on_reactive_event` entrypoint | Start one scheduled workflow turn. It is invoked once for that proc task, not once for every later event in the lane. |
 | BaseWorkflow / ContextBrowser handler setup | When the turn runtime is constructed and before timeline load, write `T.handler.turn_id`, `T.handler.status = open`, and `T.handler.status_at`. |
 | ReAct handler close gate | Close the handler only if the candidate answer saw all processed lane events. |
 | Reader/Consumer | Start after handler open, set `T.consumer.status = active`, accept lane events into the live turn path while `T.handler.status == open`, and update `T.last_processed_*`. |
@@ -160,6 +164,7 @@ Initial Lane Drain / Live Lane Drain
   for accepted entries:
     lock(T)
       if T.handler.status == open:
+        require T.handler.turn_id == current runtime turn id
         contribute entries to the live turn path
         mark the source consumed for accepted entries
         update T.last_processed_event_timestamp
@@ -207,6 +212,12 @@ Reader / Consumer Release
 Ingress does not decide whether the conversation is idle or busy. It accepts
 the batch into the lane and wakes proc when reactive work exists. The lane and
 `T` decide scheduling and reader acceptance.
+
+The Postgres `conversation.state` record is not part of this ownership table.
+It remains useful as a durable UI/admission projection, but its timestamp is
+not a lease or heartbeat and must not authorize stale-owner takeover. The live
+authorities are the processor claim/start markers, the event-source owner
+lease, and the owner-fenced fields in `T`.
 
 Reactive ingress has one transaction boundary: the lane write and wake enqueue
 stand or fall together. If the processor queue rejects the wake because of
@@ -260,6 +271,12 @@ before it could reclaim the stale owner.
 `now` must come from the same clock source used by the state table. The first
 implementation uses Redis-backed state and may use process UTC timestamps
 until Redis `TIME` is wired.
+
+The current owner-freshness window is configured by
+`KDCUBE_EVENT_BUS_OPEN_HANDLER_CONSUMER_TTL_SECONDS` and defaults to 30
+seconds. Missing, non-numeric, zero, or negative values fall back to that
+default. This setting controls Redis lane-owner reclaim only; it does not
+change Postgres conversation-state handling.
 
 ## Probe-Based Wakeup
 

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/processor.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/processor.py
@@ -378,7 +378,12 @@ class EnhancedChatRequestProcessor:
       - Handles graceful shutdown
     """
 
-    QUEUE_ORDER: Iterable[str] = ("privileged", "registered", "anonymous", "paid")
+    # Must cover every user_type the gateway admits into the prompt queues
+    # (see infra/gateway/backpressure.QUEUE_USER_TYPES) — a queue that is
+    # admitted but absent here is never polled, so its tasks are never
+    # consumed. "external" is polled last (lowest priority), mirroring how
+    # backpressure gates it with the anonymous capacity ratio.
+    QUEUE_ORDER: Iterable[str] = ("privileged", "registered", "anonymous", "paid", "external")
 
     def __init__(
             self,

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/processor.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/processor.py
@@ -379,10 +379,9 @@ class EnhancedChatRequestProcessor:
     """
 
     # Must cover every user_type the gateway admits into the prompt queues
-    # (see infra/gateway/backpressure.QUEUE_USER_TYPES) — a queue that is
-    # admitted but absent here is never polled, so its tasks are never
-    # consumed. "external" is polled last (lowest priority), mirroring how
-    # backpressure gates it with the anonymous capacity ratio.
+    # (see infra/gateway/backpressure.QUEUE_USER_TYPES). A queue that is
+    # admitted but absent here is never claimed or reaped. Tuple order defines
+    # the round-robin rotation only; it is not a priority ranking.
     QUEUE_ORDER: Iterable[str] = ("privileged", "registered", "anonymous", "paid", "external")
 
     def __init__(

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/react/v2/runtime.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/react/v2/runtime.py
@@ -21,6 +21,7 @@ from langgraph.graph import StateGraph, END
 from kdcube_ai_app.apps.chat.emitters import ChatCommunicator
 from kdcube_ai_app.apps.chat.ids import new_exec_id
 from kdcube_ai_app.apps.chat.sdk.protocol import ExternalEventPayload
+from kdcube_ai_app.apps.chat.sdk.events.event_bus.exceptions import ExternalEventLaneTurnSuperseded
 from kdcube_ai_app.apps.chat.sdk.solutions.react.browser import ContextBrowser
 from kdcube_ai_app.apps.chat.sdk.solutions.infra import emit_event
 from kdcube_ai_app.apps.chat.sdk.runtime.execution import execute_tool, _safe_label
@@ -380,32 +381,31 @@ class ReactSolverV2:
                     f"[react.v2] phase={phase} direct external-event watch received count={len(events)} turn_id={self.scratchpad.turn_id}",
                     level="INFO",
                 )
-                apply_events = getattr(ctx_browser, "apply_external_events", None)
-                changed = 0
-                if apply_events is not None and timeline is not None:
-                    maybe = apply_events(events, call_hooks=True)
-                    changed = int(await maybe if asyncio.iscoroutine(maybe) else maybe or 0)
-                else:
-                    for event in events:
-                        stream_id = str(getattr(event, "stream_id", "") or "")
-                        if stream_id:
-                            self._active_phase_external_cursor = stream_id
-                        try:
-                            handled = await self.on_external_event(
-                                type=str(getattr(event, "kind", "external") or "external"),
-                                event=event,
-                                blocks=[],
-                            )
-                            changed += int(bool(handled))
-                        except Exception:
-                            self.log.log(
-                                f"[react.v2] direct external-event dispatch failure phase={phase}: {traceback.format_exc()}",
-                                level="ERROR",
-                            )
+                apply_events = getattr(ctx_browser, "apply_live_external_events", None)
+                if not callable(apply_events):
+                    self.log.log(
+                        f"[react.v2] phase={phase} cannot apply live external events: "
+                        "ownership-fenced ContextBrowser consumer is unavailable",
+                        level="ERROR",
+                    )
+                    if not phase_task.done():
+                        phase_task.cancel()
+                    return
+                maybe = apply_events(events)
+                changed = int(await maybe if asyncio.iscoroutine(maybe) else maybe or 0)
                 if changed and self._steer_interrupt_requested:
                     return
             except asyncio.CancelledError:
                 raise
+            except ExternalEventLaneTurnSuperseded as exc:
+                self.log.log(
+                    f"[react.v2] phase={phase} cancelled because external-event lane ownership moved "
+                    f"turn_id={exc.turn_id or '-'} owner_turn_id={exc.owner_turn_id or '-'}",
+                    level="INFO",
+                )
+                if not phase_task.done():
+                    phase_task.cancel()
+                return
             except Exception:
                 self.log.log(
                     f"[react.v2] external-event phase watcher failure phase={phase}: {traceback.format_exc()}",
@@ -1590,11 +1590,31 @@ class ReactSolverV2:
         allowed_plugins: List[str],
         allowed_tool_names_by_alias: Dict[str, Any] | None = None,
     ):
-        with self._bind_runtime_role_models():
-            return await self._run_impl(
-                allowed_plugins=allowed_plugins,
-                allowed_tool_names_by_alias=allowed_tool_names_by_alias,
-            )
+        try:
+            with self._bind_runtime_role_models():
+                return await self._run_impl(
+                    allowed_plugins=allowed_plugins,
+                    allowed_tool_names_by_alias=allowed_tool_names_by_alias,
+                )
+        except asyncio.CancelledError:
+            close_handler = getattr(self.ctx_browser, "close_external_event_handler", None) if self.ctx_browser else None
+            if callable(close_handler):
+                try:
+                    maybe = close_handler()
+                    if asyncio.iscoroutine(maybe):
+                        await asyncio.shield(maybe)
+                except asyncio.CancelledError:
+                    self.log.log(
+                        f"[react.v2] cancellation interrupted external-event handler cleanup "
+                        f"turn_id={self.scratchpad.turn_id}",
+                        level="WARNING",
+                    )
+                except Exception:
+                    self.log.log(
+                        f"[react.v2] failed to close external-event handler after cancellation:\n{traceback.format_exc()}",
+                        level="ERROR",
+                    )
+            raise
 
     async def _run_impl(
         self,

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/react/v2/test_runtime.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/react/v2/test_runtime.py
@@ -8,6 +8,7 @@ from types import SimpleNamespace
 
 import pytest
 
+from kdcube_ai_app.apps.chat.sdk.events.event_bus.exceptions import ExternalEventLaneTurnSuperseded
 from kdcube_ai_app.apps.chat.sdk.solutions.react.v2.runtime import ReactSolverV2
 from kdcube_ai_app.apps.chat.sdk.solutions.react.round import ReactRound
 
@@ -27,6 +28,8 @@ def _solver_stub() -> ReactSolverV2:
     solver._steer_interrupt_requested = False
     solver._latest_steer_seq_seen = 0
     solver._last_handled_steer_seq = 0
+    solver._latest_followup_seq_seen = 0
+    solver._finalize_superseded_followup_seq = 0
     solver._latest_steer_text = ""
     solver._active_phase_task = None
     solver._active_phase_name = ""
@@ -576,13 +579,16 @@ async def test_decision_node_direct_phase_watcher_interrupts_without_browser_lis
         async def ensure_external_event_listener(self):
             self.ensure_calls += 1
 
-        async def apply_external_events(self, events, *, call_hooks):
-            assert call_hooks is True
+        async def apply_live_external_events(self, events):
             for event in events:
                 self.timeline.last_external_event_seq = int(getattr(event, "sequence", 0) or 0)
                 self.timeline.last_external_event_id = str(getattr(event, "stream_id", "") or "")
                 await self.react.on_external_event(type=str(event.kind), event=event, blocks=[{"type": "user.steer"}])
             return len(events)
+
+        async def apply_external_events(self, *args, **kwargs):
+            del args, kwargs
+            raise AssertionError("phase watcher must use the ownership-fenced live consumer")
 
         def current_turn_blocks(self):
             return []
@@ -608,6 +614,69 @@ async def test_decision_node_direct_phase_watcher_interrupts_without_browser_lis
     assert out["retry_decision"] is True
     assert out["steer_finalize_mode"] is True
     assert out["steer_interrupt"]["cancelled_phase"] == "decision"
+
+
+@pytest.mark.asyncio
+async def test_phase_watcher_cancels_when_event_lane_owner_changes():
+    solver = _solver_stub()
+    event = SimpleNamespace(
+        kind="followup",
+        sequence=14,
+        text="new request",
+        message_id="evt_14",
+        stream_id="1775871766337-0",
+    )
+
+    class _EventSource:
+        async def read_since(self, cursor, *, limit=None):
+            del cursor, limit
+            return [event]
+
+    class _Browser:
+        timeline = SimpleNamespace(last_external_event_id="", last_external_event_seq=0)
+        runtime_ctx = SimpleNamespace(external_event_source=_EventSource())
+
+        async def ensure_external_event_listener(self):
+            return None
+
+        async def apply_live_external_events(self, events):
+            assert events == [event]
+            raise ExternalEventLaneTurnSuperseded(
+                turn_id="turn-1",
+                owner_turn_id="turn-2",
+                handler_status="open",
+                phase="accept_live_external_events",
+            )
+
+    solver.ctx_browser = _Browser()
+
+    with pytest.raises(asyncio.CancelledError):
+        await solver._run_cancellable_phase(phase="decision", coro=asyncio.sleep(30))
+
+
+@pytest.mark.asyncio
+async def test_run_closes_external_event_handler_when_cancelled():
+    solver = _solver_stub()
+    close_calls = 0
+
+    class _Browser:
+        runtime_ctx = SimpleNamespace(agent_role_models={})
+
+        async def close_external_event_handler(self):
+            nonlocal close_calls
+            close_calls += 1
+
+    async def _cancelled_run(**kwargs):
+        del kwargs
+        raise asyncio.CancelledError
+
+    solver.ctx_browser = _Browser()
+    solver._run_impl = _cancelled_run
+
+    with pytest.raises(asyncio.CancelledError):
+        await solver.run(allowed_plugins=[], allowed_tool_names_by_alias={})
+
+    assert close_calls == 1
 
 
 

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/react/v3/runtime.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/react/v3/runtime.py
@@ -22,6 +22,7 @@ from langgraph.graph import StateGraph, END
 from kdcube_ai_app.apps.chat.emitters import ChatCommunicator
 from kdcube_ai_app.apps.chat.ids import new_exec_id
 from kdcube_ai_app.apps.chat.sdk.protocol import ExternalEventPayload
+from kdcube_ai_app.apps.chat.sdk.events.event_bus.exceptions import ExternalEventLaneTurnSuperseded
 from kdcube_ai_app.apps.chat.sdk.solutions.react.browser import ContextBrowser
 from kdcube_ai_app.apps.chat.sdk.solutions.infra import emit_event
 from kdcube_ai_app.apps.chat.sdk.runtime.execution import execute_tool, _safe_label
@@ -479,32 +480,31 @@ class ReactSolverV2:
                     f"[react.v3] phase={phase} direct external-event watch received count={len(events)} turn_id={self.scratchpad.turn_id}",
                     level="INFO",
                 )
-                apply_events = getattr(ctx_browser, "apply_external_events", None)
-                changed = 0
-                if apply_events is not None and timeline is not None:
-                    maybe = apply_events(events, call_hooks=True)
-                    changed = int(await maybe if asyncio.iscoroutine(maybe) else maybe or 0)
-                else:
-                    for event in events:
-                        stream_id = str(getattr(event, "stream_id", "") or "")
-                        if stream_id:
-                            self._active_phase_external_cursor = stream_id
-                        try:
-                            handled = await self.on_external_event(
-                                type=str(getattr(event, "kind", "external") or "external"),
-                                event=event,
-                                blocks=[],
-                            )
-                            changed += int(bool(handled))
-                        except Exception:
-                            self.log.log(
-                                f"[react.v3] direct external-event dispatch failure phase={phase}: {traceback.format_exc()}",
-                                level="ERROR",
-                            )
+                apply_events = getattr(ctx_browser, "apply_live_external_events", None)
+                if not callable(apply_events):
+                    self.log.log(
+                        f"[react.v3] phase={phase} cannot apply live external events: "
+                        "ownership-fenced ContextBrowser consumer is unavailable",
+                        level="ERROR",
+                    )
+                    if not phase_task.done():
+                        phase_task.cancel()
+                    return
+                maybe = apply_events(events)
+                changed = int(await maybe if asyncio.iscoroutine(maybe) else maybe or 0)
                 if changed and self._steer_interrupt_requested:
                     return
             except asyncio.CancelledError:
                 raise
+            except ExternalEventLaneTurnSuperseded as exc:
+                self.log.log(
+                    f"[react.v3] phase={phase} cancelled because external-event lane ownership moved "
+                    f"turn_id={exc.turn_id or '-'} owner_turn_id={exc.owner_turn_id or '-'}",
+                    level="INFO",
+                )
+                if not phase_task.done():
+                    phase_task.cancel()
+                return
             except Exception:
                 self.log.log(
                     f"[react.v3] external-event phase watcher failure phase={phase}: {traceback.format_exc()}",
@@ -2853,11 +2853,31 @@ class ReactSolverV2:
         # spawned subagent (the child inherits the parent's tool selection).
         self._run_allowed_plugins = list(allowed_plugins or [])
         self._run_allowed_tool_names_by_alias = allowed_tool_names_by_alias
-        with self._bind_runtime_role_models():
-            return await self._run_impl(
-                allowed_plugins=allowed_plugins,
-                allowed_tool_names_by_alias=allowed_tool_names_by_alias,
-            )
+        try:
+            with self._bind_runtime_role_models():
+                return await self._run_impl(
+                    allowed_plugins=allowed_plugins,
+                    allowed_tool_names_by_alias=allowed_tool_names_by_alias,
+                )
+        except asyncio.CancelledError:
+            close_handler = getattr(self.ctx_browser, "close_external_event_handler", None) if self.ctx_browser else None
+            if callable(close_handler):
+                try:
+                    maybe = close_handler()
+                    if asyncio.iscoroutine(maybe):
+                        await asyncio.shield(maybe)
+                except asyncio.CancelledError:
+                    self.log.log(
+                        f"[react.v3] cancellation interrupted external-event handler cleanup "
+                        f"turn_id={self.scratchpad.turn_id}",
+                        level="WARNING",
+                    )
+                except Exception:
+                    self.log.log(
+                        f"[react.v3] failed to close external-event handler after cancellation:\n{traceback.format_exc()}",
+                        level="ERROR",
+                    )
+            raise
 
     async def _run_impl(
         self,

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/react/v3/test_runtime.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/react/v3/test_runtime.py
@@ -8,6 +8,7 @@ from types import SimpleNamespace
 
 import pytest
 
+from kdcube_ai_app.apps.chat.sdk.events.event_bus.exceptions import ExternalEventLaneTurnSuperseded
 from kdcube_ai_app.apps.chat.sdk.solutions.react.v3.runtime import ReactSolverV2
 from kdcube_ai_app.apps.chat.sdk.solutions.react.round import ReactRound
 from kdcube_ai_app.apps.chat.sdk.solutions.react.layout import build_tool_catalog, build_tools_block
@@ -1099,13 +1100,16 @@ async def test_decision_node_direct_phase_watcher_interrupts_without_browser_lis
         async def ensure_external_event_listener(self):
             self.ensure_calls += 1
 
-        async def apply_external_events(self, events, *, call_hooks):
-            assert call_hooks is True
+        async def apply_live_external_events(self, events):
             for event in events:
                 self.timeline.last_external_event_seq = int(getattr(event, "sequence", 0) or 0)
                 self.timeline.last_external_event_id = str(getattr(event, "stream_id", "") or "")
                 await self.react.on_external_event(type=str(event.kind), event=event, blocks=[{"type": "user.steer"}])
             return len(events)
+
+        async def apply_external_events(self, *args, **kwargs):
+            del args, kwargs
+            raise AssertionError("phase watcher must use the ownership-fenced live consumer")
 
         def current_turn_blocks(self):
             return []
@@ -1131,6 +1135,69 @@ async def test_decision_node_direct_phase_watcher_interrupts_without_browser_lis
     assert out["retry_decision"] is True
     assert out["steer_finalize_mode"] is True
     assert out["steer_interrupt"]["cancelled_phase"] == "decision"
+
+
+@pytest.mark.asyncio
+async def test_phase_watcher_cancels_when_event_lane_owner_changes():
+    solver = _solver_stub()
+    event = SimpleNamespace(
+        kind="followup",
+        sequence=14,
+        text="new request",
+        message_id="evt_14",
+        stream_id="1775871766337-0",
+    )
+
+    class _EventSource:
+        async def read_since(self, cursor, *, limit=None):
+            del cursor, limit
+            return [event]
+
+    class _Browser:
+        timeline = SimpleNamespace(last_external_event_id="", last_external_event_seq=0)
+        runtime_ctx = SimpleNamespace(external_event_source=_EventSource())
+
+        async def ensure_external_event_listener(self):
+            return None
+
+        async def apply_live_external_events(self, events):
+            assert events == [event]
+            raise ExternalEventLaneTurnSuperseded(
+                turn_id="turn-1",
+                owner_turn_id="turn-2",
+                handler_status="open",
+                phase="accept_live_external_events",
+            )
+
+    solver.ctx_browser = _Browser()
+
+    with pytest.raises(asyncio.CancelledError):
+        await solver._run_cancellable_phase(phase="decision", coro=asyncio.sleep(30))
+
+
+@pytest.mark.asyncio
+async def test_run_closes_external_event_handler_when_cancelled():
+    solver = _solver_stub()
+    close_calls = 0
+
+    class _Browser:
+        runtime_ctx = SimpleNamespace(agent_role_models={})
+
+        async def close_external_event_handler(self):
+            nonlocal close_calls
+            close_calls += 1
+
+    async def _cancelled_run(**kwargs):
+        del kwargs
+        raise asyncio.CancelledError
+
+    solver.ctx_browser = _Browser()
+    solver._run_impl = _cancelled_run
+
+    with pytest.raises(asyncio.CancelledError):
+        await solver.run(allowed_plugins=[], allowed_tool_names_by_alias={})
+
+    assert close_calls == 1
 
 
 

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/tests/test_event_bus_handler_reclaim.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/tests/test_event_bus_handler_reclaim.py
@@ -12,6 +12,7 @@ not a liveness signal.
 from __future__ import annotations
 
 import datetime as _dt
+from types import SimpleNamespace
 
 import pytest
 
@@ -306,3 +307,79 @@ async def test_browser_raises_superseded_when_handler_owner_changed():
 
     assert raised_again.value.turn_id == "turn_OLD"
     assert raised_again.value.owner_turn_id == "turn_NEW"
+
+
+@pytest.mark.asyncio
+async def test_two_turn_reclaim_fences_old_browser_from_accepting_lane_events():
+    redis = _Redis()
+    source = _Source(redis=redis)
+
+    def _browser(turn_id: str) -> ContextBrowser:
+        browser = ContextBrowser(
+            runtime_ctx=RuntimeCtx(
+                tenant="tenant",
+                project="project",
+                user_id="user",
+                conversation_id="conversation",
+                turn_id=turn_id,
+                bundle_id="bundle@1",
+                external_event_source=source,
+            ),
+        )
+        browser._timeline = SimpleNamespace()
+        return browser
+
+    old_browser = _browser("turn_OLD")
+    await old_browser.open_external_event_handler()
+    old_orchestrator = old_browser._event_bus_orchestrator()
+    assert old_orchestrator is not None
+    await old_orchestrator.mark_consumer_active(turn_id="turn_OLD")
+
+    blocked_browser = _browser("turn_BLOCKED")
+    with pytest.raises(ExternalEventLaneTurnSuperseded):
+        await blocked_browser.open_external_event_handler()
+
+    state = await old_orchestrator.state()
+    state.consumer_status_at = _ago(120)
+    await old_orchestrator.table.put(state)
+
+    new_browser = _browser("turn_NEW")
+    assert await new_browser.open_external_event_handler()
+
+    old_applied = False
+    new_applied = False
+
+    async def _old_apply(events, *, call_hooks):
+        nonlocal old_applied
+        del events, call_hooks
+        old_applied = True
+        return 1
+
+    async def _new_apply(events, *, call_hooks):
+        nonlocal new_applied
+        assert call_hooks is True
+        assert len(events) == 1
+        new_applied = True
+        return 1
+
+    old_browser.apply_external_events = _old_apply
+    new_browser.apply_external_events = _new_apply
+    event = SimpleNamespace(
+        created_at="2026-07-12T10:00:00Z",
+        message_id="evt_NEW",
+        is_continuation=True,
+        consumed_at=None,
+    )
+
+    with pytest.raises(ExternalEventLaneTurnSuperseded) as raised:
+        await old_browser.apply_live_external_events([event])
+
+    assert raised.value.turn_id == "turn_OLD"
+    assert raised.value.owner_turn_id == "turn_NEW"
+    assert old_applied is False
+    assert await new_browser.apply_live_external_events([event]) == 1
+    assert new_applied is True
+
+    final_state = await old_orchestrator.state()
+    assert final_state.handler_turn_id == "turn_NEW"
+    assert final_state.consumer_status == "active"

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/tests/test_processor.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/tests/test_processor.py
@@ -902,6 +902,55 @@ async def test_prefetch_git_bundles_resolves_missing_paths_and_collects_errors(m
     ]
 
 
+def test_queue_order_covers_every_gateway_admitted_user_type():
+    # The gateway admits tasks for every user_type in QUEUE_USER_TYPES; a
+    # queue missing from QUEUE_ORDER is admitted but never polled, so its
+    # tasks sit in redis forever (production incident: "external" tasks from
+    # unconnected Telegram users were admitted and never consumed).
+    from kdcube_ai_app.infra.gateway.backpressure import QUEUE_USER_TYPES
+
+    assert set(QUEUE_USER_TYPES) == set(EnhancedChatRequestProcessor.QUEUE_ORDER)
+    # external is polled last: lowest priority, matching how backpressure
+    # gates it with the anonymous capacity ratio
+    assert EnhancedChatRequestProcessor.QUEUE_ORDER[-1] == "external"
+
+
+@pytest.mark.asyncio
+async def test_pop_any_queue_fair_polls_external_queue():
+    redis = _MinimalRedis()
+    processor = _build_processor(redis)
+    polled = []
+
+    async def _queue_claim(ready_key, inflight_key):
+        del inflight_key
+        polled.append(ready_key)
+        return None
+
+    processor._queue_claim = _queue_claim
+
+    result = await processor._legacy_pop_any_queue_fair()
+
+    assert result is None
+    assert polled == [f"queue:{ut}" for ut in EnhancedChatRequestProcessor.QUEUE_ORDER]
+    assert "queue:external" in polled
+
+
+@pytest.mark.asyncio
+async def test_requeue_stale_inflight_task_covers_external_queue():
+    redis = _MinimalRedis()
+    processor = _build_processor(redis)
+    raw_payload = json.dumps(
+        _build_task_payload("stale-external-task", user_type="external")
+    ).encode("utf-8")
+    redis.seed_list("queue:inflight:external", [raw_payload])
+
+    reclaimed = await processor._requeue_stale_inflight_tasks()
+
+    assert reclaimed == 1
+    assert redis.lists["queue:inflight:external"] == []
+    assert redis.lists["queue:external"] == [raw_payload]
+
+
 @pytest.mark.asyncio
 async def test_pop_any_queue_fair_requeues_item_if_drain_starts_after_claim():
     redis = _MinimalRedis()

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/tests/test_processor.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/tests/test_processor.py
@@ -910,9 +910,7 @@ def test_queue_order_covers_every_gateway_admitted_user_type():
     from kdcube_ai_app.infra.gateway.backpressure import QUEUE_USER_TYPES
 
     assert set(QUEUE_USER_TYPES) == set(EnhancedChatRequestProcessor.QUEUE_ORDER)
-    # external is polled last: lowest priority, matching how backpressure
-    # gates it with the anonymous capacity ratio
-    assert EnhancedChatRequestProcessor.QUEUE_ORDER[-1] == "external"
+    assert "external" in EnhancedChatRequestProcessor.QUEUE_ORDER
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Production incident

An external Telegram task was admitted into `prompt:queue:external`, but the
processor never polled that lane. The task therefore never started and the
conversation appeared permanently busy.

## Root cause

Gateway backpressure admits every user type in `QUEUE_USER_TYPES`, including
`external`. `EnhancedChatRequestProcessor.QUEUE_ORDER` omitted `external`, and
both the fair claim loop and stale-inflight reaper derive their lanes from that
tuple. Work could therefore be admitted into a ready queue that no processor
claimed or repaired.

The Postgres `conversation.state` row is not the running-turn lease. This PR
does **not** infer liveness from its age and does not implement a timestamp-based
takeover. Live ownership belongs to the processor claim/start markers, Redis
event-source owner lease, and owner-fenced event-lane state `T`.

## Changes

1. Add `external` to the processor's round-robin queue rotation. This also
   covers `queue:inflight:external` in stale pre-start recovery. Tuple position
   is rotation order, not a priority ranking.
2. Require ReAct v2/v3's direct decision/tool phase watcher to use
   `ContextBrowser.apply_live_external_events()`. It can no longer bypass
   `accept_events_for_open_handler(...)` by calling the raw fold method or a
   direct hook fallback.
3. If event-lane ownership has moved to a newer turn, cancel the old active
   ReAct phase before its fold callback can run.
4. On processor-task cancellation, ReAct v2/v3 closes the ContextBrowser event
   handler before propagating `CancelledError`, stopping and releasing the
   independently running listener lease.
5. Add a two-turn reclaim test: a fresh owner blocks a competitor; after the
   owner acknowledgement becomes stale, a new turn reclaims; the old browser
   is fenced before materialization and only the new owner accepts the event.
6. Align processor, ingress, SDK journey, and event-bus documentation on the
   same authority boundaries and on the fact that `@on_reactive_event` starts
   one scheduled turn while ContextBrowser consumes later live events inside
   that turn.

## Verification

`216 passed` across:

- processor queue/reaper tests;
- event-bus state, orchestrator, handler-reclaim, and timeline tests;
- ReAct v2/v3 runtime tests;
- ReAct v3 subagent tests;
- policy-driven early/detached tool-execution tests after rebasing onto current
  `main`.

The branch is rebased on current `main`. The rejected Postgres stale-takeover
commit was removed from branch history rather than retained as an add/revert
pair.
