### PR TITLE
Application-hosted (bundle-session) login + auth reconfiguration in the CLI

### DIFF
--- a/app/ai-app/deployment/docker/all_in_one_kdcube/nginx/conf/nginx_proxy.conf
+++ b/app/ai-app/deployment/docker/all_in_one_kdcube/nginx/conf/nginx_proxy.conf
@@ -97,8 +97,8 @@ http {
         # Application-hosted sites are resolved from the active app registry.
         location = / {
             proxy_pass http://chat_proc/api/integrations/site-root;
-            proxy_set_header Host              $host;
-            proxy_set_header X-Forwarded-Host  $host;
+            proxy_set_header Host              $http_host;
+            proxy_set_header X-Forwarded-Host  $http_host;
             proxy_set_header X-Real-IP         $remote_addr;
             proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
@@ -106,8 +106,8 @@ http {
 
         location ^~ /sites/ {
             proxy_pass http://chat_proc/api/integrations/sites/;
-            proxy_set_header Host              $host;
-            proxy_set_header X-Forwarded-Host  $host;
+            proxy_set_header Host              $http_host;
+            proxy_set_header X-Forwarded-Host  $http_host;
             proxy_set_header X-Real-IP         $remote_addr;
             proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
@@ -116,7 +116,7 @@ http {
         location = /api/cp-frontend-config {
             proxy_pass http://chat_api/api/cp-frontend-config;
 
-            proxy_set_header Host              $host;
+            proxy_set_header Host              $http_host;
             proxy_set_header X-Real-IP         $remote_addr;
             proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
@@ -135,7 +135,7 @@ http {
             proxy_intercept_errors on;
             error_page 502 503 504 = @service_unavailable;
 
-            proxy_set_header Host $host;
+            proxy_set_header Host $http_host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
@@ -157,7 +157,7 @@ http {
             client_max_body_size 20M;
 
             proxy_http_version 1.1;
-            proxy_set_header Host              $host;
+            proxy_set_header Host              $http_host;
             proxy_set_header X-Real-IP         $remote_addr;
             proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
@@ -175,7 +175,7 @@ http {
             proxy_pass http://chat_api/api/chat/;
 
             proxy_http_version 1.1;        # good hygiene for long-lived responses
-            proxy_set_header Host $host;
+            proxy_set_header Host $http_host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
@@ -279,7 +279,7 @@ http {
             # limit_req zone=chat_api_zone burst=10 nodelay;
 
             proxy_pass http://chat_api/profile;
-            proxy_set_header Host $host;
+            proxy_set_header Host $http_host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
@@ -294,7 +294,7 @@ http {
             # limit_req zone=monitoring_api burst=10 nodelay;
 
             proxy_pass http://chat_api/monitoring;
-            proxy_set_header Host $host;
+            proxy_set_header Host $http_host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
@@ -316,12 +316,12 @@ http {
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection $connection_upgrade;
 
-            proxy_set_header Host $host;
+            proxy_set_header Host $http_host;
             proxy_set_header Origin $http_origin;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
-            proxy_set_header X-Forwarded-Host $host;
+            proxy_set_header X-Forwarded-Host $http_host;
 
             proxy_read_timeout 600s;
             proxy_send_timeout 600s;
@@ -339,7 +339,7 @@ http {
             # Keep the URI exactly as-is for the backend
             proxy_pass http://chat_api;
 
-            proxy_set_header Host              $host;
+            proxy_set_header Host              $http_host;
             proxy_set_header X-Real-IP         $remote_addr;
             proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
@@ -358,7 +358,7 @@ http {
             # Preserve full URI for the backend
             proxy_pass http://chat_api;
 
-            proxy_set_header Host              $host;
+            proxy_set_header Host              $http_host;
             proxy_set_header X-Real-IP         $remote_addr;
             proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
@@ -379,7 +379,7 @@ http {
             # Keep the URI exactly as-is for the backend
             proxy_pass http://chat_api;
 
-            proxy_set_header Host              $host;
+            proxy_set_header Host              $http_host;
             proxy_set_header X-Real-IP         $remote_addr;
             proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
@@ -398,7 +398,7 @@ http {
             # Preserve full URI for the backend
             proxy_pass http://chat_api;
 
-            proxy_set_header Host              $host;
+            proxy_set_header Host              $http_host;
             proxy_set_header X-Real-IP         $remote_addr;
             proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
@@ -415,7 +415,7 @@ http {
 
             proxy_pass http://chat_proc;
 
-            proxy_set_header Host              $host;
+            proxy_set_header Host              $http_host;
             proxy_set_header X-Real-IP         $remote_addr;
             proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
@@ -443,7 +443,7 @@ http {
 
             proxy_pass http://chat_proc;
 
-            proxy_set_header Host              $host;
+            proxy_set_header Host              $http_host;
             proxy_set_header X-Real-IP         $remote_addr;
             proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
@@ -473,7 +473,7 @@ http {
 
             proxy_pass http://chat_proc;
 
-            proxy_set_header Host              $host;
+            proxy_set_header Host              $http_host;
             proxy_set_header X-Real-IP         $remote_addr;
             proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
@@ -505,7 +505,7 @@ http {
             # keep proxy_pass WITHOUT a path to preserve the URI as-is:
             proxy_pass http://chat_proc;
 
-            proxy_set_header Host              $host;
+            proxy_set_header Host              $http_host;
             proxy_set_header X-Real-IP         $remote_addr;
             proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
@@ -530,7 +530,7 @@ http {
 
             proxy_pass http://chat_proc;
 
-            proxy_set_header Host              $host;
+            proxy_set_header Host              $http_host;
             proxy_set_header X-Real-IP         $remote_addr;
             proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
@@ -556,7 +556,7 @@ http {
 
             proxy_pass http://events_collector;
 
-            proxy_set_header Host              $host;
+            proxy_set_header Host              $http_host;
             proxy_set_header X-Real-IP         $remote_addr;
             proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
@@ -582,7 +582,7 @@ http {
 
             proxy_pass http://chat_api;
 
-            proxy_set_header Host              $host;
+            proxy_set_header Host              $http_host;
             proxy_set_header X-Real-IP         $remote_addr;
             proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
@@ -606,7 +606,7 @@ http {
 
             proxy_pass http://chat_api;
 
-            proxy_set_header Host              $host;
+            proxy_set_header Host              $http_host;
             proxy_set_header X-Real-IP         $remote_addr;
             proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
@@ -630,7 +630,7 @@ http {
 
             proxy_pass http://chat_api;
 
-            proxy_set_header Host              $host;
+            proxy_set_header Host              $http_host;
             proxy_set_header X-Real-IP         $remote_addr;
             proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
@@ -665,7 +665,7 @@ http {
         # Web UI - fallback for SPA routing
         location / {
             proxy_pass http://web_ui;
-            proxy_set_header Host $host;
+            proxy_set_header Host $http_host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
@@ -683,7 +683,7 @@ http {
         # SPA fallback location
         location @fallback {
             proxy_pass http://web_ui;
-            proxy_set_header Host $host;
+            proxy_set_header Host $http_host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;

--- a/app/ai-app/deployment/docker/custom-ui-managed-infra/nginx/conf/nginx_proxy.conf
+++ b/app/ai-app/deployment/docker/custom-ui-managed-infra/nginx/conf/nginx_proxy.conf
@@ -98,8 +98,8 @@ http {
         # Application-hosted sites are resolved from the active app registry.
         location = / {
             proxy_pass http://chat_proc/api/integrations/site-root;
-            proxy_set_header Host              $host;
-            proxy_set_header X-Forwarded-Host  $host;
+            proxy_set_header Host              $http_host;
+            proxy_set_header X-Forwarded-Host  $http_host;
             proxy_set_header X-Real-IP         $remote_addr;
             proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
@@ -107,8 +107,8 @@ http {
 
         location ^~ /sites/ {
             proxy_pass http://chat_proc/api/integrations/sites/;
-            proxy_set_header Host              $host;
-            proxy_set_header X-Forwarded-Host  $host;
+            proxy_set_header Host              $http_host;
+            proxy_set_header X-Forwarded-Host  $http_host;
             proxy_set_header X-Real-IP         $remote_addr;
             proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
@@ -117,7 +117,7 @@ http {
         location = /api/cp-frontend-config {
             proxy_pass http://chat_api/api/cp-frontend-config;
 
-            proxy_set_header Host              $host;
+            proxy_set_header Host              $http_host;
             proxy_set_header X-Real-IP         $remote_addr;
             proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
@@ -136,7 +136,7 @@ http {
             proxy_intercept_errors on;
             error_page 502 503 504 = @service_unavailable;
 
-            proxy_set_header Host $host;
+            proxy_set_header Host $http_host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
@@ -158,7 +158,7 @@ http {
             client_max_body_size 20M;
 
             proxy_http_version 1.1;
-            proxy_set_header Host              $host;
+            proxy_set_header Host              $http_host;
             proxy_set_header X-Real-IP         $remote_addr;
             proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
@@ -176,7 +176,7 @@ http {
             proxy_pass http://chat_api/api/chat/;
 
             proxy_http_version 1.1;        # good hygiene for long-lived responses
-            proxy_set_header Host $host;
+            proxy_set_header Host $http_host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
@@ -280,7 +280,7 @@ http {
             # limit_req zone=chat_api_zone burst=10 nodelay;
 
             proxy_pass http://chat_api/profile;
-            proxy_set_header Host $host;
+            proxy_set_header Host $http_host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
@@ -295,7 +295,7 @@ http {
             # limit_req zone=monitoring_api burst=10 nodelay;
 
             proxy_pass http://chat_api/monitoring;
-            proxy_set_header Host $host;
+            proxy_set_header Host $http_host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
@@ -317,12 +317,12 @@ http {
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection $connection_upgrade;
 
-            proxy_set_header Host $host;
+            proxy_set_header Host $http_host;
             proxy_set_header Origin $http_origin;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
-            proxy_set_header X-Forwarded-Host $host;
+            proxy_set_header X-Forwarded-Host $http_host;
 
             proxy_read_timeout 600s;
             proxy_send_timeout 600s;
@@ -340,7 +340,7 @@ http {
             # Keep the URI exactly as-is for the backend
             proxy_pass http://chat_api;
 
-            proxy_set_header Host              $host;
+            proxy_set_header Host              $http_host;
             proxy_set_header X-Real-IP         $remote_addr;
             proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
@@ -359,7 +359,7 @@ http {
             # Preserve full URI for the backend
             proxy_pass http://chat_api;
 
-            proxy_set_header Host              $host;
+            proxy_set_header Host              $http_host;
             proxy_set_header X-Real-IP         $remote_addr;
             proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
@@ -380,7 +380,7 @@ http {
             # Keep the URI exactly as-is for the backend
             proxy_pass http://chat_api;
 
-            proxy_set_header Host              $host;
+            proxy_set_header Host              $http_host;
             proxy_set_header X-Real-IP         $remote_addr;
             proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
@@ -399,7 +399,7 @@ http {
             # Preserve full URI for the backend
             proxy_pass http://chat_api;
 
-            proxy_set_header Host              $host;
+            proxy_set_header Host              $http_host;
             proxy_set_header X-Real-IP         $remote_addr;
             proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
@@ -416,7 +416,7 @@ http {
 
             proxy_pass http://chat_proc;
 
-            proxy_set_header Host              $host;
+            proxy_set_header Host              $http_host;
             proxy_set_header X-Real-IP         $remote_addr;
             proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
@@ -444,7 +444,7 @@ http {
 
             proxy_pass http://chat_proc;
 
-            proxy_set_header Host              $host;
+            proxy_set_header Host              $http_host;
             proxy_set_header X-Real-IP         $remote_addr;
             proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
@@ -474,7 +474,7 @@ http {
 
             proxy_pass http://chat_proc;
 
-            proxy_set_header Host              $host;
+            proxy_set_header Host              $http_host;
             proxy_set_header X-Real-IP         $remote_addr;
             proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
@@ -506,7 +506,7 @@ http {
             # keep proxy_pass WITHOUT a path to preserve the URI as-is:
             proxy_pass http://chat_proc;
 
-            proxy_set_header Host              $host;
+            proxy_set_header Host              $http_host;
             proxy_set_header X-Real-IP         $remote_addr;
             proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
@@ -531,7 +531,7 @@ http {
 
             proxy_pass http://chat_proc;
 
-            proxy_set_header Host              $host;
+            proxy_set_header Host              $http_host;
             proxy_set_header X-Real-IP         $remote_addr;
             proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
@@ -557,7 +557,7 @@ http {
 
             proxy_pass http://events_collector;
 
-            proxy_set_header Host              $host;
+            proxy_set_header Host              $http_host;
             proxy_set_header X-Real-IP         $remote_addr;
             proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
@@ -583,7 +583,7 @@ http {
 
             proxy_pass http://chat_api;
 
-            proxy_set_header Host              $host;
+            proxy_set_header Host              $http_host;
             proxy_set_header X-Real-IP         $remote_addr;
             proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
@@ -607,7 +607,7 @@ http {
 
             proxy_pass http://chat_api;
 
-            proxy_set_header Host              $host;
+            proxy_set_header Host              $http_host;
             proxy_set_header X-Real-IP         $remote_addr;
             proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
@@ -631,7 +631,7 @@ http {
 
             proxy_pass http://chat_api;
 
-            proxy_set_header Host              $host;
+            proxy_set_header Host              $http_host;
             proxy_set_header X-Real-IP         $remote_addr;
             proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
@@ -666,7 +666,7 @@ http {
         # Web UI - fallback for SPA routing
         location / {
             proxy_pass http://web_ui;
-            proxy_set_header Host $host;
+            proxy_set_header Host $http_host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
@@ -684,7 +684,7 @@ http {
         # SPA fallback location
         location @fallback {
             proxy_pass http://web_ui;
-            proxy_set_header Host $host;
+            proxy_set_header Host $http_host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;

--- a/app/ai-app/docs/recipes/operations/install-clean-README.md
+++ b/app/ai-app/docs/recipes/operations/install-clean-README.md
@@ -1,10 +1,10 @@
 ---
 id: repo:kdcube-ai-app/app/ai-app/docs/recipes/operations/install-clean-README.md
 title: "Install KDCube: Clean Bootstrap"
-summary: "Stand up a fresh KDCube runtime with one init: the configured base complectation, the first-run checklist, start, and honest verification."
+summary: "Stand up a fresh KDCube runtime with one init: application-hosted login, the configured base complectation, the optional Telegram companion, the first-run checklist, start, and honest verification."
 status: active
-tags: ["operations", "install", "bootstrap", "cli", "kdcube-cli"]
-updated_at: 2026-07-07
+tags: ["operations", "install", "bootstrap", "cli", "kdcube-cli", "auth"]
+updated_at: 2026-07-17
 see_also:
   - repo:kdcube-ai-app/app/ai-app/docs/recipes/operations/operate-runtime-README.md
   - repo:kdcube-ai-app/app/ai-app/docs/recipes/operations/install-from-descriptors-README.md
@@ -21,6 +21,11 @@ set from an existing environment (the CI/CD path), use
 
 - Docker running (`docker version`), ~20 GB free disk (`df -h $HOME`)
 - Python 3.11+ (`python3 --version`), `git`
+- A Google **Web application** OAuth client id — the one input the default
+  login needs (see [Init](#init)). It is public, and this flow has no client
+  secret.
+- Only for the optional Telegram companion: a bot token from **@BotFather** and
+  a public HTTPS URL that reaches this machine.
 - The first `--build` is slow (node, playwright/chromium, pip image layers);
   later refreshes are cached and fast.
 
@@ -43,22 +48,75 @@ platform pulls.
 
 ## Init
 
+The default identity is **application-hosted login** (`--auth-type bundle`):
+the workspace app hosts the Google sign-in page and Connection Hub issues the
+KDCube session, so you need no external IdP. Its one input is a Google **Web
+application** OAuth client id — public, no client secret, because the browser's
+ID token is verified against Google's JWKS.
+
+Create that OAuth client first and authorize, as **JavaScript origins**, every
+origin the browser loads the platform from: the local UI origin and any public
+URL you use. One client holds both.
+
+> The proxy publishes `ports.proxy_http`, falling back to `ports.ui`, then to
+> `80`. Staged defaults set `ports.ui` to **`5174`** and leave `ports.proxy_http`
+> unset, so the local UI origin is `http://localhost:5174`.
+
+Copy the client id (`…apps.googleusercontent.com`).
+
 ```shell
 export TENANT="acme"
 export PROJECT="main"
 
-# Optional inputs the init substitutes into the staged defaults:
-export KDCUBE_PUBLIC_HOST="kdcube.example.com"   # OAuth redirects, webhooks
-export KDCUBE_ADMIN_EMAIL="admin@example.com"    # bootstrapped as super-admin
+# Optional: substituted into <PUBLIC_HOST> / <ADMIN_EMAIL> placeholder slots in
+# the staged default descriptors — unrelated to the auth flags below.
+export KDCUBE_PUBLIC_HOST="kdcube.example.com"
+export KDCUBE_ADMIN_EMAIL="admin@example.com"
 
 "$KDCUBE" init --path "$REPO" --tenant "$TENANT" --project "$PROJECT" --build \
+  --auth-type bundle \
+  --client-id "<google-web-oauth-client-id>" \
+  --bootstrap-admin-email "admin@example.com" \
   --set-secret services.openai.api_key "$OPENAI_API_KEY" \
   --set-secret services.anthropic.api_key "$ANTHROPIC_API_KEY"
 ```
 
+`--bootstrap-admin-email` is the verified Google email granted `super-admin` on
+first login; omit it and no bootstrap admin rule is written. `--provider`
+defaults to `google`, the only supported bundle provider. All three bundle flags
+require `--auth-type bundle`.
+
+Secrets are never typed inline: export them and let the shell expand the
+reference, as with `"$OPENAI_API_KEY"` above.
+
+The other methods (`cognito`, `simple`, `delegated`), their per-mode flags, and
+reconfiguring auth on a live runtime with `kdcube config apply` live in
+[CLI §2.3e Authentication](../../service/cicd/cli-README.md#auth-flags), the
+canonical flag reference.
+
 `init` is first-time creation ONLY: it refuses an already-initialized
 workdir. `init --build` builds images and stops — nothing runs until
 `kdcube start`.
+
+### Optional: the Telegram companion
+
+A Telegram bot needs a public HTTPS URL Telegram can reach for the webhook and
+Mini App. Any tunnel works — ngrok, cloudflared, or your own domain; point it at
+the proxy UI port above and prefer a stable URL over a random per-run one.
+
+The bot token has no flag by design — it is a secret, so the CLI reads it from
+the environment:
+
+```shell
+export KDCUBE_TELEGRAM_BOT_TOKEN="<token-from-@BotFather>"
+
+"$KDCUBE" init ... \
+  --enable-telegram --external-https-url "https://<your-public-host>"
+```
+
+Authorize that same public URL as a JavaScript origin on the OAuth client. Init
+appends its origin to `cors.allow_origins` for you — the Mini App's cross-origin
+WebSocket needs it.
 
 ### What the init stages
 
@@ -74,7 +132,8 @@ workspace@2026-03-31-13-36  showcase scene + chat wired to everything
 
 Default identity is the bundle-session flavor: Google sign-in validated by
 the workspace app, KDCube session issued by Connection Hub — no external
-IdP. `KDCUBE_ADMIN_EMAIL` becomes the super-admin bootstrap rule.
+IdP. `--bootstrap-admin-email` is the super-admin bootstrap rule in the
+Connection Hub authority registry.
 
 ### The first-run checklist
 
@@ -103,8 +162,8 @@ reports process/mount state, not per-bundle build outcomes):
 ```shell
 "$KDCUBE" info
 
-# 1) the UI actually answers — the real done-signal:
-curl -s -o /dev/null -w "chat UI -> HTTP %{http_code}\n" http://localhost:5173/platform/chat  # want 200
+# 1) the UI actually answers — the real done-signal (port = ports.ui, 5174 by default):
+curl -s -o /dev/null -w "chat UI -> HTTP %{http_code}\n" http://localhost:5174/platform/chat  # want 200
 
 # 2) staged descriptors are the runtime authority:
 ls "$WORKDIR/config/"

--- a/app/ai-app/docs/recipes/operations/operate-runtime-README.md
+++ b/app/ai-app/docs/recipes/operations/operate-runtime-README.md
@@ -117,6 +117,8 @@ OAuth callbacks) put ONE stable HTTPS origin in front of the local web
 proxy — see `docs/service/cicd/ngrok-README.md`. Keep `domain: ""` and
 `proxy.ssl: false` locally; the tunnel origin belongs in CORS
 (`--cors-origin` at init) and in app public URLs, never in local proxy SSL.
+Configuring the Telegram companion adds its `--external-https-url` origin to
+CORS automatically.
 
 ## Shell paste rule
 

--- a/app/ai-app/docs/sdk/bundle/build/how-to-navigate-kdcube-docs-README.md
+++ b/app/ai-app/docs/sdk/bundle/build/how-to-navigate-kdcube-docs-README.md
@@ -82,7 +82,7 @@ Use this order.
    | Link | Meaning |
    | --- | --- |
    | `repo:kdcube-ai-app/...` | Path relative to the KDCube platform repo checkout. |
-   | `repo:applications/...` | Path relative to the applications/content repo checkout. |
+   | `repo:my-bundles/...` | Path relative to a configured bundle/content repo checkout. |
    | `repo:website/...` | Path relative to the website repo checkout. |
    | relative Markdown link | Resolve relative to the current doc file. |
 

--- a/app/ai-app/docs/sdk/bundle/build/how-to-release-bundle-content-README.md
+++ b/app/ai-app/docs/sdk/bundle/build/how-to-release-bundle-content-README.md
@@ -158,7 +158,7 @@ Use this shape unless the bundle repo already has a stricter local format:
 
 ```yaml
 bundle:
-  repo: "https://github.com/org/applications.git"
+  repo: "https://github.com/your-org/your-bundles.git"
   ref: "2026.5.2.1643"
   description: |
     Release for my.bundle@1-0.
@@ -297,7 +297,7 @@ consume the new release:
 bundles:
   items:
     - id: "my.bundle@1-0"
-      repo: "https://github.com/org/applications.git"
+      repo: "https://github.com/your-org/your-bundles.git"
       ref: "2026.5.2.1643"
       subdir: "src"
       module: "my.bundle@1-0.entrypoint"

--- a/app/ai-app/docs/sdk/bundle/build/sync-tier1-bundle-docs-to-build-with-kdcube-plugins-README.md
+++ b/app/ai-app/docs/sdk/bundle/build/sync-tier1-bundle-docs-to-build-with-kdcube-plugins-README.md
@@ -62,8 +62,8 @@ absolute paths:
 
 - KDCube platform docs live under `repo:kdcube-ai-app/app/ai-app/docs/...`.
 - `repo:kdcube-ai-app/...` resolves to the local KDCube platform repository.
-- `repo:applications/...` resolves to the local applications/content
-  repository.
+- `repo:my-bundles/...` resolves to a local bundle/content
+  repository the operator configures.
 - `repo:website/...` resolves to the local website repository.
 
 If the plugin cannot resolve a repo alias, it should infer the checkout from

--- a/app/ai-app/docs/sdk/bundle/bundle-economics-integration-README.md
+++ b/app/ai-app/docs/sdk/bundle/bundle-economics-integration-README.md
@@ -190,9 +190,7 @@ for the actual agent work.
 | Memory named-service search | `kdcube_ai_app/apps/chat/sdk/solutions/chatbot/entrypoint_with_memory.py` and `context/memory/named_service.py` | `_memory_named_service_provider(... model_service=self.search_model_service(flow="memory.search"))` and provider `_search_embedding(...)` |
 | Canvas pin search | `kdcube_ai_app/apps/chat/sdk/solutions/canvas/search/service.py` | `CanvasPinSearch._model_service()` resolving `entrypoint.search_model_service(flow=self.flow)` |
 | Generic hybrid index | `kdcube_ai_app/infra/index/sqlite/hybrid_index.py` | `_embed_query(...)` calling `model_service.embed_search_query(...)` and skipping semantic ranking when it returns `None` |
-| Enforcement core + search guard | `kdcube_ai_app/apps/chat/sdk/infra/economics/enforcement.py` and `infra/economics/search_guard.py` | the central enforcement state machine, and the `embed_search_query(...)` guard wrapper that reserves/settles per query and returns `None` on denial |
-| Task tracker issue search | private applications repo, task tracker `issues/service.py` | `_embed_search(...)` calling `model_service.embed_search_query(..., flow="task_tracker.issue.search")`; attachment search logs metadata-only execution |
-| Task execution economics | `kdcube_ai_app/apps/chat/sdk/solutions/tasks/operations.py` | `_task_verify_economics(...)` before execution and later ReAct work through the economics entrypoint |
+| Enforcement core + search guard | `kdcube_ai_app/apps/chat/sdk/infra/economics/enforcement.py` and `infra/economics/search_guard.py` | the central enforcement state machine, and the `embed_search_query(...)` guard wrapper that reserves/settles per query and returns `None` on denial || Task execution economics | `kdcube_ai_app/apps/chat/sdk/solutions/tasks/operations.py` | `_task_verify_economics(...)` before execution and later ReAct work through the economics entrypoint |
 
 ## Logs And Verification
 

--- a/app/ai-app/docs/service/cicd/cli-README.md
+++ b/app/ai-app/docs/service/cicd/cli-README.md
@@ -400,6 +400,54 @@ kdcube init --tenant <t> --project <p> \
   --release 2026.4.11.012
 ```
 
+### 2.3e Authentication<a id="auth-flags"></a>
+
+`kdcube init` selects a platform authentication method. Without `--auth-type` the
+interactive wizard prompts for it; the picker lists `simple`, `cognito`, and `bundle`
+(application-hosted login) with `bundle` preselected. `delegated` is listed only when it
+is already the configured mode, and is otherwise set with `--auth-type delegated`.
+
+Non-interactive installs pass the method and its fields as flags:
+
+```bash
+# Application-hosted (Google) login — the default identity
+kdcube init --tenant <t> --project <p> \
+  --auth-type bundle \
+  --client-id "<google-web-oauth-client-id>" \
+  --bootstrap-admin-email admin@example.com
+
+# Cognito (or delegated)
+kdcube init --tenant <t> --project <p> \
+  --auth-type cognito \
+  --cognito-region eu-west-1 \
+  --cognito-user-pool-id <pool-id> \
+  --cognito-app-client-id <app-client-id> \
+  --cognito-service-client-id <service-client-id>
+```
+
+Per-mode fields:
+
+- `bundle`: `--provider google` (only supported provider), `--client-id`,
+  `--bootstrap-admin-email` (verified Google email granted `super-admin` on first login).
+- `cognito` / `delegated`: `--cognito-region`, `--cognito-user-pool-id`,
+  `--cognito-app-client-id`, `--cognito-service-client-id` (or the matching `COGNITO_*`
+  env vars / descriptor values).
+
+The same flags apply to `kdcube config apply` (see §2.3f, Reconfigure authentication).
+
+**Telegram companion (optional).** `--enable-telegram --external-https-url <url>` configures
+the Telegram companion during init. The bot token is a secret with no flag; it is read from
+the `KDCUBE_TELEGRAM_BOT_TOKEN` env var (required for non-interactive setup, prompted
+interactively). The external URL's origin is added to `cors.allow_origins` so the Mini App's
+cross-origin WebSocket is accepted.
+
+```bash
+KDCUBE_TELEGRAM_BOT_TOKEN="<bot-token>" \
+kdcube init --tenant <t> --project <p> \
+  --auth-type bundle --client-id "<id>" \
+  --enable-telegram --external-https-url https://<stable-ngrok-domain>
+```
+
 ### 2.4 Refresh (re-init) — `kdcube refresh`<a id="refresh"></a>
 
 `kdcube refresh` is the command to use when you want to **rebuild platform
@@ -543,6 +591,37 @@ With `--include-platform-descriptors`, export writes `assembly.yaml`,
 `secrets.yaml`, `gateway.yaml`, `economics.yaml`, `bundles.yaml`, and
 `bundles.secrets.yaml`. For what `economics.yaml` owns, see
 [economics-descriptor-README.md](../../economics/economics-descriptor-README.md).
+
+### 2.3f Reconfigure authentication — `kdcube config apply`<a id="config-apply-auth"></a>
+
+`kdcube config apply` changes the platform authentication of an already-initialized
+runtime. It takes the same `--auth-type` and per-mode flags as `init` (§2.3e) and
+reconciles the descriptors to the target method: the previous method's platform login
+provider, its upstream authority, admin bootstrap rule, and consent UI are removed, and
+unrelated configuration (bundles, connectors, the Telegram companion) is preserved.
+
+```bash
+# Preview the descriptor changes without writing
+kdcube config apply --tenant <t> --project <p> \
+  --auth-type cognito \
+  --cognito-region eu-west-1 --cognito-user-pool-id <pool-id> \
+  --cognito-app-client-id <app-client-id> \
+  --dry-run
+
+# Apply and restart the stack
+kdcube config apply --tenant <t> --project <p> \
+  --auth-type cognito \
+  --cognito-region eu-west-1 --cognito-user-pool-id <pool-id> \
+  --cognito-app-client-id <app-client-id> \
+  --restart
+```
+
+`--dry-run` prints a per-descriptor semantic diff and writes nothing. `-i` prompts for
+fields not passed as flags. Without `--restart`, descriptors are updated and
+`kdcube refresh` (or a later `--restart`) applies them to the running stack.
+
+This is distinct from `kdcube bundle config apply` (§2.3b, above), which syncs bundle
+descriptors only and does not change authentication.
 
 Exported descriptors are shaped for review and re-seeding, not as a byte-for-byte
 copy of the container runtime files:
@@ -978,6 +1057,9 @@ You can also pre‑seed paths and flags via environment variables:
 | `KDCUBE_USE_BUNDLES_SECRETS` | `1/0` to apply bundles secrets. |
 | `KDCUBE_GATEWAY_DESCRIPTOR_PATH` | Path to `gateway.yaml` (copied into workdir config). |
 | `KDCUBE_CLI_NONINTERACTIVE` | Internal installer flag. Prompt helpers use defaults instead of asking. The CLI sets this automatically for the descriptor fast path. |
+| `KDCUBE_TELEGRAM_BOT_TOKEN` | Telegram companion bot token (secret; has no flag). Required for non-interactive `--enable-telegram`; prompted interactively. |
+| `KDCUBE_TELEGRAM_EXTERNAL_HTTPS_URL` | Externally reachable HTTPS URL for the Telegram companion. Equivalent to `--external-https-url`. |
+| `KDCUBE_ENABLE_TELEGRAM` | `1/0` to configure the Telegram companion non-interactively. Equivalent to `--enable-telegram`. |
 
 ---
 

--- a/app/ai-app/docs/service/cicd/cli-README.md
+++ b/app/ai-app/docs/service/cicd/cli-README.md
@@ -433,7 +433,7 @@ Per-mode fields:
   `--cognito-app-client-id`, `--cognito-service-client-id` (or the matching `COGNITO_*`
   env vars / descriptor values).
 
-The same flags apply to `kdcube config apply` (see §2.3f, Reconfigure authentication).
+The same flags apply to `kdcube config apply` (see [§2.3f, Reconfigure authentication](#config-apply-auth)).
 
 **Telegram companion (optional).** `--enable-telegram --external-https-url <url>` configures
 the Telegram companion during init. The bot token is a secret with no flag; it is read from
@@ -595,7 +595,7 @@ With `--include-platform-descriptors`, export writes `assembly.yaml`,
 ### 2.3f Reconfigure authentication — `kdcube config apply`<a id="config-apply-auth"></a>
 
 `kdcube config apply` changes the platform authentication of an already-initialized
-runtime. It takes the same `--auth-type` and per-mode flags as `init` (§2.3e) and
+runtime. It takes the same `--auth-type` and per-mode flags as `init` ([§2.3e](#auth-flags)) and
 reconciles the descriptors to the target method: the previous method's platform login
 provider, its upstream authority, admin bootstrap rule, and consent UI are removed, and
 unrelated configuration (bundles, connectors, the Telegram companion) is preserved.

--- a/app/ai-app/src/kdcube-ai-app/kdcube_cli/README.md
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_cli/README.md
@@ -205,6 +205,38 @@ kdcube init --tenant acme --project staging \
   --build
 ```
 
+### Authentication
+
+The default identity is bundle-session (application-hosted login). Select a
+different method with `--auth-type {simple,cognito,delegated,bundle}`:
+
+```bash
+# Application-hosted (Google) login
+kdcube init --tenant acme --project staging \
+  --auth-type bundle \
+  --client-id "<google-web-oauth-client-id>" \
+  --bootstrap-admin-email admin@example.com
+
+# Cognito
+kdcube init --tenant acme --project staging \
+  --auth-type cognito \
+  --cognito-region eu-west-1 \
+  --cognito-user-pool-id <pool-id> \
+  --cognito-app-client-id <app-client-id>
+```
+
+To change the method on an already-initialized runtime, use `kdcube config apply`
+with the same flags; `--dry-run` shows the descriptor diff, `--restart` applies it:
+
+```bash
+kdcube config apply --tenant acme --project staging \
+  --auth-type cognito --cognito-region eu-west-1 \
+  --cognito-user-pool-id <pool-id> --cognito-app-client-id <app-client-id> \
+  --dry-run
+```
+
+See [Authentication modes](additional_README.md#authentication-modes) for per-mode fields.
+
 ### Typical day-to-day flow
 
 Pass `--tenant` / `--project` (or set them with `kdcube defaults`) to point
@@ -412,6 +444,7 @@ kdcube defaults \
 | `kdcube bundle reload <bundle_id> [--json] [--quiet]` | Reapply bundle config and clear proc caches — no full restart needed |
 | `kdcube bundle <bundle_id>` | Create, update, or delete a staged bundle entry |
 | `kdcube bundle config apply --descriptors-location <dir> [--dry-run] [--reload]` | User/operator flow to reapply seed `bundles.yaml` / `bundles.secrets.yaml` to an existing runtime — no platform refresh |
+| `kdcube config apply --auth-type <mode> [mode flags] [-i] [--dry-run] [--restart]` | Reconfigure the platform authentication of an initialized runtime; reconciles descriptors to the target mode and preserves unrelated config. `--dry-run` shows the diff without writing |
 | `kdcube config export --out-dir <dir> [--include-platform-descriptors]` | Export live local runtime descriptors for review/reuse |
 | `kdcube config export --tenant <t> --project <p> --aws-region <r> --out-dir <dir>` | Export deployment-scoped bundle descriptors from AWS Secrets Manager |
 | `kdcube config import --descriptors-location <dir> [--include-platform-descriptors] [--dry-run] [--reload]` | Import reviewed runtime descriptors into an existing local runtime |

--- a/app/ai-app/src/kdcube-ai-app/kdcube_cli/additional_README.md
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_cli/additional_README.md
@@ -379,6 +379,20 @@ cors:
     - "https://<stable-ngrok-domain>"
 ```
 
+Configuring the Telegram companion (interactive, `--enable-telegram --external-https-url <url>`,
+or the `KDCUBE_ENABLE_TELEGRAM` / `KDCUBE_TELEGRAM_EXTERNAL_HTTPS_URL` env vars) also appends the
+external URL's origin to `cors.allow_origins`. The Mini App is served from that origin, and its
+cross-origin WebSocket (the Connection Hub account-link flow) requires the origin to be allow-listed.
+
+The bot token has no flag (it is a secret) and is read from the `KDCUBE_TELEGRAM_BOT_TOKEN`
+env var. Non-interactive setup requires it to be set; interactive setup prompts for it. Example:
+
+```bash
+KDCUBE_TELEGRAM_BOT_TOKEN="<bot-token>" \
+kdcube init --tenant <t> --project <p> \
+  --enable-telegram --external-https-url https://<stable-ngrok-domain>
+```
+
 For bundle integrations, configure public URLs in `bundles.yaml` or in the
 staged bundle config under the runtime workdir. Telegram webhooks and any OAuth
 integration with redirect/public-base URLs follow this pattern. Example:
@@ -546,13 +560,14 @@ what is incomplete.
 
 | Subcommand | Purpose |
 |---|---|
-| `kdcube init [--workdir <full-path> \| --workdir-base <base> --tenant T --project P] [--path <repo>] [--descriptors-location <dir>] [--latest\|--upstream\|--release <ref>] [--build] [-i] [--reset-config] [--prompt-secrets] [--set-secret KEY VALUE]... [--cors-origin ORIGIN]...` | **First-time setup only.** Initialize a fresh runtime workdir (stage descriptors, generate env files). Pick one of `--workdir <full-path>` (the trailing segment must be `<tenant>__<project>`) or `--workdir-base <base> --tenant T --project P` (the CLI composes the namespaced path). Refuses if the resolved workdir is already initialized — use `kdcube refresh` for that case. Explicit `--path` stages that local source tree unless a version selector is used. With `--build`, also build images **without** starting containers. `--cors-origin` appends an allowed origin to staged `config/assembly.yaml`. |
+| `kdcube init [--workdir <full-path> \| --workdir-base <base> --tenant T --project P] [--path <repo>] [--descriptors-location <dir>] [--latest\|--upstream\|--release <ref>] [--build] [-i] [--reset-config] [--prompt-secrets] [--set-secret KEY VALUE]... [--cors-origin ORIGIN]... [--auth-type {simple,cognito,delegated,bundle}] [--provider google] [--client-id <id>] [--bootstrap-admin-email <email>] [--cognito-region <r>] [--cognito-user-pool-id <id>] [--cognito-app-client-id <id>] [--cognito-service-client-id <id>] [--enable-telegram --external-https-url <url>]` | **First-time setup only.** Initialize a fresh runtime workdir (stage descriptors, generate env files). Pick one of `--workdir <full-path>` (the trailing segment must be `<tenant>__<project>`) or `--workdir-base <base> --tenant T --project P` (the CLI composes the namespaced path). Refuses if the resolved workdir is already initialized — use `kdcube refresh` for that case. Explicit `--path` stages that local source tree unless a version selector is used. With `--build`, also build images **without** starting containers. `--cors-origin` appends an allowed origin to staged `config/assembly.yaml`. `--auth-type` selects the platform authentication method (see [Authentication modes](#authentication-modes)); `--provider`/`--client-id`/`--bootstrap-admin-email` fill the bundle (application-hosted) login; `--cognito-*` fill the Cognito/delegated fields; `--enable-telegram` with `--external-https-url` configures the Telegram companion (the bot token is read from the `KDCUBE_TELEGRAM_BOT_TOKEN` env var). |
 | `kdcube refresh [--workdir <full-path>] [--path <repo>] [--latest\|--upstream\|--release <ref>] [--build] [--no-restart]` | Re-init an already-initialized runtime: stop the stack, optionally select a platform ref, restage explicit local `--path` into `<workdir>/repo`, rebuild platform Docker images when `--build` is given, restart the stack (unless `--no-restart`). **Never** modifies staged descriptors (`assembly.yaml`, `secrets.yaml`, `bundles.yaml`, `bundles.secrets.yaml`, `gateway.yaml`). Refuses if the workdir is not initialized. |
 | `kdcube start [--workdir <path>] [--build]` | Start the Docker Compose stack for an already-initialized workdir. `--build` is a convenience rebuild before start, not required if `init --build` was already run; for a structured re-init after platform changes, prefer `kdcube refresh --build`. |
 | `kdcube stop [--workdir <path>] [--remove-volumes]` | Stop the local Docker Compose stack. |
 | `kdcube bundle reload <bundle_id> [--workdir <path>] [--json] [--quiet] [--verbose]` | Reapply `bundles.yaml` from the active runtime and clear proc bundle caches. Normal output is concise; `--json` is scriptable; `--verbose` shows the raw Docker Compose command and proc response. |
 | `kdcube reload <bundle_id> [--workdir <path>] [--json] [--quiet] [--verbose]` | Compatibility alias for bundle reload. |
 | `kdcube bundle config apply [--workdir <path>] [--tenant <id>] [--project <id>] --descriptors-location <dir> [--dry-run] [--reload]` | User/operator descriptor-sync flow. Reapply seed `bundles.yaml` and optional `bundles.secrets.yaml` to an existing runtime; with `--reload`, reload changed declared bundle ids. Does not touch platform descriptors, rebuild images, or restart Docker. |
+| `kdcube config apply [--workdir <path>] [--tenant <id>] [--project <id>] --auth-type {simple,cognito,delegated,bundle} [--provider google] [--client-id <id>] [--bootstrap-admin-email <email>] [--cognito-region <r>] [--cognito-user-pool-id <id>] [--cognito-app-client-id <id>] [--cognito-service-client-id <id>] [-i] [--dry-run] [--restart]` | Reconfigure the platform authentication of an initialized runtime. Reconciles the descriptors to `--auth-type`, removing the previous method's platform login artifacts and preserving unrelated configuration (including the Telegram companion). Bundle fields come from `--provider`/`--client-id`/`--bootstrap-admin-email`; Cognito/delegated fields from the `--cognito-*` flags. `-i` prompts for fields not passed as flags. `--dry-run` prints a per-descriptor semantic diff and writes nothing. Without `--restart`, descriptors are updated and `kdcube refresh` (or a later `--restart`) applies them to the running stack. |
 | `kdcube config export [--workdir <path>] [--tenant <id>] [--project <id>] --out-dir <dir> [--include-platform-descriptors]` | Export live local runtime descriptors. By default exports `bundles.yaml` and `bundles.secrets.yaml`; with `--include-platform-descriptors`, also exports `assembly.yaml`, `secrets.yaml`, and `gateway.yaml`. |
 | `kdcube config import [--workdir <path>] [--tenant <id>] [--project <id>] --descriptors-location <dir> [--include-platform-descriptors] [--dry-run] [--reload]` | Import reviewed descriptors into an existing local runtime. Bundle descriptors are path-normalized; with `--include-platform-descriptors`, platform descriptors are overwritten exactly and runtime env/config files are regenerated. |
 | `kdcube export [--workdir <path>] [--tenant <id>] [--project <id>] [--out-dir <dir>] [--aws-region <region>]` | Export effective live `bundles.yaml` and `bundles.secrets.yaml`. Local export normalizes runtime paths back to reusable descriptor paths. |
@@ -738,6 +753,12 @@ When you run `kdcube`, the **wizard** performs the steps below:
 ### Authentication modes
 The wizard prompts for an auth mode and updates both backend and frontend config.
 
+Pass `--auth-type {simple,cognito,delegated,bundle}` to select the mode without a
+prompt. The interactive picker lists `simple`, `cognito`, and `bundle`, with `bundle`
+preselected; `delegated` is listed only when it is already the configured mode, and is
+otherwise selected with `--auth-type delegated`. The per-mode input flags below apply to
+both `kdcube init` and `kdcube config apply`.
+
 **Simple (hardcoded)**
 - `AUTH_PROVIDER=simple`
 - Frontend config: `frontend.config.hardcoded.json`
@@ -746,7 +767,7 @@ The wizard prompts for an auth mode and updates both backend and frontend config
 **Cognito**
 - `AUTH_PROVIDER=cognito`
 - Frontend config: `frontend.config.cognito.json`
-- Required fields:
+- Required fields (flags `--cognito-region`, `--cognito-user-pool-id`, `--cognito-app-client-id`, `--cognito-service-client-id`, or the matching env vars / descriptor):
   - `COGNITO_REGION`
   - `COGNITO_USER_POOL_ID`
   - `COGNITO_APP_CLIENT_ID`
@@ -762,13 +783,25 @@ The wizard prompts for an auth mode and updates both backend and frontend config
   - `auth.totpAppName`
   - `auth.totpIssuer`
 
-**Bundle session**
+**Bundle session** (application-hosted login)
 - `AUTH_PROVIDER=session`
 - Frontend config auth type: `bundle`
+- Input flags: `--provider google` (currently the only supported provider),
+  `--client-id <google-web-oauth-client-id>`, `--bootstrap-admin-email <email>`
+  (verified Google email granted `super-admin` on first login).
 - A bundle/front shell validates an external identity, calls the platform bundle
   session authority, and sets the descriptor-configured platform cookies.
 - Requires `services.session_token.secret` in `secrets.yaml`; the CLI generates
   it when missing during init/refresh.
+
+**Reconfiguring an initialized runtime**
+
+`kdcube config apply --auth-type <mode> [mode flags] [--dry-run] [--restart]` changes the
+auth mode of an existing runtime. It reconciles the descriptors to the target mode:
+the previous mode's platform login provider, its upstream authority, admin bootstrap
+rule, and consent UI are removed, and unrelated configuration (bundles, connectors, the
+Telegram companion) is preserved. `--dry-run` prints the descriptor diff without writing.
+Without `--restart`, run `kdcube refresh` afterward to apply the change to the running stack.
 
 ### Routes prefix & nginx proxy
 The frontend config includes `routesPrefix` (default: `/chatbot`).

--- a/app/ai-app/src/kdcube-ai-app/kdcube_cli/src/kdcube_cli/cli.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_cli/src/kdcube_cli/cli.py
@@ -1364,6 +1364,105 @@ def _descriptor_objects_differ(current: object, incoming: object) -> bool:
     return _canonical_descriptor_json(current) != _canonical_descriptor_json(incoming)
 
 
+def _config_apply_env_from_config_dir(config_dir: Path, assembly: dict) -> None:
+    """Point the installer's descriptor-source env at config_dir for a prepare-only run."""
+    os.environ["KDCUBE_DESCRIPTORS_LOCATION"] = str(config_dir)
+    os.environ["KDCUBE_ASSEMBLY_DESCRIPTOR_PATH"] = str(config_dir / "assembly.yaml")
+    os.environ["KDCUBE_ASSEMBLY_USER_SUPPLIED"] = "0"
+    for env_key, env_name in (
+        ("KDCUBE_SECRETS_DESCRIPTOR_PATH", "secrets.yaml"),
+        ("KDCUBE_GATEWAY_DESCRIPTOR_PATH", "gateway.yaml"),
+        ("KDCUBE_BUNDLES_DESCRIPTOR_PATH", "bundles.yaml"),
+        ("KDCUBE_BUNDLES_SECRETS_PATH", "bundles.secrets.yaml"),
+    ):
+        env_path = config_dir / env_name
+        if env_path.exists():
+            os.environ[env_key] = str(env_path)
+    os.environ["KDCUBE_ASSEMBLY_USE_BUNDLES"] = "1" if bool(_get_nested(assembly, "bundles")) else "0"
+    os.environ["KDCUBE_ASSEMBLY_USE_FRONTEND"] = "1" if bool(_get_nested(assembly, "frontend")) else "0"
+    os.environ["KDCUBE_ASSEMBLY_USE_PLATFORM"] = "0"
+    os.environ["KDCUBE_USE_BUNDLES_DESCRIPTOR"] = "1" if (config_dir / "bundles.yaml").exists() else "0"
+    os.environ["KDCUBE_USE_BUNDLES_SECRETS"] = "1" if (config_dir / "bundles.secrets.yaml").exists() else "0"
+    os.environ["KDCUBE_INIT_PREPARE_ONLY"] = "1"
+
+
+def _config_apply_dry_run(
+    op_console: Console,
+    *,
+    repo: Path,
+    workdir: Path,
+    config_dir: Path,
+    assembly_with_flags: dict,
+    json_output: bool,
+) -> None:
+    """Render the reconfiguration into a throwaway copy and show the semantic diff.
+
+    Copies the staged descriptors, runs the shared configurator against the copy with
+    Docker actions disabled and Telegram left unconfigured, then reports how each
+    descriptor would change. No live file is written and no runtime is restarted.
+    """
+    import tempfile
+    import difflib
+
+    saved_env = dict(os.environ)
+    temp_root = Path(tempfile.mkdtemp(prefix="kdcube-config-apply-"))
+    changes: list[dict] = []
+    try:
+        temp_workdir = temp_root / "workdir"
+        temp_config = temp_workdir / "config"
+        shutil.copytree(config_dir, temp_config)
+        installer_mod.save_release_descriptor(temp_config / "assembly.yaml", assembly_with_flags)
+
+        _config_apply_env_from_config_dir(temp_config, assembly_with_flags)
+        os.environ["KDCUBE_CLI_NONINTERACTIVE"] = "1"
+        os.environ.pop("KDCUBE_ENABLE_TELEGRAM", None)
+
+        quiet_console = Console(file=io.StringIO(), force_terminal=False)
+        run_installer(quiet_console, repo, temp_workdir, "skip", None, None, True)
+
+        for name in installer_mod.CANONICAL_DESCRIPTOR_FILENAMES:
+            live_obj = installer_mod.load_release_descriptor_soft(config_dir / name)
+            new_obj = installer_mod.load_release_descriptor_soft(temp_config / name)
+            if not _descriptor_objects_differ(live_obj, new_obj):
+                continue
+            live_text = yaml.safe_dump(live_obj, sort_keys=True, default_flow_style=False)
+            new_text = yaml.safe_dump(new_obj, sort_keys=True, default_flow_style=False)
+            diff = "".join(
+                difflib.unified_diff(
+                    live_text.splitlines(keepends=True),
+                    new_text.splitlines(keepends=True),
+                    fromfile=f"current/{name}",
+                    tofile=f"apply/{name}",
+                )
+            )
+            changes.append({"descriptor": name, "diff": diff})
+    finally:
+        os.environ.clear()
+        os.environ.update(saved_env)
+        shutil.rmtree(temp_root, ignore_errors=True)
+
+    if json_output:
+        _print_json(
+            {
+                "status": "dry-run",
+                "action": "apply",
+                "workdir": str(workdir),
+                "changed_descriptors": [c["descriptor"] for c in changes],
+                "changes": changes,
+            }
+        )
+        return
+
+    op_console.print("[bold]config apply (dry-run)[/bold] — no files written")
+    op_console.print(f"[dim]workdir:[/dim] {workdir}")
+    if not changes:
+        op_console.print("[dim]No descriptor changes.[/dim]")
+        return
+    for change in changes:
+        op_console.print(f"\n[bold]{change['descriptor']}[/bold]")
+        op_console.print(change["diff"].rstrip() or "[dim](structural change)[/dim]")
+
+
 def _normalize_bundle_descriptor_paths_for_runtime(data: object, workdir: Path) -> list[dict[str, str]]:
     translations: list[dict[str, str]] = []
     if not isinstance(data, dict):
@@ -2562,13 +2661,21 @@ def _apply_auth_flags(console: Console, assembly: dict, args) -> bool:
 
     --auth-type selects the platform method. For bundle (application-hosted
     login), --provider/--client-id/--bootstrap-admin-email are written under
-    auth.bundle so the setup wizard uses them without prompting. An unsupported
-    bundle provider aborts. Returns True if the assembly changed.
+    auth.bundle. For cognito/delegated, --cognito-* are written under auth.cognito
+    so the setup wizard uses them without prompting. An unsupported bundle provider
+    aborts. Returns True if the assembly changed.
     """
     auth_type = str(getattr(args, "auth_type", "") or "").strip().lower()
     provider = str(getattr(args, "provider", "") or "").strip().lower()
     client_id = str(getattr(args, "client_id", "") or "").strip()
     admin_email = str(getattr(args, "bootstrap_admin_email", "") or "").strip()
+    cognito_values = {
+        "region": str(getattr(args, "cognito_region", "") or "").strip(),
+        "user_pool_id": str(getattr(args, "cognito_user_pool_id", "") or "").strip(),
+        "app_client_id": str(getattr(args, "cognito_app_client_id", "") or "").strip(),
+        "service_client_id": str(getattr(args, "cognito_service_client_id", "") or "").strip(),
+    }
+    any_cognito = any(cognito_values.values())
 
     auth = assembly.get("auth")
     if not isinstance(auth, dict):
@@ -2586,7 +2693,26 @@ def _apply_auth_flags(console: Console, assembly: dict, args) -> bool:
             raise SystemExit(
                 "--provider/--client-id/--bootstrap-admin-email require --auth-type bundle."
             )
+        if any_cognito:
+            if effective_type not in ("cognito", "delegated"):
+                raise SystemExit(
+                    "--cognito-region/--cognito-user-pool-id/--cognito-app-client-id/"
+                    "--cognito-service-client-id require --auth-type cognito or delegated."
+                )
+            cognito_block = auth.get("cognito")
+            if not isinstance(cognito_block, dict):
+                cognito_block = {}
+                auth["cognito"] = cognito_block
+            for key, value in cognito_values.items():
+                if value and cognito_block.get(key) != value:
+                    cognito_block[key] = value
+                    changed = True
         return changed
+    if any_cognito:
+        raise SystemExit(
+            "--cognito-region/--cognito-user-pool-id/--cognito-app-client-id/"
+            "--cognito-service-client-id require --auth-type cognito or delegated."
+        )
 
     seed = auth.get("bundle")
     if not isinstance(seed, dict):
@@ -3751,6 +3877,10 @@ def main() -> None:
         default="",
         help="With `config apply --auth-type bundle`, the verified Google email granted platform super-admin on first login.",
     )
+    _sp.add_argument("--cognito-region", default="", help="With `config apply --auth-type cognito|delegated`, the Cognito region.")
+    _sp.add_argument("--cognito-user-pool-id", default="", help="With `config apply --auth-type cognito|delegated`, the Cognito user pool id.")
+    _sp.add_argument("--cognito-app-client-id", default="", help="With `config apply --auth-type cognito|delegated`, the Cognito app client id.")
+    _sp.add_argument("--cognito-service-client-id", default="", help="With `config apply --auth-type cognito|delegated`, the Cognito service (machine) client id.")
     _sp.add_argument("--restart", action="store_true", help="With `config apply`, restart the runtime after writing the new configuration.")
     _sp.add_argument("-i", "--interactive", action="store_true", help="With `config apply`, prompt for auth fields not given as flags.")
     _sp.add_argument("--out-dir", default="", help="With `config export`, output directory for exported files")
@@ -3929,6 +4059,10 @@ def main() -> None:
             "first login, for --auth-type bundle."
         ),
     )
+    _sp.add_argument("--cognito-region", default="", help="Cognito region for --auth-type cognito|delegated.")
+    _sp.add_argument("--cognito-user-pool-id", default="", help="Cognito user pool id for --auth-type cognito|delegated.")
+    _sp.add_argument("--cognito-app-client-id", default="", help="Cognito app client id for --auth-type cognito|delegated.")
+    _sp.add_argument("--cognito-service-client-id", default="", help="Cognito service (machine) client id for --auth-type cognito|delegated.")
     _sp.add_argument(
         "--enable-telegram",
         action="store_true",
@@ -4683,59 +4817,33 @@ def main() -> None:
                 _assembly = installer_mod.load_release_descriptor_soft(_assembly_path)
                 _apply_auth_flags(_op_console, _assembly, args)
                 _effective_type = str(_get_nested(_assembly, "auth", "type") or "").strip().lower()
-                if _effective_type != "bundle":
+                _supported_types = {"bundle", "cognito", "simple", "delegated"}
+                if _effective_type not in _supported_types:
                     raise SystemExit(
-                        "`kdcube config apply` reconfigures application-hosted login. "
-                        "Pass --auth-type bundle with --client-id (and optionally --bootstrap-admin-email)."
+                        "`kdcube config apply` requires a supported --auth-type "
+                        "(bundle, cognito, simple, or delegated)."
                     )
                 _bundles = installer_mod.load_release_descriptor_soft(_config_dir / "bundles.yaml")
-                _client_id = _bundle_session_client_id(_assembly, _bundles)
-                if not args.interactive and not _has_value(_client_id):
-                    raise SystemExit(
-                        "`kdcube config apply --auth-type bundle` requires a Google client id "
-                        "(--client-id, or an existing application-hosted login runtime)."
-                    )
-                if args.dry_run:
-                    _preview_assembly = json.loads(json.dumps(_assembly))
-                    _preview_bundles = json.loads(json.dumps(_bundles))
-                    installer_mod.apply_bundle_session_auth(
-                        assembly_data=_preview_assembly,
-                        bundles_data=_preview_bundles,
-                        env_targets=[],
-                        client_id=_client_id or "<client-id>",
-                        provider=str(_get_nested(_assembly, "auth", "bundle", "provider") or "google"),
-                        bootstrap_admin_email=str(_get_nested(_assembly, "auth", "bundle", "bootstrap_admin_email") or ""),
-                    )
-                    _auth_preview = _get_nested(_preview_assembly, "auth") or {}
-                    if args.json_output:
-                        _print_json(
-                            {"status": "dry-run", "action": "apply", "workdir": str(_resolved), "auth": _auth_preview}
+                if _effective_type == "bundle":
+                    _client_id = _bundle_session_client_id(_assembly, _bundles)
+                    if not args.interactive and not _has_value(_client_id):
+                        raise SystemExit(
+                            "`kdcube config apply --auth-type bundle` requires a Google client id "
+                            "(--client-id, or an existing application-hosted login runtime)."
                         )
-                    else:
-                        _op_console.print("[bold]config apply (dry-run)[/bold] — no files written")
-                        _op_console.print(f"[dim]workdir:[/dim] {_resolved}")
-                        _op_console.print(yaml.safe_dump({"auth": _auth_preview}, sort_keys=False).rstrip())
+                _repo = _resolve_subcommand_repo(args.path, workdir=_resolved, path_provided=_arg_provided("--path"))
+                if args.dry_run:
+                    _config_apply_dry_run(
+                        _op_console,
+                        repo=_repo,
+                        workdir=_resolved,
+                        config_dir=_config_dir,
+                        assembly_with_flags=_assembly,
+                        json_output=bool(args.json_output),
+                    )
                     return
                 installer_mod.save_release_descriptor(_assembly_path, _assembly)
-                _repo = _resolve_subcommand_repo(args.path, workdir=_resolved, path_provided=_arg_provided("--path"))
-                os.environ["KDCUBE_DESCRIPTORS_LOCATION"] = str(_config_dir)
-                os.environ["KDCUBE_ASSEMBLY_DESCRIPTOR_PATH"] = str(_assembly_path)
-                os.environ["KDCUBE_ASSEMBLY_USER_SUPPLIED"] = "0"
-                for _env_key, _env_name in (
-                    ("KDCUBE_SECRETS_DESCRIPTOR_PATH", "secrets.yaml"),
-                    ("KDCUBE_GATEWAY_DESCRIPTOR_PATH", "gateway.yaml"),
-                    ("KDCUBE_BUNDLES_DESCRIPTOR_PATH", "bundles.yaml"),
-                    ("KDCUBE_BUNDLES_SECRETS_PATH", "bundles.secrets.yaml"),
-                ):
-                    _env_path = _config_dir / _env_name
-                    if _env_path.exists():
-                        os.environ[_env_key] = str(_env_path)
-                os.environ["KDCUBE_ASSEMBLY_USE_BUNDLES"] = "1" if bool(_get_nested(_assembly, "bundles")) else "0"
-                os.environ["KDCUBE_ASSEMBLY_USE_FRONTEND"] = "1" if bool(_get_nested(_assembly, "frontend")) else "0"
-                os.environ["KDCUBE_ASSEMBLY_USE_PLATFORM"] = "0"
-                os.environ["KDCUBE_USE_BUNDLES_DESCRIPTOR"] = "1" if (_config_dir / "bundles.yaml").exists() else "0"
-                os.environ["KDCUBE_USE_BUNDLES_SECRETS"] = "1" if (_config_dir / "bundles.secrets.yaml").exists() else "0"
-                os.environ["KDCUBE_INIT_PREPARE_ONLY"] = "1"
+                _config_apply_env_from_config_dir(_config_dir, _assembly)
                 if not args.interactive:
                     os.environ["KDCUBE_CLI_NONINTERACTIVE"] = "1"
                 # Re-render env/bundles/frontend/nginx from the updated descriptors without Docker actions.

--- a/app/ai-app/src/kdcube-ai-app/kdcube_cli/src/kdcube_cli/cli.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_cli/src/kdcube_cli/cli.py
@@ -2557,6 +2557,56 @@ def _apply_cors_origins(assembly: dict, origins: list[str]) -> list[str]:
     return added
 
 
+def _apply_auth_flags(console: Console, assembly: dict, args) -> bool:
+    """Seed the staged assembly auth block from init auth flags.
+
+    --auth-type selects the platform method. For bundle (application-hosted
+    login), --provider/--client-id/--bootstrap-admin-email are written under
+    auth.bundle so the setup wizard uses them without prompting. An unsupported
+    bundle provider aborts. Returns True if the assembly changed.
+    """
+    auth_type = str(getattr(args, "auth_type", "") or "").strip().lower()
+    provider = str(getattr(args, "provider", "") or "").strip().lower()
+    client_id = str(getattr(args, "client_id", "") or "").strip()
+    admin_email = str(getattr(args, "bootstrap_admin_email", "") or "").strip()
+
+    auth = assembly.get("auth")
+    if not isinstance(auth, dict):
+        auth = {}
+        assembly["auth"] = auth
+
+    changed = False
+    if auth_type and auth.get("type") != auth_type:
+        auth["type"] = auth_type
+        changed = True
+
+    effective_type = str(auth.get("type") or "").strip().lower()
+    if effective_type != "bundle":
+        if provider or client_id or admin_email:
+            raise SystemExit(
+                "--provider/--client-id/--bootstrap-admin-email require --auth-type bundle."
+            )
+        return changed
+
+    seed = auth.get("bundle")
+    if not isinstance(seed, dict):
+        seed = {}
+        auth["bundle"] = seed
+    resolved_provider = installer_mod.validate_bundle_auth_provider(
+        console, provider or str(seed.get("provider") or "google")
+    )
+    if seed.get("provider") != resolved_provider:
+        seed["provider"] = resolved_provider
+        changed = True
+    if client_id and seed.get("client_id") != client_id:
+        seed["client_id"] = client_id
+        changed = True
+    if admin_email and seed.get("bootstrap_admin_email") != admin_email:
+        seed["bootstrap_admin_email"] = admin_email
+        changed = True
+    return changed
+
+
 def _iter_bundle_specs(payload: dict | None):
     if not isinstance(payload, dict):
         return
@@ -2633,6 +2683,33 @@ def _connection_hub_cognito_provider_has_fields(assembly: dict, bundles_descript
     )
 
 
+def _bundle_session_client_id(assembly: dict, bundles_descriptor: dict | None) -> str:
+    """Resolve the Google client id for an application-hosted login descriptor set.
+
+    Reads assembly auth.bundle.client_id first, then the Connection Hub
+    google_oidc provider's authenticator in the bundles descriptor.
+    """
+    direct = _get_nested(assembly, "auth", "bundle", "client_id")
+    if _has_value(direct):
+        return str(direct).strip()
+    for spec in _iter_bundle_specs(bundles_descriptor):
+        authorities = _get_nested(spec, "config", "authority_registry", "authorities")
+        if not isinstance(authorities, dict):
+            continue
+        for authority in authorities.values():
+            providers = authority.get("providers") if isinstance(authority, dict) else None
+            if not isinstance(providers, dict):
+                continue
+            for prov in providers.values():
+                if not isinstance(prov, dict):
+                    continue
+                if str(prov.get("type") or "").strip().lower() == "google_id_token":
+                    cid = _get_nested(prov, "authenticator", "client_id")
+                    if _has_value(cid):
+                        return str(cid).strip()
+    return ""
+
+
 def _descriptor_fast_path_reasons(
     assembly: dict,
     *,
@@ -2664,8 +2741,20 @@ def _descriptor_fast_path_reasons(
             reasons.append(f"assembly {'.'.join(field)} is required")
 
     auth_type = str(_get_nested(assembly, "auth", "type") or "").strip().lower()
-    if auth_type not in {"simple", "cognito", "delegated"}:
-        reasons.append("assembly auth.type must be simple, cognito, or delegated")
+    if auth_type not in {"simple", "cognito", "delegated", "bundle"}:
+        reasons.append("assembly auth.type must be simple, cognito, delegated, or bundle")
+    if auth_type == "bundle":
+        provider = str(_get_nested(assembly, "auth", "bundle", "provider") or "google").strip().lower()
+        if provider not in installer_mod.SUPPORTED_BUNDLE_AUTH_PROVIDERS:
+            reasons.append(
+                f"application-hosted authentication provider '{provider}' is not supported "
+                "(currently supported: google)"
+            )
+        elif not _has_value(_bundle_session_client_id(assembly, bundles_descriptor)):
+            reasons.append(
+                "application-hosted login requires a Google client id "
+                "(assembly auth.bundle.client_id or the Connection Hub google_oidc provider)"
+            )
     if auth_type in {"cognito", "delegated"}:
         has_connection_hub_provider = _connection_hub_cognito_provider_has_fields(assembly, bundles_descriptor)
         if not has_connection_hub_provider:
@@ -3644,11 +3733,26 @@ def main() -> None:
 
     _sp = subparsers.add_parser("config", help="Export or import runtime descriptors")
     _add_quiet_arg(_sp)
-    _sp.add_argument("config_action", choices=("export", "import"), help="Descriptor operation")
+    _sp.add_argument("config_action", choices=("export", "import", "apply"), help="Descriptor operation")
     _sp.add_argument("--tenant", default="", help="Tenant of the runtime. With --project, composes under the platform default base.")
     _sp.add_argument("--project", default="", help="Project of the runtime. Pair with --tenant.")
     _sp.add_argument("--workdir", default=None, help="(Advanced) Fully-qualified namespaced runtime workdir")
     _sp.add_argument("--path", default=str(DEFAULT_DIR), help="Platform repo path")
+    _sp.add_argument(
+        "--auth-type",
+        choices=("bundle", "cognito", "simple", "delegated"),
+        default="",
+        help="With `config apply`, the platform authentication method to reconfigure to.",
+    )
+    _sp.add_argument("--provider", default="", help="With `config apply --auth-type bundle`, the login provider. Supported: google.")
+    _sp.add_argument("--client-id", default="", help="With `config apply --auth-type bundle`, the Google OAuth client id (Web application).")
+    _sp.add_argument(
+        "--bootstrap-admin-email",
+        default="",
+        help="With `config apply --auth-type bundle`, the verified Google email granted platform super-admin on first login.",
+    )
+    _sp.add_argument("--restart", action="store_true", help="With `config apply`, restart the runtime after writing the new configuration.")
+    _sp.add_argument("-i", "--interactive", action="store_true", help="With `config apply`, prompt for auth fields not given as flags.")
     _sp.add_argument("--out-dir", default="", help="With `config export`, output directory for exported files")
     _sp.add_argument("--descriptors-location", default="", help="With `config import`, source directory containing descriptors")
     _sp.add_argument(
@@ -3659,7 +3763,7 @@ def main() -> None:
     _sp.add_argument("--aws-region", default="", help="With `config export`, AWS region for aws-sm bundle descriptor export")
     _sp.add_argument("--aws-profile", default="", help="With `config export`, AWS profile for aws-sm bundle descriptor export")
     _sp.add_argument("--aws-sm-prefix", default="", help="With `config export`, explicit AWS Secrets Manager prefix")
-    _sp.add_argument("--dry-run", action="store_true", help="With `config import`, show what would change without staging files")
+    _sp.add_argument("--dry-run", action="store_true", help="With `config import` or `config apply`, show what would change without writing files")
     _sp.add_argument("--reload", action="store_true", dest="reload_changed", help="With `config import`, reload changed bundle ids after staging descriptors")
     _sp.add_argument("--json", action="store_true", dest="json_output", help="Print machine-readable JSON")
     _sp.add_argument(
@@ -3796,6 +3900,50 @@ def main() -> None:
         "--interactive",
         action="store_true",
         help="Prompt for required fields missing in the assembly instead of failing",
+    )
+    _sp.add_argument(
+        "--auth-type",
+        choices=("bundle", "cognito", "simple", "delegated"),
+        default="",
+        help=(
+            "Platform authentication method. 'bundle' is application-hosted login "
+            "(the app hosts the login page; KDCube accepts the result as a platform "
+            "session). Non-interactive installs must pass this to select the method."
+        ),
+    )
+    _sp.add_argument(
+        "--provider",
+        default="",
+        help="Application-hosted login provider for --auth-type bundle. Supported: google.",
+    )
+    _sp.add_argument(
+        "--client-id",
+        default="",
+        help="Google OAuth client id (Web application) for --auth-type bundle.",
+    )
+    _sp.add_argument(
+        "--bootstrap-admin-email",
+        default="",
+        help=(
+            "Verified Google email that receives the platform super-admin role on "
+            "first login, for --auth-type bundle."
+        ),
+    )
+    _sp.add_argument(
+        "--enable-telegram",
+        action="store_true",
+        help=(
+            "Configure the Telegram companion after application-hosted login setup. "
+            "Reads the bot token from KDCUBE_TELEGRAM_BOT_TOKEN and needs --external-https-url."
+        ),
+    )
+    _sp.add_argument(
+        "--external-https-url",
+        default="",
+        help=(
+            "Externally reachable HTTPS URL Telegram uses to reach the runtime "
+            "(webhook and Mini App). Required with --enable-telegram."
+        ),
     )
 
     _sp = subparsers.add_parser(
@@ -4523,7 +4671,101 @@ def main() -> None:
                 if args.json_output:
                     _print_json(_result)
                 return
-            raise SystemExit("Usage: kdcube config <export|import> ...")
+            if _action == "apply":
+                if _config_dir is None:
+                    raise SystemExit(
+                        f"Workdir is not initialized: {_resolved}\n"
+                        "`kdcube config apply` reconfigures a runtime created by `kdcube init`."
+                    )
+                if str(args.descriptors_location or "").strip() or str(args.out_dir or "").strip():
+                    raise SystemExit("--descriptors-location/--out-dir are not used with `kdcube config apply`.")
+                _assembly_path = _config_dir / "assembly.yaml"
+                _assembly = installer_mod.load_release_descriptor_soft(_assembly_path)
+                _apply_auth_flags(_op_console, _assembly, args)
+                _effective_type = str(_get_nested(_assembly, "auth", "type") or "").strip().lower()
+                if _effective_type != "bundle":
+                    raise SystemExit(
+                        "`kdcube config apply` reconfigures application-hosted login. "
+                        "Pass --auth-type bundle with --client-id (and optionally --bootstrap-admin-email)."
+                    )
+                _bundles = installer_mod.load_release_descriptor_soft(_config_dir / "bundles.yaml")
+                _client_id = _bundle_session_client_id(_assembly, _bundles)
+                if not args.interactive and not _has_value(_client_id):
+                    raise SystemExit(
+                        "`kdcube config apply --auth-type bundle` requires a Google client id "
+                        "(--client-id, or an existing application-hosted login runtime)."
+                    )
+                if args.dry_run:
+                    _preview_assembly = json.loads(json.dumps(_assembly))
+                    _preview_bundles = json.loads(json.dumps(_bundles))
+                    installer_mod.apply_bundle_session_auth(
+                        assembly_data=_preview_assembly,
+                        bundles_data=_preview_bundles,
+                        env_targets=[],
+                        client_id=_client_id or "<client-id>",
+                        provider=str(_get_nested(_assembly, "auth", "bundle", "provider") or "google"),
+                        bootstrap_admin_email=str(_get_nested(_assembly, "auth", "bundle", "bootstrap_admin_email") or ""),
+                    )
+                    _auth_preview = _get_nested(_preview_assembly, "auth") or {}
+                    if args.json_output:
+                        _print_json(
+                            {"status": "dry-run", "action": "apply", "workdir": str(_resolved), "auth": _auth_preview}
+                        )
+                    else:
+                        _op_console.print("[bold]config apply (dry-run)[/bold] — no files written")
+                        _op_console.print(f"[dim]workdir:[/dim] {_resolved}")
+                        _op_console.print(yaml.safe_dump({"auth": _auth_preview}, sort_keys=False).rstrip())
+                    return
+                installer_mod.save_release_descriptor(_assembly_path, _assembly)
+                _repo = _resolve_subcommand_repo(args.path, workdir=_resolved, path_provided=_arg_provided("--path"))
+                os.environ["KDCUBE_DESCRIPTORS_LOCATION"] = str(_config_dir)
+                os.environ["KDCUBE_ASSEMBLY_DESCRIPTOR_PATH"] = str(_assembly_path)
+                os.environ["KDCUBE_ASSEMBLY_USER_SUPPLIED"] = "0"
+                for _env_key, _env_name in (
+                    ("KDCUBE_SECRETS_DESCRIPTOR_PATH", "secrets.yaml"),
+                    ("KDCUBE_GATEWAY_DESCRIPTOR_PATH", "gateway.yaml"),
+                    ("KDCUBE_BUNDLES_DESCRIPTOR_PATH", "bundles.yaml"),
+                    ("KDCUBE_BUNDLES_SECRETS_PATH", "bundles.secrets.yaml"),
+                ):
+                    _env_path = _config_dir / _env_name
+                    if _env_path.exists():
+                        os.environ[_env_key] = str(_env_path)
+                os.environ["KDCUBE_ASSEMBLY_USE_BUNDLES"] = "1" if bool(_get_nested(_assembly, "bundles")) else "0"
+                os.environ["KDCUBE_ASSEMBLY_USE_FRONTEND"] = "1" if bool(_get_nested(_assembly, "frontend")) else "0"
+                os.environ["KDCUBE_ASSEMBLY_USE_PLATFORM"] = "0"
+                os.environ["KDCUBE_USE_BUNDLES_DESCRIPTOR"] = "1" if (_config_dir / "bundles.yaml").exists() else "0"
+                os.environ["KDCUBE_USE_BUNDLES_SECRETS"] = "1" if (_config_dir / "bundles.secrets.yaml").exists() else "0"
+                os.environ["KDCUBE_INIT_PREPARE_ONLY"] = "1"
+                if not args.interactive:
+                    os.environ["KDCUBE_CLI_NONINTERACTIVE"] = "1"
+                # Re-render env/bundles/frontend/nginx from the updated descriptors without Docker actions.
+                run_installer(_op_console, _repo, _resolved, "skip", None, None, True)
+                _t, _p = _parse_workdir_namespace(_resolved)
+                if args.restart:
+                    try:
+                        stop_compose_stack(_op_console, repo_root=_repo, workdir=_resolved)
+                    except SystemExit as _stop_exit:
+                        if "Deployment is not running" not in str(_stop_exit):
+                            raise
+                    _check_before_start(_op_console, tenant=_t, project=_p, workdir=_resolved)
+                    start_compose_stack(_op_console, repo_root=_repo, workdir=_resolved, build=False)
+                else:
+                    _op_console.print(
+                        "[dim]config apply: descriptors updated. Run "
+                        f"`kdcube refresh --workdir {_resolved}` (or pass --restart) to apply to the running stack.[/dim]"
+                    )
+                if args.json_output:
+                    _print_json(
+                        {
+                            "status": "ok",
+                            "action": "apply",
+                            "workdir": str(_resolved),
+                            "auth_type": _effective_type,
+                            "restarted": bool(args.restart),
+                        }
+                    )
+                return
+            raise SystemExit("Usage: kdcube config <export|import|apply> ...")
         if args.command == "export":
             _workdir = _resolve_subcommand_workdir(
                 args.workdir, cli_defaults,
@@ -4867,6 +5109,19 @@ def main() -> None:
                     "[dim]Added CORS origins to config/assembly.yaml:[/dim] "
                     + ", ".join(_added_cors_origins)
                 )
+            if _apply_auth_flags(console, _descriptor_bootstrap["assembly"], args):
+                installer_mod.save_release_descriptor(
+                    _descriptor_bootstrap["assembly_path"],
+                    _descriptor_bootstrap["assembly"],
+                )
+                console.print("[dim]Applied authentication settings to config/assembly.yaml.[/dim]")
+            if getattr(args, "enable_telegram", False):
+                os.environ["KDCUBE_ENABLE_TELEGRAM"] = "1"
+            _external_https_url = str(getattr(args, "external_https_url", "") or "").strip()
+            if _external_https_url:
+                os.environ["KDCUBE_TELEGRAM_EXTERNAL_HTTPS_URL"] = _external_https_url
+            if getattr(args, "enable_telegram", False) and not _external_https_url:
+                raise SystemExit("--enable-telegram requires --external-https-url.")
             _init_runtime_secrets = _parse_init_secret_pairs(args.set_secret)
             if args.prompt_secrets and not args.interactive:
                 _init_runtime_secrets = _prompt_init_standard_secrets(console, _init_runtime_secrets)
@@ -4891,6 +5146,15 @@ def main() -> None:
                 "0"
                 if _init_descriptors_location.resolve() == (_init_resolved / "config").resolve()
                 else "1"
+            )
+            # Recommend application-hosted login as the interactive default only when the
+            # auth type was not chosen explicitly: no user-supplied descriptor set and no
+            # --auth-type flag. Otherwise the explicit choice is honored.
+            os.environ["KDCUBE_RECOMMEND_BUNDLE_AUTH"] = (
+                "1"
+                if not str(args.descriptors_location or "").strip()
+                and not str(getattr(args, "auth_type", "") or "").strip()
+                else "0"
             )
             if _descriptor_bootstrap["secrets_path"]:
                 os.environ["KDCUBE_SECRETS_DESCRIPTOR_PATH"] = str(_descriptor_bootstrap["secrets_path"])

--- a/app/ai-app/src/kdcube-ai-app/kdcube_cli/src/kdcube_cli/installer.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_cli/src/kdcube_cli/installer.py
@@ -364,6 +364,26 @@ def patch_gateway_config_json(env: EnvFile, tenant: str, project: str) -> None:
     replace_multiline_block(env, "GATEWAY_CONFIG_JSON", _format_json_multiline("GATEWAY_CONFIG_JSON", data))
 
 
+def patch_gateway_descriptor_file(config_dir: Path, tenant: str, project: str) -> None:
+    """Substitute tenant/project into the staged gateway.yaml when they are placeholders."""
+    path = config_dir / "gateway.yaml"
+    if not path.exists():
+        return
+    data = load_release_descriptor(path)
+    gateway = data.get("gateway") if isinstance(data, dict) else None
+    if not isinstance(gateway, dict):
+        return
+    changed = False
+    if is_placeholder(_as_str(gateway.get("tenant"))):
+        gateway["tenant"] = tenant
+        changed = True
+    if is_placeholder(_as_str(gateway.get("project"))):
+        gateway["project"] = project
+        changed = True
+    if changed:
+        save_release_descriptor(path, data)
+
+
 def _load_json_file(path: Path) -> Dict[str, object]:
     try:
         return json.loads(path.read_text())
@@ -595,6 +615,514 @@ def _ensure_connection_hub_cognito_provider(
     )
 
 
+def _bundle_session_default_grants() -> Dict[str, object]:
+    """Default and assignable platform grants for a bundle-session provider."""
+    return {
+        "default": {"roles": ["kdcube:role:registered"], "permissions": []},
+        "assignable": {
+            "roles": ["kdcube:role:registered", "kdcube:role:super-admin"],
+            "permissions": ["kdcube:*:chat:*;read;write", "kdcube:*:*:*"],
+        },
+    }
+
+
+def _google_upstream_spec(client_id: str) -> Dict[str, object]:
+    """Upstream authenticator spec that verifies Google OIDC ID tokens.
+
+    Describes the `google.accounts/google_oidc` authority the bundle-session
+    provider trusts and the claim used to bootstrap an admin (verified Google email).
+    """
+    return {
+        "authority_id": "google.accounts",
+        "authority_label": "Google Accounts",
+        "provider_id": "google_oidc",
+        "provider_type": "google_id_token",
+        "authenticator": {"client_id": str(client_id or "")},
+        "bootstrap_id": "bootstrap_admin_by_google_email",
+        "bootstrap_provider": "google",
+        "bootstrap_email_claim": {"email_verified": True},
+    }
+
+
+def _ensure_connection_hub_bundle_session_provider(
+    bundles_data: Dict[str, object],
+    *,
+    connection_hub_bundle_id: str,
+    authority_id: str,
+    provider_id: str,
+    provider_label: str,
+    host_bundle_id: str,
+    ttl_seconds: int,
+    auth_token_cookie_name: str,
+    id_token_cookie_name: str,
+    masqueraded_token_cookie_name: str,
+    upstream: Dict[str, object],
+    admin_bootstrap_email: str = "",
+    login_operation: str = "platform_login",
+    session_issue_operation: str = "auth_google_session",
+    consent_operation: str = "delegated_consent",
+) -> None:
+    """Write the bundle-session platform authority into the Connection Hub descriptor.
+
+    Registers the platform authority (`platform: true`), its `bundle_session_login`
+    provider (issuer, grants, and the host-bundle login/session/consent entrypoints),
+    an optional admin bootstrap rule, and the upstream authenticator authority.
+    """
+    connection_hub = _ensure_bundle_item(bundles_data, connection_hub_bundle_id)
+    config = connection_hub.get("config")
+    if not isinstance(config, dict):
+        config = {}
+        connection_hub["config"] = config
+
+    authority_path = ["authority_registry", "authorities", authority_id]
+    _set_nested(config, authority_path + ["label"], "KDCube platform authority")
+    _set_nested(config, authority_path + ["platform"], True)
+    _set_nested(config, authority_path + ["grants", "subjects"], {})
+
+    if admin_bootstrap_email:
+        claims: Dict[str, object] = {"email": admin_bootstrap_email}
+        extra = upstream.get("bootstrap_email_claim")
+        if isinstance(extra, dict):
+            claims.update(extra)
+        _set_nested(
+            config,
+            authority_path + ["grants", "bootstrap_rules"],
+            [
+                {
+                    "id": str(upstream.get("bootstrap_id") or "bootstrap_admin_by_email"),
+                    "when": {"provider": str(upstream.get("bootstrap_provider") or ""), "claims": claims},
+                    "roles": ["kdcube:role:super-admin"],
+                    "permissions": ["kdcube:*:*:*"],
+                }
+            ],
+        )
+
+    _set_nested(
+        config,
+        authority_path + ["providers", provider_id],
+        {
+            "type": "bundle_session_login",
+            "enabled": True,
+            "label": provider_label,
+            "input": {
+                "authenticator_ref": {
+                    "authority_id": str(upstream.get("authority_id") or ""),
+                    "provider_id": str(upstream.get("provider_id") or ""),
+                }
+            },
+            "issuer": {
+                "type": "kdcube_session_token",
+                "ttl_seconds": int(ttl_seconds),
+                "cookie": {
+                    "secure": True,
+                    "same_site": "lax",
+                    "auth_token_cookie_name": auth_token_cookie_name,
+                    "id_token_cookie_name": id_token_cookie_name,
+                    "masqueraded_token_cookie_name": masqueraded_token_cookie_name,
+                },
+            },
+            "grants": _bundle_session_default_grants(),
+            "entrypoints": {
+                "login": {"bundle_id": host_bundle_id, "route": "public", "operation": login_operation},
+                "session_issue": {"bundle_id": host_bundle_id, "route": "public", "operation": session_issue_operation},
+                "consent": {"bundle_id": host_bundle_id, "route": "public", "operation": consent_operation},
+            },
+        },
+    )
+
+    upstream_authority = str(upstream.get("authority_id") or "")
+    upstream_provider = str(upstream.get("provider_id") or "")
+    upstream_authority_path = ["authority_registry", "authorities", upstream_authority]
+    _set_nested(config, upstream_authority_path + ["label"], str(upstream.get("authority_label") or ""))
+    _set_nested(config, upstream_authority_path + ["platform"], False)
+    _set_nested(
+        config,
+        upstream_authority_path + ["providers", upstream_provider],
+        {
+            "type": str(upstream.get("provider_type") or ""),
+            "enabled": True,
+            "authenticator": dict(upstream.get("authenticator") or {}),
+        },
+    )
+
+
+SUPPORTED_BUNDLE_AUTH_PROVIDERS = ("google",)
+
+
+def validate_bundle_auth_provider(console: Console, provider: str) -> str:
+    """Return the normalized provider, or abort if it is not supported."""
+    normalized = str(provider or "").strip().lower() or "google"
+    if normalized not in SUPPORTED_BUNDLE_AUTH_PROVIDERS:
+        supported = ", ".join(SUPPORTED_BUNDLE_AUTH_PROVIDERS)
+        console.print(
+            f"[yellow]WARNING: Application-hosted authentication provider '{provider}' "
+            f"is not supported.\nCurrently supported provider: {supported}.[/yellow]"
+        )
+        raise SystemExit(1)
+    return normalized
+
+
+def _bundle_session_existing_values(
+    bundles_data: Dict[str, object],
+    connection_hub_bundle_id: str,
+    authority_id: str,
+) -> Tuple[str, str]:
+    """Read the current upstream client_id and bootstrap admin email from the descriptor."""
+    config: Dict[str, object] = {}
+    for spec in _iter_bundle_specs(bundles_data):
+        if str(spec.get("id") or "").strip() == connection_hub_bundle_id:
+            cfg = spec.get("config")
+            config = cfg if isinstance(cfg, dict) else {}
+            break
+    upstream = _google_upstream_spec("")
+    client_id = _as_str(
+        _get_nested(
+            config, "authority_registry", "authorities", str(upstream["authority_id"]),
+            "providers", str(upstream["provider_id"]), "authenticator", "client_id",
+        )
+    ) or ""
+    admin_email = ""
+    rules = _get_nested(config, "authority_registry", "authorities", authority_id, "grants", "bootstrap_rules")
+    if isinstance(rules, list):
+        for rule in rules:
+            email = _get_nested(rule, "when", "claims", "email") if isinstance(rule, dict) else None
+            if email:
+                admin_email = str(email)
+                break
+    return client_id, admin_email
+
+
+def apply_bundle_session_auth(
+    *,
+    assembly_data: Dict[str, object],
+    bundles_data: Dict[str, object],
+    env_targets: list,
+    client_id: str,
+    provider: str = "google",
+    bootstrap_admin_email: str = "",
+    connection_hub_bundle_id: str = "connection-hub@1-0",
+    authority_id: str = "kdcube.platform",
+    provider_id: str = "workspace_google_session",
+    host_bundle_id: str = "workspace@2026-03-31-13-36",
+    provider_label: str = "Workspace Google platform session",
+    ttl_seconds: int = 43200,
+    auth_token_cookie_name: str = "__Secure-LATC",
+    id_token_cookie_name: str = "__Secure-LITC",
+    masqueraded_token_cookie_name: str = "__Secure-LMTC",
+    id_token_header_name: str = "X-ID-Token",
+) -> None:
+    """Apply the application-hosted (bundle-session) auth topology to descriptors and env.
+
+    Writes assembly.auth (Connection Hub provider selection), the Connection Hub
+    authority registry, cookie/AUTH_PROVIDER env, and clears leftover cognito/proxy
+    fields. Shared by `kdcube init` and `kdcube config apply`.
+    """
+    for env in env_targets:
+        # Selection is driven by assembly.auth.connection_hub; AUTH_PROVIDER is cleared.
+        update_env_value(env, "AUTH_PROVIDER", "")
+        update_env_value(env, "AUTH_TOKEN_COOKIE_NAME", auth_token_cookie_name)
+        update_env_value(env, "ID_TOKEN_COOKIE_NAME", id_token_cookie_name)
+        update_env_value(env, "ID_TOKEN_HEADER_NAME", id_token_header_name)
+
+    _set_nested(assembly_data, ["auth", "type"], "bundle")
+    _set_nested(assembly_data, ["auth", "idp"], "session")
+    _set_nested(
+        assembly_data,
+        ["auth", "connection_hub"],
+        {
+            "bundle_id": connection_hub_bundle_id,
+            "authority_id": authority_id,
+            "provider_id": provider_id,
+            "entrypoint": "login",
+        },
+    )
+    _set_nested(
+        assembly_data,
+        ["auth", "authenticators", "connection_hub"],
+        {"enabled": True, "app_id": connection_hub_bundle_id, "operation": "request_authenticate"},
+    )
+    for legacy_path in (
+        ["auth", "cognito"],
+        ["auth", "providers"],
+        ["auth", "jwks_cache_ttl_seconds"],
+        ["auth", "proxy_login"],
+        ["auth", "bundle"],
+        ["auth", "id_token_header_name"],
+        ["auth", "auth_token_cookie_name"],
+        ["auth", "id_token_cookie_name"],
+        ["auth", "masqueraded_token_cookie_name"],
+        ["frontend", "config", "auth"],
+    ):
+        _delete_nested(assembly_data, legacy_path)
+
+    _ensure_connection_hub_bundle_session_provider(
+        bundles_data,
+        connection_hub_bundle_id=connection_hub_bundle_id,
+        authority_id=authority_id,
+        provider_id=provider_id,
+        provider_label=provider_label,
+        host_bundle_id=host_bundle_id,
+        ttl_seconds=ttl_seconds,
+        auth_token_cookie_name=auth_token_cookie_name,
+        id_token_cookie_name=id_token_cookie_name,
+        masqueraded_token_cookie_name=masqueraded_token_cookie_name,
+        upstream=_google_upstream_spec(client_id),
+        admin_bootstrap_email=bootstrap_admin_email,
+    )
+
+
+# Stable, non-secret Telegram companion id used in webhook URLs, widget
+# auth-context headers, and Connection Hub identity/authority records.
+TELEGRAM_INTEGRATION_ID = "telegram.kdcube_ref"
+TELEGRAM_SECRET_STEM = "telegram_kdcube_ref"
+
+
+def telegram_webhook_url(external_https_url: str, tenant: str, project: str, host_bundle_id: str) -> str:
+    base = str(external_https_url or "").strip().rstrip("/")
+    return (
+        f"{base}/api/integrations/bundles/{tenant}/{project}/{host_bundle_id}"
+        f"/public/telegram_webhook?integration_id={TELEGRAM_INTEGRATION_ID}"
+    )
+
+
+def telegram_mini_app_url(external_https_url: str, tenant: str, project: str, host_bundle_id: str) -> str:
+    base = str(external_https_url or "").strip().rstrip("/")
+    return (
+        f"{base}/api/integrations/bundles/{tenant}/{project}/{host_bundle_id}"
+        f"/public/widgets/telegram_miniapp"
+    )
+
+
+def _telegram_api_call(bot_token: str, method: str, params: Optional[Dict[str, str]] = None, timeout: int = 15) -> Dict[str, object]:
+    """Call one Telegram Bot API method. Returns the parsed response or an {ok: false} error dict."""
+    import urllib.request
+    import urllib.error
+    from urllib.parse import urlencode
+
+    url = f"https://api.telegram.org/bot{bot_token}/{method}"
+    data = urlencode(params).encode() if params else None
+    request = urllib.request.Request(url, data=data, method="POST" if data else "GET")
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            return json.loads(response.read().decode())
+    except urllib.error.HTTPError as exc:
+        try:
+            return json.loads(exc.read().decode())
+        except Exception:
+            return {"ok": False, "description": f"HTTP {exc.code}"}
+    except Exception as exc:
+        return {"ok": False, "description": str(exc)}
+
+
+def telegram_get_me(bot_token: str) -> Dict[str, object]:
+    return _telegram_api_call(bot_token, "getMe")
+
+
+def telegram_set_webhook(bot_token: str, url: str, secret_token: str) -> Dict[str, object]:
+    return _telegram_api_call(bot_token, "setWebhook", {"url": url, "secret_token": secret_token})
+
+
+def telegram_get_webhook_info(bot_token: str) -> Dict[str, object]:
+    return _telegram_api_call(bot_token, "getWebhookInfo")
+
+
+def _upsert_telegram_identity_authenticator(ch_config: Dict[str, object]) -> None:
+    identity = ch_config.setdefault("identity", {})
+    if not isinstance(identity, dict):
+        identity = {}
+        ch_config["identity"] = identity
+    identity["enabled"] = True
+    # Edge projection resolves platform roles/economics from the linked platform
+    # user. Set the resolver defaults without clobbering an existing configuration.
+    identity.setdefault("authenticator_selector_cache", {"enabled": True, "ttl_seconds": 30})
+    identity.setdefault("role_resolver", {"mode": "platform"})
+    identity.setdefault("role_bindings", {})
+    authenticators = identity.setdefault("authenticators", [])
+    if not isinstance(authenticators, list):
+        authenticators = []
+        identity["authenticators"] = authenticators
+    entry = {
+        "id": TELEGRAM_INTEGRATION_ID,
+        "provider": "telegram",
+        "where": "built-in",
+        "enabled": True,
+        "role_providing": False,
+        "secret_ref": f"identity.authenticators.{TELEGRAM_SECRET_STEM}.bot_token",
+        "definition": {"label": "KDCube Telegram bot", "web_app_auth_max_age_seconds": 86400},
+    }
+    for index, existing in enumerate(authenticators):
+        if isinstance(existing, dict) and str(existing.get("id") or "") == TELEGRAM_INTEGRATION_ID:
+            authenticators[index] = entry
+            return
+    authenticators.append(entry)
+
+
+def apply_telegram_companion(
+    *,
+    bundles_data: Dict[str, object],
+    bundles_secrets_data: Dict[str, object],
+    tenant: str,
+    project: str,
+    bot_token: str,
+    external_https_url: str,
+    webhook_secret: str,
+    bot_name: str = "",
+    bot_username: str = "",
+    host_bundle_id: str = "workspace@2026-03-31-13-36",
+    connection_hub_bundle_id: str = "connection-hub@1-0",
+    web_app_auth_max_age_seconds: int = 86400,
+    link_challenge_ttl_seconds: int = 600,
+) -> None:
+    """Configure the Telegram companion channel on an application-hosted login runtime.
+
+    Adds the Telegram webhook integration and Mini App on the login host bundle,
+    the Connection Hub identity authenticator, authority, and link flow, and writes
+    the bot token and webhook secret into the bundle secrets.
+    """
+    webhook_url = telegram_webhook_url(external_https_url, tenant, project, host_bundle_id)
+
+    host = _ensure_bundle_item(bundles_data, host_bundle_id)
+    host_config = host.get("config")
+    if not isinstance(host_config, dict):
+        host_config = {}
+        host["config"] = host_config
+    _set_nested(
+        host_config,
+        ["integrations", TELEGRAM_INTEGRATION_ID],
+        {
+            "provider": "telegram",
+            "where": "built-in",
+            "enabled": True,
+            "secret_refs": {
+                "bot_token": f"integrations.{TELEGRAM_SECRET_STEM}.definition.bot_token",
+                "webhook_secret": f"integrations.{TELEGRAM_SECRET_STEM}.definition.webhook_secret",
+            },
+            "definition": {
+                "bot_name": bot_name,
+                "bot_username": bot_username,
+                "webhook": {"url": webhook_url, "send_responses": True, "stream_activity": True},
+                "web_app_auth_max_age_seconds": web_app_auth_max_age_seconds,
+            },
+        },
+    )
+    _set_nested(host_config, ["ui", "widgets", "telegram_miniapp", "enabled"], True)
+
+    connection_hub = _ensure_bundle_item(bundles_data, connection_hub_bundle_id)
+    ch_config = connection_hub.get("config")
+    if not isinstance(ch_config, dict):
+        ch_config = {}
+        connection_hub["config"] = ch_config
+    _upsert_telegram_identity_authenticator(ch_config)
+    _set_nested(
+        ch_config,
+        ["identity", "link_flows", "telegram"],
+        {"enabled": True, "challenge_ttl_seconds": link_challenge_ttl_seconds, "platform_claim_url": ""},
+    )
+    _set_nested(
+        ch_config,
+        ["authority_registry", "authorities", TELEGRAM_INTEGRATION_ID],
+        {
+            "label": "KDCube Telegram identity",
+            "platform": False,
+            "providers": {
+                "telegram_bot_init_data": {
+                    "type": "telegram_init_data",
+                    "enabled": True,
+                    "authenticator": {"secret_ref": f"identity.authenticators.{TELEGRAM_SECRET_STEM}.bot_token"},
+                }
+            },
+        },
+    )
+
+    _upsert_bundle_secret(
+        bundles_secrets_data,
+        bundle_id=connection_hub_bundle_id,
+        secret_path=["identity", "authenticators", TELEGRAM_SECRET_STEM, "bot_token"],
+        value=bot_token,
+    )
+    _upsert_bundle_secret(
+        bundles_secrets_data,
+        bundle_id=host_bundle_id,
+        secret_path=["integrations", TELEGRAM_SECRET_STEM, "definition", "bot_token"],
+        value=bot_token,
+    )
+    _upsert_bundle_secret(
+        bundles_secrets_data,
+        bundle_id=host_bundle_id,
+        secret_path=["integrations", TELEGRAM_SECRET_STEM, "definition", "webhook_secret"],
+        value=webhook_secret,
+    )
+
+
+def configure_telegram_companion(
+    console: Console,
+    *,
+    bundles_data: Dict[str, object],
+    bundles_secrets_data: Dict[str, object],
+    tenant: str,
+    project: str,
+    bot_token: str,
+    external_https_url: str,
+    host_bundle_id: str = "workspace@2026-03-31-13-36",
+    connection_hub_bundle_id: str = "connection-hub@1-0",
+) -> bool:
+    """Validate the bot, stage the Telegram companion descriptors, and register the webhook.
+
+    Calls getMe to validate the token and read the bot name, generates the webhook
+    secret, writes the companion descriptors and secrets, then setWebhook and
+    getWebhookInfo to register and verify. Returns True on success.
+    """
+    bot_token = str(bot_token or "").strip()
+    external_https_url = str(external_https_url or "").strip()
+    if not bot_token or not external_https_url:
+        console.print("[yellow]Telegram companion: bot token and external HTTPS URL are required; skipping.[/yellow]")
+        return False
+
+    me = telegram_get_me(bot_token)
+    if not me.get("ok"):
+        console.print(f"[red]Telegram companion: getMe failed: {me.get('description') or me}[/red]")
+        return False
+    result = me.get("result") if isinstance(me.get("result"), dict) else {}
+    bot_username = str(result.get("username") or "")
+    bot_name = str(result.get("first_name") or bot_username)
+    console.print(f"[dim]Telegram companion: bot @{bot_username} verified.[/dim]")
+
+    webhook_secret = secrets.token_urlsafe(32)
+    apply_telegram_companion(
+        bundles_data=bundles_data,
+        bundles_secrets_data=bundles_secrets_data,
+        tenant=tenant,
+        project=project,
+        bot_token=bot_token,
+        external_https_url=external_https_url,
+        webhook_secret=webhook_secret,
+        bot_name=bot_name,
+        bot_username=bot_username,
+        host_bundle_id=host_bundle_id,
+        connection_hub_bundle_id=connection_hub_bundle_id,
+    )
+
+    webhook_url = telegram_webhook_url(external_https_url, tenant, project, host_bundle_id)
+    set_result = telegram_set_webhook(bot_token, webhook_url, webhook_secret)
+    if not set_result.get("ok"):
+        console.print(f"[red]Telegram companion: setWebhook failed: {set_result.get('description') or set_result}[/red]")
+        return False
+    info = telegram_get_webhook_info(bot_token)
+    info_url = str((info.get("result") or {}).get("url") or "") if isinstance(info.get("result"), dict) else ""
+    if info_url != webhook_url:
+        console.print(
+            f"[yellow]Telegram companion: webhook registered but getWebhookInfo url mismatch "
+            f"(expected {webhook_url}, got {info_url or '<empty>'}).[/yellow]"
+        )
+    else:
+        console.print("[green]Telegram companion: webhook registered and verified.[/green]")
+    console.print(
+        "[dim]Telegram Mini App URL (set as BotFather Main Mini App + menu button):[/dim] "
+        + telegram_mini_app_url(external_https_url, tenant, project, host_bundle_id)
+    )
+    return True
+
+
 def _connection_hub_provider_config(
     assembly_data: Dict[str, object],
     bundles_data: Dict[str, object],
@@ -729,6 +1257,29 @@ def ensure_generated_runtime_secrets(config_dir: Path) -> Dict[str, str]:
 
     if generated:
         save_release_descriptor(secrets_path, secrets_data)
+
+    bundles_secrets_path = config_dir / "bundles.secrets.yaml"
+    if bundles_secrets_path.exists():
+        bundles_secrets_data = load_release_descriptor(bundles_secrets_path)
+        changed_bundles_secrets = False
+        for item in _iter_bundle_specs(bundles_secrets_data):
+            secrets_block = item.get("secrets")
+            if not isinstance(secrets_block, dict):
+                continue
+            bundle_id = str(item.get("id") or "")
+            for secret_path in (
+                ["connections", "oauth_state_secret"],
+                ["connections", "delegated_to_kdcube", "oauth_state_secret"],
+            ):
+                current = _get_nested(secrets_block, *secret_path)
+                if isinstance(current, str) and is_placeholder(current):
+                    value = secrets.token_hex(32)
+                    _set_nested(secrets_block, secret_path, value)
+                    changed_bundles_secrets = True
+                    generated[f"bundles.{bundle_id}.secrets.{'.'.join(secret_path)}"] = value
+        if changed_bundles_secrets:
+            save_release_descriptor(bundles_secrets_path, bundles_secrets_data)
+
     return generated
 
 
@@ -1040,6 +1591,38 @@ def update_nginx_routes_prefix(path: Path, routes_prefix: str) -> None:
             updated = root_redirect_re.sub(_insert_prefix_redirect, updated, count=1)
     if updated != current:
         path.write_text(updated)
+
+
+_NGINX_ORIGIN_HEADER_RE = re.compile(
+    r"^(?P<pre>\s*proxy_set_header\s+(?:Host|X-Forwarded-Host)\s+)\$host;",
+)
+
+
+def ensure_nginx_origin_forwarding(path: Path) -> None:
+    """Forward the browser's Host header (including port) to the backends.
+
+    Rewrites active ``proxy_set_header Host`` / ``X-Forwarded-Host`` directives
+    to use ``$http_host`` so the backend sees the request authority and port
+    the browser used (localhost:PORT, an ngrok host, HTTPS). Commented lines are
+    left as-is. Intended for the base HTTP proxy config; SSL configs keep
+    ``$host`` because they pin ``server_name`` and use it in redirects.
+    """
+    if not path.exists():
+        return
+    try:
+        lines = path.read_text().split("\n")
+    except Exception:
+        return
+    changed = False
+    for i, line in enumerate(lines):
+        if line.lstrip().startswith("#"):
+            continue
+        match = _NGINX_ORIGIN_HEADER_RE.match(line)
+        if match:
+            lines[i] = match.group("pre") + "$http_host;"
+            changed = True
+    if changed:
+        path.write_text("\n".join(lines))
 
 
 def update_nginx_ssl_domain(path: Path, domain: str) -> None:
@@ -2586,6 +3169,7 @@ def gather_configuration(
     _set_nested(assembly_data, ["context", "project"], project)
     for env in (env_ingress, env_proc, env_metrics):
         patch_gateway_config_json(env, tenant, project)
+    patch_gateway_descriptor_file(ctx.config_dir, tenant, project)
     if is_placeholder(env_pg.entries.get("TENANT_ID", (None, None))[1]) or is_default_tenant_project(
         env_pg.entries.get("TENANT_ID", (None, None))[1]
     ):
@@ -2625,7 +3209,13 @@ def gather_configuration(
         if isinstance(raw_auth, dict):
             auth_descriptor = raw_auth
     descriptor_auth_type = (auth_descriptor.get("type") or "").strip().lower()
-    auth_options = ["simple", "cognito", "delegated"]
+    auth_options = ["bundle", "cognito", "simple", "delegated"]
+    auth_option_labels = {
+        "bundle": "Application-hosted login (recommended)",
+        "cognito": "cognito",
+        "simple": "simple",
+        "delegated": "delegated",
+    }
     if descriptor_auth_type in auth_options:
         default_auth = descriptor_auth_type
     else:
@@ -2633,26 +3223,146 @@ def gather_configuration(
     current_proxy_cfg = env_main.entries.get("NGINX_PROXY_RUNTIME_CONFIG_PATH", (None, None))[1] or ""
     if "delegated" in current_proxy_cfg:
         default_auth = "delegated"
-    default_idx = auth_options.index(default_auth)
+    # The interactive prompt recommends bundle by default on a fresh init bootstrapped from
+    # the repo shipped defaults (no user-supplied descriptor and no explicit --auth-type),
+    # where the "simple" auth.type is only a baseline. An explicit auth choice — a
+    # user-supplied descriptor or --auth-type flag — is honored as-is via default_auth.
+    recommend_bundle_auth = os.getenv("KDCUBE_RECOMMEND_BUNDLE_AUTH", "").lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+    interactive_default_auth = default_auth
+    if (
+        recommend_bundle_auth
+        and descriptor_auth_type not in ("cognito", "delegated")
+        and (existing_auth or "").strip().lower() != "cognito"
+        and "delegated" not in current_proxy_cfg
+    ):
+        interactive_default_auth = "bundle"
     if default_local_bootstrap_mode and not force_prompt:
         auth_choice = default_auth
     else:
         console.print("[bold]Authentication[/bold]")
-        auth_choice = select_option(
+        display_options = [auth_option_labels[opt] for opt in auth_options]
+        selected_label = select_option(
             console,
             "Auth type",
-            options=auth_options,
-            default_index=default_idx,
+            options=display_options,
+            default_index=auth_options.index(interactive_default_auth),
         )
+        auth_choice = auth_options[display_options.index(selected_label)]
     auth_mode = auth_choice
     _set_nested(assembly_data, ["auth", "type"], auth_mode)
-    auth_provider = "simple" if auth_choice == "simple" else "cognito"
-    update_env_value(env_ingress, "AUTH_PROVIDER", auth_provider)
-    update_env_value(env_proc, "AUTH_PROVIDER", auth_provider)
+    if auth_choice == "simple":
+        auth_provider = "simple"
+    elif auth_choice == "bundle":
+        auth_provider = "session"
+    else:
+        auth_provider = "cognito"
+    # Bundle-session leaves AUTH_PROVIDER empty; simple/cognito set it.
+    auth_provider_env = "" if auth_provider == "session" else auth_provider
+    update_env_value(env_ingress, "AUTH_PROVIDER", auth_provider_env)
+    update_env_value(env_proc, "AUTH_PROVIDER", auth_provider_env)
     proxy_ssl_env = parse_bool(os.getenv("KDCUBE_PROXY_SSL"))
     proxy_ssl_descriptor = parse_bool(_get_nested(assembly_data, "proxy", "ssl"))
     proxy_ssl_enabled = proxy_ssl_env if proxy_ssl_env is not None else (proxy_ssl_descriptor or False)
     _set_nested(assembly_data, ["proxy", "ssl"], proxy_ssl_enabled)
+
+    if auth_provider == "session":
+        # Application-hosted login: collect the environment-specific inputs, then
+        # apply_bundle_session_auth writes the Workspace/Google topology.
+        bundle_seed = auth_descriptor.get("bundle") if isinstance(auth_descriptor.get("bundle"), dict) else {}
+        ch_ref = auth_descriptor.get("connection_hub") if isinstance(auth_descriptor.get("connection_hub"), dict) else {}
+
+        provider = validate_bundle_auth_provider(console, str(bundle_seed.get("provider") or "google"))
+        connection_hub_bundle_id = (
+            str(ch_ref.get("bundle_id") or ch_ref.get("bundleId") or "").strip() or "connection-hub@1-0"
+        )
+        authority_id = (
+            str(ch_ref.get("authority_id") or ch_ref.get("authorityId") or "").strip() or "kdcube.platform"
+        )
+        provider_id = (
+            str(ch_ref.get("provider_id") or ch_ref.get("providerId") or bundle_seed.get("provider_id") or "").strip()
+            or "workspace_google_session"
+        )
+        host_bundle_id = str(bundle_seed.get("host_bundle_id") or "").strip() or "workspace@2026-03-31-13-36"
+
+        existing_client_id, existing_admin_email = _bundle_session_existing_values(
+            bundles_data, connection_hub_bundle_id, authority_id
+        )
+
+        console.print("[bold]Application-hosted login[/bold]")
+        console.print(f"[dim]Application-hosted authentication provider: {provider}[/dim]")
+
+        client_id = str(bundle_seed.get("client_id") or "").strip()
+        if not client_id or force_prompt:
+            client_id = ask(
+                console,
+                "Google OAuth client_id (Web application)",
+                default=client_id or existing_client_id or None,
+            )
+        client_id = (client_id or "").strip()
+
+        admin_email = str(bundle_seed.get("bootstrap_admin_email") or "").strip()
+        if not admin_email or force_prompt:
+            admin_email = ask(
+                console,
+                "Bootstrap admin email (verified Google email; blank to skip)",
+                default=admin_email or existing_admin_email or "",
+            )
+        admin_email = (admin_email or "").strip()
+
+        try:
+            ttl_seconds = int(bundle_seed.get("session_ttl") or bundle_seed.get("ttl_seconds") or 43200)
+        except (TypeError, ValueError):
+            ttl_seconds = 43200
+
+        apply_bundle_session_auth(
+            assembly_data=assembly_data,
+            bundles_data=bundles_data,
+            env_targets=[env_main, env_ingress, env_proc],
+            client_id=client_id,
+            provider=provider,
+            bootstrap_admin_email=admin_email,
+            connection_hub_bundle_id=connection_hub_bundle_id,
+            authority_id=authority_id,
+            provider_id=provider_id,
+            host_bundle_id=host_bundle_id,
+            ttl_seconds=ttl_seconds,
+        )
+
+        # Optional Telegram companion. The browser login origin is request-derived;
+        # the external HTTPS URL is only how Telegram reaches the runtime.
+        telegram_bot_token = os.getenv("KDCUBE_TELEGRAM_BOT_TOKEN", "").strip()
+        telegram_external_url = os.getenv("KDCUBE_TELEGRAM_EXTERNAL_HTTPS_URL", "").strip()
+        telegram_wanted = parse_bool(os.getenv("KDCUBE_ENABLE_TELEGRAM", "")) is True
+        if not telegram_wanted and not _noninteractive_enabled():
+            telegram_wanted = ask_confirm(console, "Configure Telegram Companion now?", default=False)
+        if telegram_wanted:
+            if not telegram_bot_token:
+                telegram_bot_token = ask(console, "Telegram bot token", default=None, secret=True).strip()
+            if not telegram_external_url:
+                telegram_external_url = ask(console, "Externally reachable HTTPS URL", default=None).strip()
+            if configure_telegram_companion(
+                console,
+                bundles_data=bundles_data,
+                bundles_secrets_data=bundles_secrets_data,
+                tenant=tenant,
+                project=project,
+                bot_token=telegram_bot_token,
+                external_https_url=telegram_external_url,
+                host_bundle_id=host_bundle_id,
+                connection_hub_bundle_id=connection_hub_bundle_id,
+            ):
+                _autosave()
+                try:
+                    save_release_descriptor(
+                        (ctx.config_dir / "bundles.secrets.yaml").resolve(), bundles_secrets_data
+                    )
+                except Exception as exc:
+                    console.print(f"[yellow]Telegram companion: failed to persist bundle secrets: {exc}[/yellow]")
 
     if auth_provider == "cognito":
         def _pick(dct: Dict[str, Any], *keys: str) -> str:
@@ -4060,7 +4770,10 @@ def gather_configuration(
     company_name_raw = _get_nested(assembly_data, "company")
     company_name = company_name_raw.strip() if isinstance(company_name_raw, str) else None
 
-    if auth_provider == "simple":
+    if auth_provider in {"simple", "session"}:
+        # Bundle-session reuses the base proxy config and the hardcoded frontend
+        # template; the frontend authType is derived from assembly.auth when the
+        # config is generated.
         frontend_template = ctx.ai_app_root / "deployment/docker/all_in_one_kdcube/frontend/config.hardcoded.json"
         compose_ui_config = ctx.config_dir / "frontend.config.hardcoded.json"
         if ctx.docker_dir.name == "custom-ui-managed-infra":
@@ -4151,6 +4864,10 @@ def gather_configuration(
     runtime_proxy = Path(runtime_proxy_path).expanduser()
     sync_nginx_proxy_config(runtime_proxy, ctx.ai_app_root, defaults["nginx_proxy_config"], assembly=assembly_data)
     update_nginx_routes_prefix(runtime_proxy, routes_prefix)
+    # The base HTTP proxy config forwards the browser Host (with port); SSL
+    # configs keep $host for their pinned server_name and redirects.
+    if Path(defaults["nginx_proxy_config"]).name == "nginx_proxy.conf":
+        ensure_nginx_origin_forwarding(runtime_proxy)
     apply_nginx_frame_embedding_config(runtime_proxy, assembly_data)
     if proxy_ssl_enabled:
         ssl_domain = normalize_domain_host(_as_str(_get_nested(assembly_data, "domain")))
@@ -4193,7 +4910,7 @@ def gather_configuration(
     except Exception:
         pass
 
-    if auth_provider == "simple":
+    if auth_provider in {"simple", "session"}:
         dev_ui_config = ctx.ai_app_root / "ui/chat-web-app/public/private/config.hardcoded.json"
     elif auth_mode == "delegated":
         dev_ui_config = ctx.ai_app_root / "ui/chat-web-app/public/private/config.delegated.json"
@@ -4751,6 +5468,7 @@ def run_setup(
                 runtime_secrets=runtime_secrets,
             )
             console.print("[dim]Secrets persisted to staged descriptors.[/dim]")
+        ensure_generated_runtime_secrets(config_dir)
         return
 
     if install_mode == "release":
@@ -4872,6 +5590,7 @@ def run_setup(
                     config_dir=config_dir,
                     runtime_secrets=runtime_secrets,
                 )
+                ensure_generated_runtime_secrets(config_dir)
                 console.print("[dim]Applied runtime secrets to staged secrets-file descriptors.[/dim]")
             elif runtime_secrets:
                 console.print(

--- a/app/ai-app/src/kdcube-ai-app/kdcube_cli/src/kdcube_cli/installer.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_cli/src/kdcube_cli/installer.py
@@ -745,6 +745,140 @@ def _ensure_connection_hub_bundle_session_provider(
         },
     )
 
+    # The delegated-OAuth consent flow authenticates the approving user through the
+    # platform login provider. Attach its reference when the delegated connection exists.
+    delegated_oauth = _get_nested(config, "connections", "delegated_credentials", "oauth")
+    if isinstance(delegated_oauth, dict):
+        delegated_oauth["consent_ui"] = {
+            "mode": "authority_provider",
+            "authority_id": authority_id,
+            "provider_id": provider_id,
+            "entrypoint": "consent",
+        }
+
+
+# Provider key the cognito auth type writes under the platform authority.
+_COGNITO_PLATFORM_PROVIDER_ID = "cognito"
+
+
+def _find_bundle_item(payload: Dict[str, object] | None, bundle_id: str) -> Optional[Dict[str, object]]:
+    """Return the mutable bundle item for bundle_id, or None when it is absent."""
+    if not isinstance(payload, dict):
+        return None
+    bundles = payload.get("bundles")
+    if not isinstance(bundles, dict):
+        return None
+    items = bundles.get("items")
+    if isinstance(items, list):
+        for item in items:
+            if isinstance(item, dict) and str(item.get("id") or "").strip() == bundle_id:
+                return item
+        return None
+    item = bundles.get(bundle_id)
+    return item if isinstance(item, dict) else None
+
+
+def _platform_provider_exists(authorities: object, authority_id: object, provider_id: object) -> bool:
+    """True when authorities[authority_id].providers[provider_id] resolves."""
+    providers = _get_nested(authorities, str(authority_id), "providers") if isinstance(authorities, dict) else None
+    return isinstance(providers, dict) and str(provider_id) in providers
+
+
+def _collect_authenticator_refs(authorities: object) -> set:
+    """Authority ids referenced by any provider's authenticator_ref across the registry."""
+    refs: set = set()
+    if not isinstance(authorities, dict):
+        return refs
+    for authority in authorities.values():
+        providers = authority.get("providers") if isinstance(authority, dict) else None
+        if not isinstance(providers, dict):
+            continue
+        for provider in providers.values():
+            ref = _get_nested(provider, "input", "authenticator_ref", "authority_id") if isinstance(provider, dict) else None
+            if ref:
+                refs.add(str(ref))
+    return refs
+
+
+def _prune_dangling_platform_consent_ui(node: object, authorities: object) -> None:
+    """Remove consent_ui blocks whose referenced authority/provider no longer exists."""
+    if isinstance(node, dict):
+        consent = node.get("consent_ui")
+        if isinstance(consent, dict):
+            authority_id = consent.get("authority_id")
+            provider_id = consent.get("provider_id")
+            if (
+                authority_id is not None
+                and provider_id is not None
+                and not _platform_provider_exists(authorities, authority_id, provider_id)
+            ):
+                node.pop("consent_ui", None)
+        for value in node.values():
+            _prune_dangling_platform_consent_ui(value, authorities)
+    elif isinstance(node, list):
+        for item in node:
+            _prune_dangling_platform_consent_ui(item, authorities)
+
+
+def _prune_foreign_platform_login(
+    bundles_data: Dict[str, object],
+    *,
+    connection_hub_bundle_id: str,
+    authority_id: str,
+    keep_provider_ids: set,
+    keep_bootstrap_rules: bool,
+) -> None:
+    """Reconcile the platform authority to the target auth type's login artifacts.
+
+    Keeps only the platform providers in keep_provider_ids (the provider the target auth
+    type just wrote), garbage-collects upstream authorities no longer referenced by any
+    surviving provider, optionally removes the admin bootstrap rules, and drops consent_ui
+    blocks left without a provider. Platform grants.subjects, the telegram authority, and
+    delegated connectors are preserved.
+    """
+    item = _find_bundle_item(bundles_data, connection_hub_bundle_id)
+    if not isinstance(item, dict):
+        return
+    config = item.get("config")
+    if not isinstance(config, dict):
+        return
+    authorities = _get_nested(config, "authority_registry", "authorities")
+    if not isinstance(authorities, dict):
+        return
+    platform = authorities.get(authority_id)
+    if not isinstance(platform, dict):
+        return
+
+    providers = platform.get("providers")
+    removed_upstreams: set = set()
+    if isinstance(providers, dict):
+        for provider_id in list(providers.keys()):
+            if provider_id in keep_provider_ids:
+                continue
+            provider = providers.get(provider_id)
+            ref = _get_nested(provider, "input", "authenticator_ref", "authority_id") if isinstance(provider, dict) else None
+            if ref:
+                removed_upstreams.add(str(ref))
+            providers.pop(provider_id, None)
+
+    surviving_refs = _collect_authenticator_refs(authorities)
+    for orphan in removed_upstreams - surviving_refs - {authority_id}:
+        authorities.pop(orphan, None)
+
+    if not keep_bootstrap_rules:
+        _delete_nested(platform, ["grants", "bootstrap_rules"])
+        # Drop the empty grant scaffolding left by the bundle-session default,
+        # while preserving any real per-subject grants.
+        grants = platform.get("grants")
+        if isinstance(grants, dict):
+            subjects = grants.get("subjects")
+            if isinstance(subjects, dict) and not subjects:
+                grants.pop("subjects", None)
+            if not grants:
+                platform.pop("grants", None)
+
+    _prune_dangling_platform_consent_ui(config, authorities)
+
 
 SUPPORTED_BUNDLE_AUTH_PROVIDERS = ("google",)
 
@@ -870,11 +1004,49 @@ def apply_bundle_session_auth(
         admin_bootstrap_email=bootstrap_admin_email,
     )
 
+    _prune_foreign_platform_login(
+        bundles_data,
+        connection_hub_bundle_id=connection_hub_bundle_id,
+        authority_id=authority_id,
+        keep_provider_ids={provider_id},
+        keep_bootstrap_rules=True,
+    )
+
 
 # Stable, non-secret Telegram companion id used in webhook URLs, widget
 # auth-context headers, and Connection Hub identity/authority records.
 TELEGRAM_INTEGRATION_ID = "telegram.kdcube_ref"
 TELEGRAM_SECRET_STEM = "telegram_kdcube_ref"
+
+
+def _origin_from_url(url: str) -> str:
+    """Return the scheme://host[:port] origin of a URL, or empty when it has none."""
+    from urllib.parse import urlsplit
+
+    parts = urlsplit(str(url or "").strip())
+    if not parts.scheme or not parts.netloc:
+        return ""
+    return f"{parts.scheme}://{parts.netloc}"
+
+
+def _ensure_cors_allow_origin(assembly_data: Dict[str, object], url: str) -> bool:
+    """Add the URL's origin to assembly cors.allow_origins when missing.
+
+    An externally reachable origin (e.g. a tunnel used by a Telegram Mini App) must be
+    allow-listed so its cross-origin WebSocket/HTTP requests are accepted. Returns True
+    when the origin was added.
+    """
+    origin = _origin_from_url(url)
+    if not origin:
+        return False
+    origins = _get_nested(assembly_data, "cors", "allow_origins")
+    if not isinstance(origins, list):
+        origins = []
+        _set_nested(assembly_data, ["cors", "allow_origins"], origins)
+    if "*" in origins or origin in origins:
+        return False
+    origins.append(origin)
+    return True
 
 
 def telegram_webhook_url(external_https_url: str, tenant: str, project: str, host_bundle_id: str) -> str:
@@ -3245,14 +3417,21 @@ def gather_configuration(
         auth_choice = default_auth
     else:
         console.print("[bold]Authentication[/bold]")
-        display_options = [auth_option_labels[opt] for opt in auth_options]
+        # Delegated is not offered as a new interactive choice. It stays selectable only
+        # when it is already the configured mode, so a delegated runtime is preserved.
+        picker_options = [
+            opt for opt in auth_options
+            if opt != "delegated" or interactive_default_auth == "delegated"
+        ]
+        display_options = [auth_option_labels[opt] for opt in picker_options]
+        picker_default = interactive_default_auth if interactive_default_auth in picker_options else "cognito"
         selected_label = select_option(
             console,
             "Auth type",
             options=display_options,
-            default_index=auth_options.index(interactive_default_auth),
+            default_index=picker_options.index(picker_default),
         )
-        auth_choice = auth_options[display_options.index(selected_label)]
+        auth_choice = picker_options[display_options.index(selected_label)]
     auth_mode = auth_choice
     _set_nested(assembly_data, ["auth", "type"], auth_mode)
     if auth_choice == "simple":
@@ -3270,6 +3449,11 @@ def gather_configuration(
     proxy_ssl_enabled = proxy_ssl_env if proxy_ssl_env is not None else (proxy_ssl_descriptor or False)
     _set_nested(assembly_data, ["proxy", "ssl"], proxy_ssl_enabled)
 
+    # Telegram companion host defaults; the session branch overrides them with the
+    # application-hosted login's own host/connection-hub bundle ids.
+    telegram_host_bundle_id = "workspace@2026-03-31-13-36"
+    telegram_connection_hub_bundle_id = "connection-hub@1-0"
+
     if auth_provider == "session":
         # Application-hosted login: collect the environment-specific inputs, then
         # apply_bundle_session_auth writes the Workspace/Google topology.
@@ -3283,8 +3467,11 @@ def gather_configuration(
         authority_id = (
             str(ch_ref.get("authority_id") or ch_ref.get("authorityId") or "").strip() or "kdcube.platform"
         )
+        # The provider id is the bundle-session provider key. It comes from the
+        # bundle seed or the default, not from auth.connection_hub, whose provider_id
+        # reflects whatever auth type is currently active (e.g. cognito).
         provider_id = (
-            str(ch_ref.get("provider_id") or ch_ref.get("providerId") or bundle_seed.get("provider_id") or "").strip()
+            str(bundle_seed.get("provider_id") or bundle_seed.get("providerId") or "").strip()
             or "workspace_google_session"
         )
         host_bundle_id = str(bundle_seed.get("host_bundle_id") or "").strip() or "workspace@2026-03-31-13-36"
@@ -3332,37 +3519,8 @@ def gather_configuration(
             host_bundle_id=host_bundle_id,
             ttl_seconds=ttl_seconds,
         )
-
-        # Optional Telegram companion. The browser login origin is request-derived;
-        # the external HTTPS URL is only how Telegram reaches the runtime.
-        telegram_bot_token = os.getenv("KDCUBE_TELEGRAM_BOT_TOKEN", "").strip()
-        telegram_external_url = os.getenv("KDCUBE_TELEGRAM_EXTERNAL_HTTPS_URL", "").strip()
-        telegram_wanted = parse_bool(os.getenv("KDCUBE_ENABLE_TELEGRAM", "")) is True
-        if not telegram_wanted and not _noninteractive_enabled():
-            telegram_wanted = ask_confirm(console, "Configure Telegram Companion now?", default=False)
-        if telegram_wanted:
-            if not telegram_bot_token:
-                telegram_bot_token = ask(console, "Telegram bot token", default=None, secret=True).strip()
-            if not telegram_external_url:
-                telegram_external_url = ask(console, "Externally reachable HTTPS URL", default=None).strip()
-            if configure_telegram_companion(
-                console,
-                bundles_data=bundles_data,
-                bundles_secrets_data=bundles_secrets_data,
-                tenant=tenant,
-                project=project,
-                bot_token=telegram_bot_token,
-                external_https_url=telegram_external_url,
-                host_bundle_id=host_bundle_id,
-                connection_hub_bundle_id=connection_hub_bundle_id,
-            ):
-                _autosave()
-                try:
-                    save_release_descriptor(
-                        (ctx.config_dir / "bundles.secrets.yaml").resolve(), bundles_secrets_data
-                    )
-                except Exception as exc:
-                    console.print(f"[yellow]Telegram companion: failed to persist bundle secrets: {exc}[/yellow]")
+        telegram_host_bundle_id = host_bundle_id
+        telegram_connection_hub_bundle_id = connection_hub_bundle_id
 
     if auth_provider == "cognito":
         def _pick(dct: Dict[str, Any], *keys: str) -> str:
@@ -3509,6 +3667,7 @@ def gather_configuration(
             masqueraded_token_cookie_name=masqueraded_token_cookie_name,
             jwks_cache_ttl_seconds=int(jwks_cache_ttl) if jwks_cache_ttl.isdigit() else jwks_cache_ttl,
         )
+        _set_nested(assembly_data, ["auth", "idp"], "cognito")
         _set_nested(
             assembly_data,
             ["auth", "connection_hub"],
@@ -3518,6 +3677,18 @@ def gather_configuration(
                 "provider_id": "cognito",
             },
         )
+        _set_nested(
+            assembly_data,
+            ["auth", "authenticators", "connection_hub"],
+            {"enabled": True, "app_id": "connection-hub@1-0", "operation": "request_authenticate"},
+        )
+        _prune_foreign_platform_login(
+            bundles_data,
+            connection_hub_bundle_id="connection-hub@1-0",
+            authority_id="kdcube.platform",
+            keep_provider_ids={_COGNITO_PLATFORM_PROVIDER_ID},
+            keep_bootstrap_rules=False,
+        )
         for legacy_path in (
             ["auth", "cognito"],
             ["auth", "providers"],
@@ -3526,6 +3697,8 @@ def gather_configuration(
             ["auth", "id_token_cookie_name"],
             ["auth", "masqueraded_token_cookie_name"],
             ["auth", "jwks_cache_ttl_seconds"],
+            # The frontend derives authType from assembly.auth; drop the stale override.
+            ["frontend", "config", "auth"],
         ):
             _delete_nested(assembly_data, legacy_path)
 
@@ -3658,6 +3831,55 @@ def gather_configuration(
                 http_urlbase = f"{scheme}://{proxy_domain}/auth"
             update_env_value(env_proxy, "HTTP_URLBASE", http_urlbase)
             _set_nested(assembly_data, ["auth", "proxy_login", "http_urlbase"], http_urlbase)
+
+    if auth_provider == "simple":
+        _set_nested(assembly_data, ["auth", "idp"], "simple")
+        _set_nested(assembly_data, ["auth", "authenticators", "connection_hub", "enabled"], False)
+        _delete_nested(assembly_data, ["auth", "connection_hub"])
+        # The frontend derives authType from assembly.auth; drop a stale override.
+        _delete_nested(assembly_data, ["frontend", "config", "auth"])
+        _prune_foreign_platform_login(
+            bundles_data,
+            connection_hub_bundle_id="connection-hub@1-0",
+            authority_id="kdcube.platform",
+            keep_provider_ids=set(),
+            keep_bootstrap_rules=False,
+        )
+
+    # Optional Telegram companion, offered for every auth type. The browser login
+    # origin is request-derived; the external HTTPS URL is only how Telegram reaches
+    # the runtime. The telegram authority is independent of the platform login provider.
+    telegram_bot_token = os.getenv("KDCUBE_TELEGRAM_BOT_TOKEN", "").strip()
+    telegram_external_url = os.getenv("KDCUBE_TELEGRAM_EXTERNAL_HTTPS_URL", "").strip()
+    telegram_wanted = parse_bool(os.getenv("KDCUBE_ENABLE_TELEGRAM", "")) is True
+    if not telegram_wanted and not _noninteractive_enabled():
+        telegram_wanted = ask_confirm(console, "Configure Telegram Companion now?", default=False)
+    if telegram_wanted:
+        if not telegram_bot_token:
+            telegram_bot_token = ask(console, "Telegram bot token", default=None, secret=True).strip()
+        if not telegram_external_url:
+            telegram_external_url = ask(console, "Externally reachable HTTPS URL", default=None).strip()
+        # The Mini App is served from this external origin; allow-list it so its
+        # cross-origin WebSocket (Connection Hub link flow) and requests are accepted.
+        if _ensure_cors_allow_origin(assembly_data, telegram_external_url):
+            console.print(f"[dim]Added {_origin_from_url(telegram_external_url)} to cors.allow_origins.[/dim]")
+        if configure_telegram_companion(
+            console,
+            bundles_data=bundles_data,
+            bundles_secrets_data=bundles_secrets_data,
+            tenant=tenant,
+            project=project,
+            bot_token=telegram_bot_token,
+            external_https_url=telegram_external_url,
+            host_bundle_id=telegram_host_bundle_id,
+            connection_hub_bundle_id=telegram_connection_hub_bundle_id,
+        ):
+            try:
+                save_release_descriptor(
+                    (ctx.config_dir / "bundles.secrets.yaml").resolve(), bundles_secrets_data
+                )
+            except Exception as exc:
+                console.print(f"[yellow]Telegram companion: failed to persist bundle secrets: {exc}[/yellow]")
 
     _autosave()
 
@@ -4849,6 +5071,19 @@ def gather_configuration(
         id_token_cookie_name=id_token_cookie_name_val,
         assembly=assembly_data,
     )
+    # Remove frontend config files for other auth types so reconfiguring does not
+    # leave stale copies next to the active one.
+    for stale_name in (
+        "frontend.config.hardcoded.json",
+        "frontend.config.cognito.json",
+        "frontend.config.delegated.json",
+    ):
+        stale_path = ctx.config_dir / stale_name
+        if stale_path.exists() and stale_path.resolve() != compose_ui_config.resolve():
+            try:
+                stale_path.unlink()
+            except OSError:
+                pass
     routes_prefix = proxy_route_prefix or normalize_routes_prefix(_load_json_file(compose_ui_config).get("routesPrefix"))
     runtime_proxy_path = env_main.entries.get("NGINX_PROXY_RUNTIME_CONFIG_PATH", (None, None))[1]
     desired_runtime_path = str((ctx.config_dir / Path(defaults["nginx_proxy_config"]).name).resolve())

--- a/app/ai-app/src/kdcube-ai-app/kdcube_cli/tests/test_cli_descriptors.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_cli/tests/test_cli_descriptors.py
@@ -1,6 +1,9 @@
 import json
 import subprocess
 from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
 
 import yaml
 from rich.console import Console
@@ -18,6 +21,8 @@ from kdcube_cli.cli import (
     _cli_quiet_requested,
     _compose_running_services,
     _descriptor_fast_path_reasons,
+    _apply_auth_flags,
+    _bundle_session_client_id,
     _compose_logs_dir_from_env,
     _load_bundle_ids_from_descriptor,
     _load_cli_defaults,
@@ -36,12 +41,20 @@ from kdcube_cli.cli import (
 )
 from kdcube_cli import export_live_bundles as export_mod
 from kdcube_cli.installer import (
+    EnvFile,
     PathsContext,
+    TELEGRAM_INTEGRATION_ID,
+    TELEGRAM_SECRET_STEM,
+    apply_bundle_session_auth,
+    apply_telegram_companion,
+    telegram_mini_app_url,
+    telegram_webhook_url,
     _connection_hub_provider_config,
     apply_runtime_secrets_to_file_descriptors,
     build_ui_url,
     ensure_generated_runtime_secrets,
     ensure_local_dirs,
+    patch_gateway_descriptor_file,
     gather_configuration,
     render_nginx_frame_embedding_config,
     resolve_frontend_routes_prefix,
@@ -3640,3 +3653,402 @@ def test_resolve_subcommand_workdir_uses_default_workdir(tmp_path: Path):
     resolved = _resolve_subcommand_workdir(None, {"default_workdir": str(default)})
 
     assert resolved == default.resolve()
+
+
+def _empty_env() -> EnvFile:
+    return EnvFile(path=Path(".env"), lines=[], entries={})
+
+
+def _bundle_provider(bundles_data: dict) -> dict:
+    item = bundles_data["bundles"]["items"][0]
+    authorities = item["config"]["authority_registry"]["authorities"]
+    return authorities["kdcube.platform"]["providers"]["workspace_google_session"]
+
+
+def test_apply_bundle_session_auth_generates_topology():
+    assembly: dict = {
+        "auth": {"type": "cognito", "cognito": {"region": "eu-west-1"}},
+        "frontend": {"config": {"routesPrefix": "/platform", "auth": {"authType": "simple", "token": "test-admin-token-123"}}},
+    }
+    bundles: dict = {"bundles": {"items": [{"id": "connection-hub@1-0", "config": {}}]}}
+    env_main, env_ingress, env_proc = _empty_env(), _empty_env(), _empty_env()
+
+    apply_bundle_session_auth(
+        assembly_data=assembly,
+        bundles_data=bundles,
+        env_targets=[env_main, env_ingress, env_proc],
+        client_id="test-web.apps.googleusercontent.com",
+        provider="google",
+        bootstrap_admin_email="owner@example.com",
+    )
+
+    # assembly selects the Connection Hub bundle-session provider and drops cognito.
+    assert assembly["auth"]["type"] == "bundle"
+    assert assembly["auth"]["idp"] == "session"
+    assert assembly["auth"]["connection_hub"] == {
+        "bundle_id": "connection-hub@1-0",
+        "authority_id": "kdcube.platform",
+        "provider_id": "workspace_google_session",
+        "entrypoint": "login",
+    }
+    assert assembly["auth"]["authenticators"]["connection_hub"]["app_id"] == "connection-hub@1-0"
+    assert "cognito" not in assembly["auth"]
+    # Cookie/header names and the input seed live in env and the CH provider, not assembly.auth.
+    for stray in (
+        "bundle",
+        "auth_token_cookie_name",
+        "id_token_cookie_name",
+        "id_token_header_name",
+        "masqueraded_token_cookie_name",
+    ):
+        assert stray not in assembly["auth"]
+    # The frontend derives authType from assembly auth; the simple/test-token override is cleared.
+    assert "auth" not in assembly["frontend"]["config"]
+    assert assembly["frontend"]["config"]["routesPrefix"] == "/platform"
+
+    # AUTH_PROVIDER is cleared; cookie names are written on every worker env.
+    for env in (env_main, env_ingress, env_proc):
+        assert env.entries["AUTH_PROVIDER"][1] == ""
+        assert env.entries["AUTH_TOKEN_COOKIE_NAME"][1] == "__Secure-LATC"
+        assert env.entries["ID_TOKEN_COOKIE_NAME"][1] == "__Secure-LITC"
+
+    # Connection Hub authority registry carries the platform provider and upstream.
+    provider = _bundle_provider(bundles)
+    assert provider["type"] == "bundle_session_login"
+    assert provider["input"]["authenticator_ref"] == {
+        "authority_id": "google.accounts",
+        "provider_id": "google_oidc",
+    }
+    assert provider["issuer"]["type"] == "kdcube_session_token"
+
+    authorities = bundles["bundles"]["items"][0]["config"]["authority_registry"]["authorities"]
+    assert authorities["kdcube.platform"]["platform"] is True
+    # Role policy lives on the provider; the authority grants hold subjects/bootstrap only.
+    platform_grants = authorities["kdcube.platform"]["grants"]
+    assert platform_grants["subjects"] == {}
+    assert "default" not in platform_grants and "assignable" not in platform_grants
+    assert provider["grants"]["default"]["roles"] == ["kdcube:role:registered"]
+    google = authorities["google.accounts"]["providers"]["google_oidc"]
+    assert google["type"] == "google_id_token"
+    assert google["authenticator"]["client_id"] == "test-web.apps.googleusercontent.com"
+
+
+def test_apply_bundle_session_auth_omits_bootstrap_rule_without_email():
+    assembly: dict = {"auth": {"type": "simple"}}
+    bundles: dict = {"bundles": {"items": [{"id": "connection-hub@1-0", "config": {}}]}}
+
+    apply_bundle_session_auth(
+        assembly_data=assembly,
+        bundles_data=bundles,
+        env_targets=[_empty_env()],
+        client_id="test-web.apps.googleusercontent.com",
+        provider="google",
+        bootstrap_admin_email="",
+    )
+
+    grants = _bundle_provider(bundles)["grants"]
+    assert "bootstrap_rules" not in grants
+
+
+def _bundle_assembly(client_id: str = "web.apps.googleusercontent.com") -> dict:
+    return {
+        "context": {"tenant": "acme", "project": "platform"},
+        "platform": {"ref": "2026.4.04.318"},
+        "secrets": {"provider": "secrets-file"},
+        "auth": {"type": "bundle", "bundle": {"provider": "google", "client_id": client_id}},
+        "proxy": {"ssl": False},
+    }
+
+
+def test_descriptor_fast_path_accepts_bundle():
+    reasons = _descriptor_fast_path_reasons(
+        _bundle_assembly(),
+        have_secrets=True,
+        have_gateway=True,
+        latest=False,
+        release=None,
+    )
+
+    assert reasons == []
+
+
+def test_descriptor_fast_path_bundle_reads_client_id_from_bundles_descriptor():
+    assembly = _bundle_assembly(client_id="")
+    assembly["auth"]["bundle"].pop("client_id")
+    bundles = {
+        "bundles": {
+            "items": [
+                {
+                    "id": "connection-hub@1-0",
+                    "config": {
+                        "authority_registry": {
+                            "authorities": {
+                                "google.accounts": {
+                                    "providers": {
+                                        "google_oidc": {
+                                            "type": "google_id_token",
+                                            "authenticator": {"client_id": "from-bundles.apps.googleusercontent.com"},
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                }
+            ]
+        }
+    }
+
+    assert _bundle_session_client_id(assembly, bundles) == "from-bundles.apps.googleusercontent.com"
+    reasons = _descriptor_fast_path_reasons(
+        assembly,
+        have_secrets=True,
+        have_gateway=True,
+        bundles_descriptor=bundles,
+        latest=False,
+        release=None,
+    )
+    assert reasons == []
+
+
+def test_descriptor_fast_path_rejects_unsupported_bundle_provider():
+    assembly = _bundle_assembly()
+    assembly["auth"]["bundle"]["provider"] = "telegram"
+
+    reasons = _descriptor_fast_path_reasons(
+        assembly,
+        have_secrets=True,
+        have_gateway=True,
+        latest=False,
+        release=None,
+    )
+
+    assert any("not supported" in reason for reason in reasons)
+
+
+def test_descriptor_fast_path_bundle_requires_client_id():
+    assembly = _bundle_assembly(client_id="")
+    assembly["auth"]["bundle"].pop("client_id")
+
+    reasons = _descriptor_fast_path_reasons(
+        assembly,
+        have_secrets=True,
+        have_gateway=True,
+        latest=False,
+        release=None,
+    )
+
+    assert any("Google client id" in reason for reason in reasons)
+
+
+def test_apply_auth_flags_seeds_bundle_from_flags():
+    console = Console()
+    assembly: dict = {"auth": {"type": "simple"}}
+    args = SimpleNamespace(
+        auth_type="bundle",
+        provider="google",
+        client_id="flag-web.apps.googleusercontent.com",
+        bootstrap_admin_email="owner@example.com",
+    )
+
+    changed = _apply_auth_flags(console, assembly, args)
+
+    assert changed is True
+    assert assembly["auth"]["type"] == "bundle"
+    assert assembly["auth"]["bundle"] == {
+        "provider": "google",
+        "client_id": "flag-web.apps.googleusercontent.com",
+        "bootstrap_admin_email": "owner@example.com",
+    }
+
+
+def test_apply_auth_flags_rejects_unsupported_provider():
+    console = Console()
+    assembly: dict = {"auth": {"type": "simple"}}
+    args = SimpleNamespace(
+        auth_type="bundle",
+        provider="telegram",
+        client_id="web.apps.googleusercontent.com",
+        bootstrap_admin_email="",
+    )
+
+    with pytest.raises(SystemExit):
+        _apply_auth_flags(console, assembly, args)
+
+
+def test_apply_auth_flags_bundle_flags_require_bundle_auth_type():
+    console = Console()
+    assembly: dict = {"auth": {"type": "simple"}}
+    args = SimpleNamespace(
+        auth_type="",
+        provider="google",
+        client_id="web.apps.googleusercontent.com",
+        bootstrap_admin_email="",
+    )
+
+    with pytest.raises(SystemExit):
+        _apply_auth_flags(console, assembly, args)
+
+
+def test_build_frontend_config_bundle_derives_authtype_and_drops_token():
+    from kdcube_cli.frontend_config import build_frontend_config
+
+    # Worst case: base template ships simple auth with a hardcoded dev token.
+    template = {"auth": {"authType": "simple", "token": "test-admin-token-123"}, "routesPrefix": "/x"}
+    assembly = {
+        "auth": {
+            "type": "bundle",
+            "idp": "session",
+            "connection_hub": {
+                "bundle_id": "connection-hub@1-0",
+                "authority_id": "kdcube.platform",
+                "provider_id": "workspace_google_session",
+                "entrypoint": "login",
+            },
+        }
+    }
+
+    out = build_frontend_config(tenant="t", project="p", assembly=assembly, template_data=template)
+
+    assert out["auth"]["authType"] == "bundle"
+    assert "token" not in out["auth"]
+    assert out["auth"]["connectionHub"]["providerId"] == "workspace_google_session"
+
+
+def test_telegram_webhook_and_mini_app_urls():
+    webhook = telegram_webhook_url("https://runtime.example.com/", "demo", "proj", "workspace@2026-03-31-13-36")
+    assert webhook == (
+        "https://runtime.example.com/api/integrations/bundles/demo/proj/"
+        "workspace@2026-03-31-13-36/public/telegram_webhook?integration_id=telegram.kdcube_ref"
+    )
+    mini_app = telegram_mini_app_url("https://runtime.example.com", "demo", "proj", "workspace@2026-03-31-13-36")
+    assert mini_app.endswith("/public/widgets/telegram_miniapp")
+
+
+def test_apply_telegram_companion_generates_topology():
+    bundles: dict = {"bundles": {"items": []}}
+    bundles_secrets: dict = {}
+
+    apply_telegram_companion(
+        bundles_data=bundles,
+        bundles_secrets_data=bundles_secrets,
+        tenant="demo",
+        project="proj",
+        bot_token="123:ABC",
+        external_https_url="https://runtime.example.com",
+        webhook_secret="whsec-test",
+        bot_name="KDCube Ref",
+        bot_username="kdcube_ref_bot",
+    )
+
+    items = {item["id"]: item for item in bundles["bundles"]["items"]}
+    host = items["workspace@2026-03-31-13-36"]["config"]
+    ch = items["connection-hub@1-0"]["config"]
+
+    # Host bundle: webhook integration + Mini App widget.
+    integration = host["integrations"][TELEGRAM_INTEGRATION_ID]
+    assert integration["provider"] == "telegram"
+    assert integration["definition"]["bot_username"] == "kdcube_ref_bot"
+    assert integration["definition"]["webhook"]["url"].endswith(
+        "/public/telegram_webhook?integration_id=telegram.kdcube_ref"
+    )
+    assert "mini_apps" not in integration["definition"]
+    assert host["ui"]["widgets"]["telegram_miniapp"]["enabled"] is True
+
+    # Connection Hub: identity authenticator, edge resolver defaults, link flow, authority.
+    assert ch["identity"]["enabled"] is True
+    assert ch["identity"]["role_resolver"]["mode"] == "platform"
+    assert ch["identity"]["link_flows"]["telegram"]["enabled"] is True
+    authenticator = ch["identity"]["authenticators"][0]
+    assert authenticator["id"] == TELEGRAM_INTEGRATION_ID
+    assert authenticator["secret_ref"] == f"identity.authenticators.{TELEGRAM_SECRET_STEM}.bot_token"
+    provider = ch["authority_registry"]["authorities"][TELEGRAM_INTEGRATION_ID]["providers"]["telegram_bot_init_data"]
+    assert provider["type"] == "telegram_init_data"
+
+    # Secrets: CH identity bot token + bundle-local integration token/webhook secret.
+    secret_items = {item["id"]: item for item in bundles_secrets["bundles"]["items"]}
+    ch_secret = secret_items["connection-hub@1-0"]["secrets"]["identity"]["authenticators"][TELEGRAM_SECRET_STEM]
+    assert ch_secret["bot_token"] == "123:ABC"
+    host_secret = secret_items["workspace@2026-03-31-13-36"]["secrets"]["integrations"][TELEGRAM_SECRET_STEM]["definition"]
+    assert host_secret["bot_token"] == "123:ABC"
+    assert host_secret["webhook_secret"] == "whsec-test"
+
+
+def test_patch_gateway_descriptor_file_substitutes_placeholders(tmp_path: Path):
+    config_dir = tmp_path
+    (config_dir / "gateway.yaml").write_text(
+        yaml.safe_dump({"gateway": {"tenant": "TENANT_ID", "project": "PROJECT_ID", "profile": "development"}})
+    )
+
+    patch_gateway_descriptor_file(config_dir, "demo-tenant", "demo-project")
+
+    data = yaml.safe_load((config_dir / "gateway.yaml").read_text())
+    assert data["gateway"]["tenant"] == "demo-tenant"
+    assert data["gateway"]["project"] == "demo-project"
+    assert data["gateway"]["profile"] == "development"
+
+
+def test_patch_gateway_descriptor_file_preserves_real_values(tmp_path: Path):
+    config_dir = tmp_path
+    (config_dir / "gateway.yaml").write_text(
+        yaml.safe_dump({"gateway": {"tenant": "real-tenant", "project": "real-project"}})
+    )
+
+    patch_gateway_descriptor_file(config_dir, "demo-tenant", "demo-project")
+
+    data = yaml.safe_load((config_dir / "gateway.yaml").read_text())
+    assert data["gateway"]["tenant"] == "real-tenant"
+    assert data["gateway"]["project"] == "real-project"
+
+
+def test_ensure_generated_runtime_secrets_fills_oauth_state_secret(tmp_path: Path):
+    config_dir = tmp_path
+    (config_dir / "secrets.yaml").write_text(yaml.safe_dump({"services": {}}))
+    (config_dir / "bundles.secrets.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "bundles": {
+                    "items": [
+                        {
+                            "id": "connection-hub@1-0",
+                            "secrets": {
+                                "connections": {
+                                    "oauth_state_secret": "<FILL_ME>",
+                                    "delegated_to_kdcube": {"oauth_state_secret": "<FILL_ME>"},
+                                }
+                            },
+                        }
+                    ]
+                }
+            }
+        )
+    )
+
+    generated = ensure_generated_runtime_secrets(config_dir)
+
+    bundles_secrets = yaml.safe_load((config_dir / "bundles.secrets.yaml").read_text())
+    connections = bundles_secrets["bundles"]["items"][0]["secrets"]["connections"]
+    assert connections["oauth_state_secret"] != "<FILL_ME>"
+    assert connections["delegated_to_kdcube"]["oauth_state_secret"] != "<FILL_ME>"
+    assert len(connections["oauth_state_secret"]) >= 32
+    assert "bundles.connection-hub@1-0.secrets.connections.oauth_state_secret" in generated
+
+
+def test_apply_telegram_companion_is_idempotent():
+    bundles: dict = {"bundles": {"items": []}}
+    bundles_secrets: dict = {}
+    kwargs = dict(
+        bundles_data=bundles,
+        bundles_secrets_data=bundles_secrets,
+        tenant="demo",
+        project="proj",
+        bot_token="123:ABC",
+        external_https_url="https://runtime.example.com",
+        webhook_secret="whsec-test",
+    )
+    apply_telegram_companion(**kwargs)
+    apply_telegram_companion(**kwargs)
+
+    ch = {item["id"]: item for item in bundles["bundles"]["items"]}["connection-hub@1-0"]["config"]
+    # The identity authenticator is upserted by id, not duplicated.
+    assert len(ch["identity"]["authenticators"]) == 1

--- a/app/ai-app/src/kdcube-ai-app/kdcube_cli/tests/test_cli_descriptors.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_cli/tests/test_cli_descriptors.py
@@ -46,6 +46,10 @@ from kdcube_cli.installer import (
     TELEGRAM_INTEGRATION_ID,
     TELEGRAM_SECRET_STEM,
     apply_bundle_session_auth,
+    _ensure_connection_hub_cognito_provider,
+    _ensure_cors_allow_origin,
+    _origin_from_url,
+    _prune_foreign_platform_login,
     apply_telegram_companion,
     telegram_mini_app_url,
     telegram_webhook_url,
@@ -3748,6 +3752,340 @@ def test_apply_bundle_session_auth_omits_bootstrap_rule_without_email():
 
     grants = _bundle_provider(bundles)["grants"]
     assert "bootstrap_rules" not in grants
+
+
+def _polluted_bundle_session_bundles() -> dict:
+    """Connection Hub descriptor carrying application-hosted login plus a telegram authority.
+
+    Mirrors the shipped default where the platform authority already holds the
+    bundle-session provider, its google upstream, an admin bootstrap rule, and a
+    consent_ui pointing at the login provider.
+    """
+    return {
+        "bundles": {
+            "items": [
+                {
+                    "id": "connection-hub@1-0",
+                    "config": {
+                        "connections": {
+                            "delegated_credentials": {
+                                "oauth": {
+                                    "enabled": True,
+                                    "consent_ui": {
+                                        "mode": "authority_provider",
+                                        "authority_id": "kdcube.platform",
+                                        "provider_id": "workspace_google_session",
+                                        "entrypoint": "consent",
+                                    },
+                                }
+                            }
+                        },
+                        "authority_registry": {
+                            "authorities": {
+                                "kdcube.platform": {
+                                    "platform": True,
+                                    "grants": {
+                                        "subjects": {"user:existing": {"roles": ["kdcube:role:registered"]}},
+                                        "bootstrap_rules": [
+                                            {
+                                                "id": "bootstrap_admin_by_google_email",
+                                                "when": {"provider": "google", "claims": {"email": "owner@example.com"}},
+                                                "roles": ["kdcube:role:super-admin"],
+                                            }
+                                        ],
+                                    },
+                                    "providers": {
+                                        "workspace_google_session": {
+                                            "type": "bundle_session_login",
+                                            "enabled": True,
+                                            "input": {
+                                                "authenticator_ref": {
+                                                    "authority_id": "google.accounts",
+                                                    "provider_id": "google_oidc",
+                                                }
+                                            },
+                                        }
+                                    },
+                                },
+                                "google.accounts": {
+                                    "platform": False,
+                                    "providers": {
+                                        "google_oidc": {
+                                            "type": "google_id_token",
+                                            "enabled": True,
+                                            "authenticator": {"client_id": "old-web.apps.googleusercontent.com"},
+                                        }
+                                    },
+                                },
+                                "telegram.kdcube_ref": {
+                                    "platform": True,
+                                    "providers": {
+                                        "telegram_bot_init_data": {
+                                            "type": "telegram_bot_init_data",
+                                            "enabled": True,
+                                        }
+                                    },
+                                },
+                            }
+                        },
+                    },
+                }
+            ]
+        }
+    }
+
+
+def _ch_authorities(bundles_data: dict) -> dict:
+    return bundles_data["bundles"]["items"][0]["config"]["authority_registry"]["authorities"]
+
+
+def test_reconcile_to_cognito_removes_bundle_session_login_artifacts():
+    bundles = _polluted_bundle_session_bundles()
+
+    _ensure_connection_hub_cognito_provider(
+        bundles,
+        region="eu-west-1",
+        user_pool_id="eu-west-1_pool",
+        app_client_id="app-client",
+        service_client_id="service-client",
+        providers=None,
+        id_token_header_name="X-ID-Token",
+        auth_token_cookie_name="__Secure-LATC",
+        id_token_cookie_name="__Secure-LITC",
+        masqueraded_token_cookie_name="__Secure-LMTC",
+        jwks_cache_ttl_seconds=3600,
+    )
+    _prune_foreign_platform_login(
+        bundles,
+        connection_hub_bundle_id="connection-hub@1-0",
+        authority_id="kdcube.platform",
+        keep_provider_ids={"cognito"},
+        keep_bootstrap_rules=False,
+    )
+
+    authorities = _ch_authorities(bundles)
+    platform_providers = authorities["kdcube.platform"]["providers"]
+    # The cognito provider replaces the bundle-session login provider.
+    assert "cognito" in platform_providers
+    assert "workspace_google_session" not in platform_providers
+    # The google upstream is garbage-collected once nothing references it.
+    assert "google.accounts" not in authorities
+    # The admin bootstrap rule is dropped, but real user grants are preserved.
+    assert "bootstrap_rules" not in authorities["kdcube.platform"]["grants"]
+    assert authorities["kdcube.platform"]["grants"]["subjects"] == {
+        "user:existing": {"roles": ["kdcube:role:registered"]}
+    }
+    # The consent_ui referencing the removed provider is dropped.
+    assert "consent_ui" not in bundles["bundles"]["items"][0]["config"]["connections"]["delegated_credentials"]["oauth"]
+    # The telegram authority is independent of the login provider and stays.
+    assert "telegram.kdcube_ref" in authorities
+
+
+def test_reconcile_to_simple_removes_all_platform_login_providers():
+    bundles = _polluted_bundle_session_bundles()
+
+    _prune_foreign_platform_login(
+        bundles,
+        connection_hub_bundle_id="connection-hub@1-0",
+        authority_id="kdcube.platform",
+        keep_provider_ids=set(),
+        keep_bootstrap_rules=False,
+    )
+
+    authorities = _ch_authorities(bundles)
+    assert authorities["kdcube.platform"]["providers"] == {}
+    assert "google.accounts" not in authorities
+    assert "bootstrap_rules" not in authorities["kdcube.platform"]["grants"]
+    assert authorities["kdcube.platform"]["grants"]["subjects"] == {
+        "user:existing": {"roles": ["kdcube:role:registered"]}
+    }
+    assert "consent_ui" not in bundles["bundles"]["items"][0]["config"]["connections"]["delegated_credentials"]["oauth"]
+    assert "telegram.kdcube_ref" in authorities
+
+
+def test_reconcile_drops_empty_platform_grants():
+    # Fresh install: the shipped default carries only empty subjects + the bootstrap rule.
+    bundles = _polluted_bundle_session_bundles()
+    _ch_authorities(bundles)["kdcube.platform"]["grants"]["subjects"] = {}
+
+    _prune_foreign_platform_login(
+        bundles,
+        connection_hub_bundle_id="connection-hub@1-0",
+        authority_id="kdcube.platform",
+        keep_provider_ids={"cognito"},
+        keep_bootstrap_rules=False,
+    )
+
+    # With no real subjects and no bootstrap rule, the whole grants block is removed.
+    assert "grants" not in _ch_authorities(bundles)["kdcube.platform"]
+
+
+def test_apply_bundle_session_auth_removes_stale_cognito_provider():
+    bundles = _polluted_bundle_session_bundles()
+    # Seed a stale cognito provider as if the runtime had previously used cognito.
+    _ch_authorities(bundles)["kdcube.platform"]["providers"]["cognito"] = {
+        "type": "cognito",
+        "enabled": True,
+        "authenticator": {"region": "eu-west-1"},
+    }
+
+    apply_bundle_session_auth(
+        assembly_data={"auth": {"type": "cognito"}},
+        bundles_data=bundles,
+        env_targets=[_empty_env()],
+        client_id="new-web.apps.googleusercontent.com",
+        provider="google",
+        bootstrap_admin_email="owner@example.com",
+    )
+
+    authorities = _ch_authorities(bundles)
+    platform_providers = authorities["kdcube.platform"]["providers"]
+    assert "workspace_google_session" in platform_providers
+    assert "cognito" not in platform_providers
+    # The google upstream is rebuilt with the new client id and telegram is preserved.
+    assert authorities["google.accounts"]["providers"]["google_oidc"]["authenticator"]["client_id"] == (
+        "new-web.apps.googleusercontent.com"
+    )
+    assert "telegram.kdcube_ref" in authorities
+
+
+def test_apply_bundle_session_auth_restores_consent_ui_after_cognito():
+    # Simulate a runtime that switched to cognito: the login provider became cognito,
+    # the google upstream was garbage-collected, and the consent_ui was pruned.
+    bundles = _polluted_bundle_session_bundles()
+    _ensure_connection_hub_cognito_provider(
+        bundles,
+        region="eu-west-1",
+        user_pool_id="eu-west-1_pool",
+        app_client_id="app-client",
+        service_client_id="service-client",
+        providers=None,
+        id_token_header_name="X-ID-Token",
+        auth_token_cookie_name="__Secure-LATC",
+        id_token_cookie_name="__Secure-LITC",
+        masqueraded_token_cookie_name="__Secure-LMTC",
+        jwks_cache_ttl_seconds=3600,
+    )
+    _prune_foreign_platform_login(
+        bundles,
+        connection_hub_bundle_id="connection-hub@1-0",
+        authority_id="kdcube.platform",
+        keep_provider_ids={"cognito"},
+        keep_bootstrap_rules=False,
+    )
+    oauth = bundles["bundles"]["items"][0]["config"]["connections"]["delegated_credentials"]["oauth"]
+    assert "consent_ui" not in oauth  # removed while on cognito
+
+    # Switch back to application-hosted login.
+    apply_bundle_session_auth(
+        assembly_data={"auth": {"type": "cognito", "connection_hub": {"provider_id": "cognito"}}},
+        bundles_data=bundles,
+        env_targets=[_empty_env()],
+        client_id="web.apps.googleusercontent.com",
+        provider="google",
+        bootstrap_admin_email="owner@example.com",
+    )
+
+    authorities = _ch_authorities(bundles)
+    # The bundle provider lands under its own key, not the cognito key.
+    assert "workspace_google_session" in authorities["kdcube.platform"]["providers"]
+    assert "cognito" not in authorities["kdcube.platform"]["providers"]
+    # The consent_ui is restored pointing at the bundle-session provider.
+    consent = bundles["bundles"]["items"][0]["config"]["connections"]["delegated_credentials"]["oauth"]["consent_ui"]
+    assert consent == {
+        "mode": "authority_provider",
+        "authority_id": "kdcube.platform",
+        "provider_id": "workspace_google_session",
+        "entrypoint": "consent",
+    }
+
+
+def test_apply_bundle_session_auth_heals_provider_under_wrong_key():
+    # A prior bug wrote the bundle-session provider under the cognito key; re-applying
+    # must leave exactly one login provider under the canonical key.
+    bundles = _polluted_bundle_session_bundles()
+    platform_providers = _ch_authorities(bundles)["kdcube.platform"]["providers"]
+    platform_providers["cognito"] = platform_providers.pop("workspace_google_session")
+
+    apply_bundle_session_auth(
+        assembly_data={"auth": {"type": "bundle"}},
+        bundles_data=bundles,
+        env_targets=[_empty_env()],
+        client_id="web.apps.googleusercontent.com",
+        provider="google",
+        bootstrap_admin_email="owner@example.com",
+    )
+
+    providers = _ch_authorities(bundles)["kdcube.platform"]["providers"]
+    assert set(providers) == {"workspace_google_session"}
+    assert providers["workspace_google_session"]["type"] == "bundle_session_login"
+
+
+def test_ensure_cors_allow_origin_adds_external_origin():
+    assembly: dict = {"cors": {"allow_origins": ["http://localhost:5174"]}}
+
+    added = _ensure_cors_allow_origin(assembly, "https://external.example.com/api/integrations/x")
+
+    assert added is True
+    assert assembly["cors"]["allow_origins"] == [
+        "http://localhost:5174",
+        "https://external.example.com",
+    ]
+    # Idempotent: re-adding the same origin is a no-op.
+    assert _ensure_cors_allow_origin(assembly, "https://external.example.com/other") is False
+
+
+def test_ensure_cors_allow_origin_skips_wildcard_and_bad_url():
+    wild: dict = {"cors": {"allow_origins": ["*"]}}
+    assert _ensure_cors_allow_origin(wild, "https://external.example.com") is False
+    assert wild["cors"]["allow_origins"] == ["*"]
+    assert _ensure_cors_allow_origin({}, "not-a-url") is False
+    assert _origin_from_url("https://host:8443/path?q=1") == "https://host:8443"
+
+
+def _auth_flag_args(**overrides) -> SimpleNamespace:
+    base = dict(
+        auth_type="",
+        provider="",
+        client_id="",
+        bootstrap_admin_email="",
+        cognito_region="",
+        cognito_user_pool_id="",
+        cognito_app_client_id="",
+        cognito_service_client_id="",
+    )
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+def test_apply_auth_flags_seeds_cognito_values():
+    assembly: dict = {"auth": {"type": "bundle"}}
+    args = _auth_flag_args(
+        auth_type="cognito",
+        cognito_region="eu-west-1",
+        cognito_user_pool_id="eu-west-1_POOL",
+        cognito_app_client_id="appclient",
+        cognito_service_client_id="svcclient",
+    )
+
+    changed = cli_mod._apply_auth_flags(Console(file=None), assembly, args)
+
+    assert changed is True
+    assert assembly["auth"]["type"] == "cognito"
+    assert assembly["auth"]["cognito"] == {
+        "region": "eu-west-1",
+        "user_pool_id": "eu-west-1_POOL",
+        "app_client_id": "appclient",
+        "service_client_id": "svcclient",
+    }
+
+
+def test_apply_auth_flags_rejects_cognito_flags_for_bundle():
+    assembly: dict = {"auth": {"type": "simple"}}
+    args = _auth_flag_args(auth_type="bundle", client_id="x", cognito_region="eu-west-1")
+
+    with pytest.raises(SystemExit):
+        cli_mod._apply_auth_flags(Console(file=None), assembly, args)
 
 
 def _bundle_assembly(client_id: str = "web.apps.googleusercontent.com") -> dict:


### PR DESCRIPTION
## Application-hosted (bundle-session) login + auth reconfiguration in the CLI

Adds first-class platform-authentication configuration to `kdcube init` and a new
`kdcube config apply`, so an initialized runtime can be set up with — and switched
between — any auth method without hand-editing descriptors. Also wires up the
Telegram companion end to end.

### `kdcube init`
- `--auth-type {simple,cognito,delegated,bundle}` selects the method non-interactively.
- Bundle (application-hosted login) is the recommended default; the interactive
  picker preselects it and no longer offers `delegated` as a new choice (still
  reachable via `--auth-type delegated`).
- Per-method flags: bundle `--provider/--client-id/--bootstrap-admin-email`;
  cognito/delegated `--cognito-region/-user-pool-id/-app-client-id/-service-client-id`.
- Bundle-session writes the Workspace/Google OIDC topology (assembly.auth,
  Connection Hub authority registry, generated session/oauth secrets), shared by
  init and config apply.

### `kdcube config apply` (new)
- Reconfigures the platform auth of an initialized runtime to `--auth-type`.
- Reference-driven reconcile: removes the previous method's platform login
  provider, its GC'd upstream authority, admin bootstrap rule, and dangling
  consent UI; preserves `grants.subjects`, the Telegram companion, and delegated
  connectors. Pruning keys off the provider id the target wrote, so a provider
  left under the wrong key self-heals on re-apply.
- `--dry-run` renders into a throwaway copy and prints a per-descriptor semantic
  diff without writing or restarting; `--restart` applies and restarts the stack.

### Telegram companion
- `--enable-telegram --external-https-url <url>` (or `KDCUBE_ENABLE_TELEGRAM` /
  `KDCUBE_TELEGRAM_EXTERNAL_HTTPS_URL`) configures the companion; the bot token is
  a secret read from `KDCUBE_TELEGRAM_BOT_TOKEN`.
- Generated webhook secret, `getMe`/`setWebhook`/`getWebhookInfo`, Connection Hub
  identity linking, and Mini App URL.
- The external URL's origin is added to `cors.allow_origins` so the Mini App's
  cross-origin WebSocket (Connection Hub account-link flow) is accepted.

### nginx
- Base HTTP proxy templates forward `Host`/`X-Forwarded-Host` from `$http_host`
  so the browser origin (authority + port) is preserved for localhost/ngrok.
  SSL server blocks unchanged.

### Docs
- `cli-README` auth flags, config-apply auth reconfigure, and Telegram env vars;
  `kdcube_cli` README/additional_README and the operate-runtime recipe aligned.