### PR TITLE
release: 2026.7.15.150

### DIFF
--- a/app/ai-app/src/kdcube-ai-app/kdcube_cli/pyproject.toml
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kdcube-cli"
-version = "2026.7.11.017"
+version = "2026.7.15.150"
 description = "KDCube Apps bootstrap CLI"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/release.yaml
+++ b/release.yaml
@@ -1,17 +1,41 @@
 platform:
   repo: "kdcube-ai-app"
-  ref: "2026.7.11.017"
+  ref: "2026.7.15.150"
   description: |
-    This release follows 2026.7.10.1935 and carries public content catalogs
-    and search selectivity.
+    This release follows 2026.7.11.017 — the multi-agent & port wave.
 
-    Public content apps gain browsable catalogs: content folds render with
-    site chrome and an article rail, and providers expose a search hook so
-    catalog browsing and provider search share one surface.
+    Chartered subagents land in ReAct: an agent can fork, delegate, contribute,
+    and converge. The helper runs as a fair-scheduled turn and shows up as a
+    named participant (not "you"), with threaded visibility, tiered delegation,
+    and its own economics. A default-off subagents toggle and a third admin
+    state (offered but off) let operators gate the capability.
 
-    Search selectivity improves with all-terms-first lexical matching and
-    tier-honest catalog hints, so lexical retrieval prefers results matching
-    every query term and catalog hints state only what their tier actually
-    covers. Tier-1 doc sources that lacked updated_at stamps now carry them.
+    Agents become customizable. Pluggable per-agent capability providers expose
+    a per-user model pick; a capability inventory and composer menu let a user
+    choose tools, skills, and a model within an admin-set ceiling; capabilities
+    scope to a conversation, and the conversation list and search scope to the
+    bound agent.
+
+    A worked port example ships: ported-langgraph-agents hosts two vendored
+    LangGraph/LangChain agents behind one execute_core dispatched by agent_id.
+    It rebuilds the graph per turn (scaled serving), reuses an isolated exec
+    workspace, picks tools per agent, and runs a live code-exec widget with
+    classified error propagation and an advisory output contract. A KDCube model
+    bridge and a durable Postgres checkpointer back it, and it is part of the
+    install default.
+
+    Framework-neutral turn recording lets any run-to-completion agent reload
+    like a React one: the platform records the full conversation (prompt,
+    attachments, hosted files, and emitted objects) so reload needs no
+    in-framework timeline. Conversation-title cross-talk is fixed and
+    economics/timing replay on reload.
+
+    scene_object_action (renamed from canvas_object_action) is the file-download
+    operation a file-hosting bundle serves. Public content apps gain browsable
+    catalogs with site chrome, an article rail, a provider search hook,
+    sitemaps, and alias landing policies, plus an application-hosted website
+    registry and CDN routing. Generic OAuth connected accounts arrive, the
+    ingress honors a preassigned conversation id from the caller, and Anthropic
+    Sonnet 5, Opus 4.8, and Sonnet 4.6 pricing is added.
 config:
-  version: "2026.7.11.017"
+  version: "2026.7.15.150"


### PR DESCRIPTION
Platform release **2026.7.15.150** — the multi-agent & port wave (80 commits since 2026.7.11.017).

On merge, GitHub Actions runs `release-kdcube-platform.yml`: reads `platform.ref`, creates the git tag, builds + pushes Docker images, publishes the CLI to PyPI, and creates the GitHub Release.

**Highlights**
- Chartered subagents in ReAct: fork / delegate / contribute / converge; the helper is a named participant, threaded visibility, tiered delegation, its own economics; default-off toggle + third admin state.
- Customizable agents: per-agent capability providers + per-user model pick; capability inventory + composer menu; agent-bound chat widget; capabilities scoped to a conversation.
- ported-langgraph-agents example: two vendored LangGraph/LangChain agents behind one `execute_core` (dispatch by `agent_id`); scaled per-turn serving; reusable exec workspace; per-agent tool picker; live code-exec widget with classified errors + advisory contract; KDCube model bridge + durable Postgres checkpointer; in the install default.
- Framework-neutral turn recording: run-to-completion turns reload like React (full conversation record); title cross-talk fix; economics/timing on reload.
- `scene_object_action` (renamed from `canvas_object_action`) file download; public content catalogs (folds, site chrome, article rail, provider search hook, sitemaps, alias landing, website registry, CDN routing); generic OAuth connected accounts; preassigned conversation id honored; Anthropic Sonnet 5 / Opus 4.8 / Sonnet 4.6 pricing.

Files: `release.yaml` (ref + config.version + description), `kdcube_cli/pyproject.toml` (version).