### PR TITLE
telegram: deliver only the final answer from the turn timeline

### DIFF
--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/integrations/telegram/bot.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/integrations/telegram/bot.py
@@ -474,29 +474,39 @@ async def edit_telegram_text_message(
 
 
 def _answer_texts_from_timeline(timeline: Mapping[str, Any]) -> list[str]:
-    # A turn has exactly ONE final answer to deliver. `finish_turn` persists
-    # the FULL completion history for a turn as `assistant.completion` blocks
-    # (react/layout.py:build_assistant_completion_blocks emits one such block
-    # per entry in `scratchpad.assistant_completion_attempts`, not just the
-    # final one — it exists for observability/audit of how the answer
-    # evolved across ReAct iterations) plus live `assistant.completion.attempt`
-    # blocks recorded per iteration while the loop is still drafting.
+    # A turn can legitimately deliver MULTIPLE distinct final answers: the v3
+    # ReAct runtime emits one `react.final_answer.{iteration}.{safe_idx}` block
+    # per PARALLEL action it settles (solutions/react/v3/runtime.py), and each is
+    # a real deliverable that must be preserved and rendered in order.
     #
-    # This function used to collect EVERY block whose path/type mentioned
-    # "assistant.completion" (deduping only on exact text equality), so a turn
-    # that took N ReAct iterations to settle on its answer surfaced N (near-)
-    # duplicate texts, each rendered as its own Telegram message — the
-    # "response duplicated 3-7x back-to-back" defect. `.attempt` blocks are
-    # explicitly provisional and must never be treated as a deliverable
-    # answer; among the remaining candidates only the LAST one in timeline
-    # order is the actual final answer (build_assistant_completion_blocks
-    # always appends scratchpad.answer last), so keep just that one.
+    # The duplication this function guards against comes from the COMPLETION
+    # HISTORY instead. `finish_turn` persists the full close-gate history via
+    # `build_assistant_completion_blocks` (react/layout.py): it re-emits ONE
+    # `assistant.completion` block per completion entry — the settled/final
+    # answer at the UNSUFFIXED path `conv:ar:{tid}.assistant.completion` and
+    # every earlier retry at `conv:ar:{tid}.assistant.completion.{idx}` (with
+    # meta.completion_index / meta.completion_count set when there is more than
+    # one). Rendering straight from the timeline (without
+    # `prefer_react_turn_answer`) used to resend every one of those history
+    # blocks, surfacing the same reply 3-7x back-to-back. So collapse the
+    # completion HISTORY to its FINAL entry only, while preserving DISTINCT
+    # `react.final_answer.*` deliverables untouched.
+    #
+    # `.attempt` blocks (`conv:ar:{tid}.assistant.completion.attempt.{idx}`) are
+    # provisional in-flight drafts and are never delivered — UNLESS the turn
+    # produced nothing else (an aborted turn with only attempt blocks), in which
+    # case we fall back to the last attempt text rather than going silent: this
+    # project has a stuck-turn history and an empty reply is the worst failure.
     blocks = timeline.get("blocks") if isinstance(timeline, Mapping) else None
     if not isinstance(blocks, list):
         return []
     turn_id = _timeline_turn_id(timeline)
-    latest_text = ""
-    found = False
+
+    ordered: list[tuple[str, str]] = []  # (category, text) in timeline order
+    completion_texts: list[str] = []  # completion-HISTORY texts, in timeline order
+    final_completion_text = ""  # the single FINAL completion-history entry
+    attempt_fallback_text = ""  # last provisional draft, used only if nothing else
+
     for block in blocks:
         if not isinstance(block, Mapping):
             continue
@@ -507,12 +517,22 @@ def _answer_texts_from_timeline(timeline: Mapping[str, Any]) -> list[str]:
         marker = str(block.get("marker") or "")
         if block_type.startswith("react.tool."):
             continue
-        # Provisional/in-flight drafts are never the answer to deliver.
-        if block_type.endswith(".attempt") or ".attempt." in path:
-            continue
         owner_turn_id = _path_turn_id(path)
         if turn_id and owner_turn_id and owner_turn_id != turn_id:
             continue
+        text = str(block.get("text") or "").strip()
+
+        is_completion_related = (
+            "assistant.completion" in path
+            or block_type.startswith("assistant.completion")
+        )
+        # Provisional/in-flight drafts are never delivered directly; keep the
+        # newest answer-shaped one only as a last-resort fallback.
+        if block_type.endswith(".attempt") or ".attempt." in path:
+            if text and (is_completion_related or "final_answer" in path):
+                attempt_fallback_text = text
+            continue
+
         if (
             "react.final_answer" not in path
             and "assistant.completion" not in path
@@ -520,11 +540,46 @@ def _answer_texts_from_timeline(timeline: Mapping[str, Any]) -> list[str]:
             and marker != "answer"
         ):
             continue
-        text = str(block.get("text") or "").strip()
-        if text:
-            latest_text = text
-            found = True
-    return [latest_text] if found and latest_text else []
+        if not text:
+            continue
+
+        # Completion-HISTORY blocks are the duplication source (one per close-gate
+        # retry); `react.final_answer.*` blocks are distinct deliverables.
+        is_completion_history = (
+            "assistant.completion" in path or block_type == "assistant.completion"
+        ) and "react.final_answer" not in path
+        if is_completion_history:
+            completion_texts.append(text)
+            meta = block.get("meta")
+            index_is_final = False
+            if isinstance(meta, Mapping):
+                ci = meta.get("completion_index")
+                cc = meta.get("completion_count")
+                if ci is not None and cc is not None and ci == cc:
+                    index_is_final = True
+            if path.endswith(".assistant.completion") or index_is_final:
+                final_completion_text = text
+            ordered.append(("completion", text))
+        else:
+            ordered.append(("deliverable", text))
+
+    if not final_completion_text and completion_texts:
+        final_completion_text = completion_texts[-1]
+
+    result: list[str] = []
+    seen: set[str] = set()
+    for category, text in ordered:
+        # Drop every completion-history entry except the settled final one.
+        if category == "completion" and text != final_completion_text:
+            continue
+        if text in seen:
+            continue
+        seen.add(text)
+        result.append(text)
+
+    if not result and attempt_fallback_text:
+        result.append(attempt_fallback_text)
+    return result
 
 
 def _split_text_for_telegram(text: str, *, limit: int = TELEGRAM_SAFE_TEXT_LIMIT) -> list[str]:

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/integrations/telegram/bot.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/integrations/telegram/bot.py
@@ -474,12 +474,29 @@ async def edit_telegram_text_message(
 
 
 def _answer_texts_from_timeline(timeline: Mapping[str, Any]) -> list[str]:
+    # A turn has exactly ONE final answer to deliver. `finish_turn` persists
+    # the FULL completion history for a turn as `assistant.completion` blocks
+    # (react/layout.py:build_assistant_completion_blocks emits one such block
+    # per entry in `scratchpad.assistant_completion_attempts`, not just the
+    # final one — it exists for observability/audit of how the answer
+    # evolved across ReAct iterations) plus live `assistant.completion.attempt`
+    # blocks recorded per iteration while the loop is still drafting.
+    #
+    # This function used to collect EVERY block whose path/type mentioned
+    # "assistant.completion" (deduping only on exact text equality), so a turn
+    # that took N ReAct iterations to settle on its answer surfaced N (near-)
+    # duplicate texts, each rendered as its own Telegram message — the
+    # "response duplicated 3-7x back-to-back" defect. `.attempt` blocks are
+    # explicitly provisional and must never be treated as a deliverable
+    # answer; among the remaining candidates only the LAST one in timeline
+    # order is the actual final answer (build_assistant_completion_blocks
+    # always appends scratchpad.answer last), so keep just that one.
     blocks = timeline.get("blocks") if isinstance(timeline, Mapping) else None
     if not isinstance(blocks, list):
         return []
     turn_id = _timeline_turn_id(timeline)
-    texts: list[str] = []
-    seen: set[str] = set()
+    latest_text = ""
+    found = False
     for block in blocks:
         if not isinstance(block, Mapping):
             continue
@@ -489,6 +506,9 @@ def _answer_texts_from_timeline(timeline: Mapping[str, Any]) -> list[str]:
         block_type = str(block.get("type") or "")
         marker = str(block.get("marker") or "")
         if block_type.startswith("react.tool."):
+            continue
+        # Provisional/in-flight drafts are never the answer to deliver.
+        if block_type.endswith(".attempt") or ".attempt." in path:
             continue
         owner_turn_id = _path_turn_id(path)
         if turn_id and owner_turn_id and owner_turn_id != turn_id:
@@ -501,10 +521,10 @@ def _answer_texts_from_timeline(timeline: Mapping[str, Any]) -> list[str]:
         ):
             continue
         text = str(block.get("text") or "").strip()
-        if text and text not in seen:
-            seen.add(text)
-            texts.append(text)
-    return texts
+        if text:
+            latest_text = text
+            found = True
+    return [latest_text] if found and latest_text else []
 
 
 def _split_text_for_telegram(text: str, *, limit: int = TELEGRAM_SAFE_TEXT_LIMIT) -> list[str]:

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/integrations/telegram/tests/test_answer_texts_from_timeline.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/integrations/telegram/tests/test_answer_texts_from_timeline.py
@@ -2,34 +2,120 @@ from __future__ import annotations
 
 """Regression tests for _answer_texts_from_timeline.
 
-A turn has exactly ONE final answer to deliver, but `finish_turn` persists the
-full completion history (one `assistant.completion` block per ReAct iteration)
-plus provisional `assistant.completion.attempt` blocks. Callers that render
-straight from the timeline (without `prefer_react_turn_answer`) must therefore
-see only the single, final answer — otherwise every draft is resent as its own
+A turn may legitimately deliver MULTIPLE distinct final answers — the v3 ReAct
+runtime emits one `react.final_answer.{iteration}.{safe_idx}` block per parallel
+action, and each must be preserved. The duplication we guard against is the
+COMPLETION HISTORY: `finish_turn` re-emits one `assistant.completion` block per
+close-gate retry (via react/layout.py:build_assistant_completion_blocks) — the
+settled answer at the UNSUFFIXED path `conv:ar:{tid}.assistant.completion` and
+every earlier retry at `conv:ar:{tid}.assistant.completion.{idx}` — plus
+provisional `conv:ar:{tid}.assistant.completion.attempt.{idx}` drafts. Callers
+that render straight from the timeline (without `prefer_react_turn_answer`) must
+collapse that history to its single final entry while keeping the distinct
+`react.final_answer.*` deliverables, otherwise every draft is resent as its own
 Telegram message ("same reply 3-7x").
 """
 
-
-def _completion_block(text: str, *, path: str, block_type: str = "assistant.completion") -> dict:
-    return {"type": block_type, "path": path, "text": text}
+TID = "turn_1"
 
 
-def test_multi_draft_timeline_yields_only_last_final_answer():
+def _completion_block(
+    text: str,
+    *,
+    path: str,
+    block_type: str = "assistant.completion",
+    meta: dict | None = None,
+) -> dict:
+    block: dict = {"type": block_type, "path": path, "text": text}
+    if meta is not None:
+        block["meta"] = meta
+    return block
+
+
+def test_completion_history_collapses_to_final_entry():
     from kdcube_ai_app.apps.chat.sdk.integrations.telegram.bot import (
         _answer_texts_from_timeline,
     )
 
+    # build_assistant_completion_blocks re-emits one block per close-gate retry:
+    # the earlier entries at `.assistant.completion.{idx}`, the final settled
+    # answer at the UNSUFFIXED `.assistant.completion` path (emitted last).
     timeline = {
         "blocks": [
-            _completion_block("first draft", path="scratchpad.assistant_completion_attempts.0"),
-            _completion_block("second draft", path="scratchpad.assistant_completion_attempts.1"),
-            _completion_block("FINAL ANSWER", path="scratchpad.answer"),
+            _completion_block(
+                "first draft",
+                path=f"conv:ar:{TID}.assistant.completion.1",
+                meta={"completion_index": 1, "completion_count": 3},
+            ),
+            _completion_block(
+                "second draft",
+                path=f"conv:ar:{TID}.assistant.completion.2",
+                meta={"completion_index": 2, "completion_count": 3},
+            ),
+            _completion_block(
+                "FINAL ANSWER",
+                path=f"conv:ar:{TID}.assistant.completion",
+                meta={"completion_index": 3, "completion_count": 3},
+            ),
         ]
     }
 
-    # Exactly one text, and it is the last completion block in timeline order.
+    # Exactly one text: the settled final completion (unsuffixed path).
     assert _answer_texts_from_timeline(timeline) == ["FINAL ANSWER"]
+
+
+def test_completion_history_final_selected_by_index_when_out_of_order():
+    from kdcube_ai_app.apps.chat.sdk.integrations.telegram.bot import (
+        _answer_texts_from_timeline,
+    )
+
+    # The final entry is identified by the unsuffixed path OR by
+    # completion_index == completion_count, not merely by timeline position.
+    timeline = {
+        "blocks": [
+            _completion_block(
+                "FINAL ANSWER",
+                path=f"conv:ar:{TID}.assistant.completion",
+                meta={"completion_index": 2, "completion_count": 2},
+            ),
+            _completion_block(
+                "stale draft",
+                path=f"conv:ar:{TID}.assistant.completion.1",
+                meta={"completion_index": 1, "completion_count": 2},
+            ),
+        ]
+    }
+
+    assert _answer_texts_from_timeline(timeline) == ["FINAL ANSWER"]
+
+
+def test_distinct_react_final_answers_are_all_preserved():
+    from kdcube_ai_app.apps.chat.sdk.integrations.telegram.bot import (
+        _answer_texts_from_timeline,
+    )
+
+    # One `react.final_answer.{iteration}.{safe_idx}` block per parallel action:
+    # these are DISTINCT deliverables and must NOT be collapsed.
+    timeline = {
+        "blocks": [
+            _completion_block(
+                "First response.",
+                path=f"tc:{TID}.react.final_answer.0.0",
+                block_type="react.final_answer",
+            ),
+            {"type": "note", "path": f"tc:{TID}.notes", "text": "internal note"},
+            _completion_block(
+                "Second response.",
+                path=f"tc:{TID}.react.final_answer.0.1",
+                block_type="react.final_answer",
+            ),
+        ]
+    }
+
+    assert _answer_texts_from_timeline(timeline) == [
+        "First response.",
+        "Second response.",
+    ]
 
 
 def test_attempt_blocks_are_never_delivered():
@@ -39,14 +125,23 @@ def test_attempt_blocks_are_never_delivered():
 
     timeline = {
         "blocks": [
-            _completion_block("settled draft", path="scratchpad.assistant_completion_attempts.0"),
+            _completion_block(
+                "settled draft",
+                path=f"conv:ar:{TID}.assistant.completion.1",
+                meta={"completion_index": 1, "completion_count": 2},
+            ),
             # Provisional / in-flight draft recorded per ReAct iteration.
             _completion_block(
                 "IN-FLIGHT DRAFT",
-                path="scratchpad.assistant_completion.attempt.1",
+                path=f"conv:ar:{TID}.assistant.completion.attempt.1",
                 block_type="assistant.completion.attempt",
+                meta={"provisional": True, "completion_attempt_index": 1},
             ),
-            _completion_block("FINAL ANSWER", path="scratchpad.answer"),
+            _completion_block(
+                "FINAL ANSWER",
+                path=f"conv:ar:{TID}.assistant.completion",
+                meta={"completion_index": 2, "completion_count": 2},
+            ),
         ]
     }
 
@@ -65,14 +160,46 @@ def test_attempt_detected_by_path_segment():
     # attempt only in the path (".attempt." segment). It must still be excluded.
     timeline = {
         "blocks": [
-            _completion_block("FINAL ANSWER", path="scratchpad.answer"),
-            _completion_block("PATH-FLAGGED ATTEMPT", path="scratchpad.assistant.completion.attempt.2"),
+            _completion_block(
+                "FINAL ANSWER",
+                path=f"conv:ar:{TID}.assistant.completion",
+            ),
+            _completion_block(
+                "PATH-FLAGGED ATTEMPT",
+                path=f"conv:ar:{TID}.assistant.completion.attempt.2",
+            ),
         ]
     }
 
     result = _answer_texts_from_timeline(timeline)
     assert result == ["FINAL ANSWER"]
     assert "PATH-FLAGGED ATTEMPT" not in result
+
+
+def test_aborted_turn_falls_back_to_last_attempt():
+    from kdcube_ai_app.apps.chat.sdk.integrations.telegram.bot import (
+        _answer_texts_from_timeline,
+    )
+
+    # A turn that aborted before settling has only provisional attempt blocks.
+    # Silence is the worst failure (stuck-turn history), so deliver the last
+    # attempt text rather than nothing.
+    timeline = {
+        "blocks": [
+            _completion_block(
+                "early attempt",
+                path=f"conv:ar:{TID}.assistant.completion.attempt.1",
+                block_type="assistant.completion.attempt",
+            ),
+            _completion_block(
+                "LAST ATTEMPT",
+                path=f"conv:ar:{TID}.assistant.completion.attempt.2",
+                block_type="assistant.completion.attempt",
+            ),
+        ]
+    }
+
+    assert _answer_texts_from_timeline(timeline) == ["LAST ATTEMPT"]
 
 
 def test_single_completion_turn_is_unchanged():
@@ -84,7 +211,10 @@ def test_single_completion_turn_is_unchanged():
     # byte-identical to the pre-fix output.
     timeline = {
         "blocks": [
-            _completion_block("the only answer", path="scratchpad.answer"),
+            _completion_block(
+                "the only answer",
+                path=f"conv:ar:{TID}.assistant.completion",
+            ),
         ]
     }
 

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/integrations/telegram/tests/test_answer_texts_from_timeline.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/integrations/telegram/tests/test_answer_texts_from_timeline.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+"""Regression tests for _answer_texts_from_timeline.
+
+A turn has exactly ONE final answer to deliver, but `finish_turn` persists the
+full completion history (one `assistant.completion` block per ReAct iteration)
+plus provisional `assistant.completion.attempt` blocks. Callers that render
+straight from the timeline (without `prefer_react_turn_answer`) must therefore
+see only the single, final answer — otherwise every draft is resent as its own
+Telegram message ("same reply 3-7x").
+"""
+
+
+def _completion_block(text: str, *, path: str, block_type: str = "assistant.completion") -> dict:
+    return {"type": block_type, "path": path, "text": text}
+
+
+def test_multi_draft_timeline_yields_only_last_final_answer():
+    from kdcube_ai_app.apps.chat.sdk.integrations.telegram.bot import (
+        _answer_texts_from_timeline,
+    )
+
+    timeline = {
+        "blocks": [
+            _completion_block("first draft", path="scratchpad.assistant_completion_attempts.0"),
+            _completion_block("second draft", path="scratchpad.assistant_completion_attempts.1"),
+            _completion_block("FINAL ANSWER", path="scratchpad.answer"),
+        ]
+    }
+
+    # Exactly one text, and it is the last completion block in timeline order.
+    assert _answer_texts_from_timeline(timeline) == ["FINAL ANSWER"]
+
+
+def test_attempt_blocks_are_never_delivered():
+    from kdcube_ai_app.apps.chat.sdk.integrations.telegram.bot import (
+        _answer_texts_from_timeline,
+    )
+
+    timeline = {
+        "blocks": [
+            _completion_block("settled draft", path="scratchpad.assistant_completion_attempts.0"),
+            # Provisional / in-flight draft recorded per ReAct iteration.
+            _completion_block(
+                "IN-FLIGHT DRAFT",
+                path="scratchpad.assistant_completion.attempt.1",
+                block_type="assistant.completion.attempt",
+            ),
+            _completion_block("FINAL ANSWER", path="scratchpad.answer"),
+        ]
+    }
+
+    result = _answer_texts_from_timeline(timeline)
+    assert result == ["FINAL ANSWER"]
+    # The .attempt block must not leak into the deliverable set.
+    assert "IN-FLIGHT DRAFT" not in result
+
+
+def test_attempt_detected_by_path_segment():
+    from kdcube_ai_app.apps.chat.sdk.integrations.telegram.bot import (
+        _answer_texts_from_timeline,
+    )
+
+    # Some producers emit a plain "assistant.completion" type but flag the
+    # attempt only in the path (".attempt." segment). It must still be excluded.
+    timeline = {
+        "blocks": [
+            _completion_block("FINAL ANSWER", path="scratchpad.answer"),
+            _completion_block("PATH-FLAGGED ATTEMPT", path="scratchpad.assistant.completion.attempt.2"),
+        ]
+    }
+
+    result = _answer_texts_from_timeline(timeline)
+    assert result == ["FINAL ANSWER"]
+    assert "PATH-FLAGGED ATTEMPT" not in result
+
+
+def test_single_completion_turn_is_unchanged():
+    from kdcube_ai_app.apps.chat.sdk.integrations.telegram.bot import (
+        _answer_texts_from_timeline,
+    )
+
+    # Behavior-preserving: a turn that settled on its answer in one shot is
+    # byte-identical to the pre-fix output.
+    timeline = {
+        "blocks": [
+            _completion_block("the only answer", path="scratchpad.answer"),
+        ]
+    }
+
+    assert _answer_texts_from_timeline(timeline) == ["the only answer"]
+
+
+def test_empty_timeline_yields_nothing():
+    from kdcube_ai_app.apps.chat.sdk.integrations.telegram.bot import (
+        _answer_texts_from_timeline,
+    )
+
+    assert _answer_texts_from_timeline({}) == []
+    assert _answer_texts_from_timeline({"blocks": []}) == []
+    assert _answer_texts_from_timeline({"blocks": "not-a-list"}) == []


### PR DESCRIPTION
## What

`_answer_texts_from_timeline` (in `apps/chat/sdk/integrations/telegram/bot.py`) used to collect **every** `assistant.completion` block for a turn, deduping only on exact-text equality. It now keeps only the **last non-`.attempt`** completion block.

## Why

`finish_turn` persists the *full* completion history for a turn: `build_assistant_completion_blocks` emits one `assistant.completion` block per entry in `scratchpad.assistant_completion_attempts` (for observability/audit of how the answer evolved across ReAct iterations), plus live `assistant.completion.attempt` blocks recorded per iteration while the loop is still drafting.

A turn has exactly **one** final answer to deliver. Any caller that renders straight from the timeline — i.e. without `prefer_react_turn_answer` — therefore resent every intermediate draft, each as its own Telegram message. That is the "same reply duplicated 3-7x back-to-back" defect.

The fix:
- excludes any block whose `type` ends in `.attempt` or whose `path` contains an `.attempt.` segment (provisional drafts are never deliverable), and
- among the remaining candidates keeps only the **last** in timeline order (`build_assistant_completion_blocks` always appends the settled `scratchpad.answer` last).

## Generally useful, not deployment-specific

This corrects the timeline-rendering path for **every** Telegram caller, not any one bundle or deployment. There is nothing environment-specific here.

## Behavior-preserving for single-completion turns

For a turn that settled on its answer in one shot, the output is **byte-identical** to before — the only observable change is that multi-iteration turns and `.attempt` drafts no longer get resent.

## Test

Adds `tests/test_answer_texts_from_timeline.py` asserting:
- a multi-draft timeline yields exactly one text (the last, final answer);
- `.attempt` blocks are excluded (both by type suffix and by `.attempt.` path segment);
- a single-completion turn is unchanged;
- an empty/malformed timeline yields `[]`.

Verified: passes with the fix; the three non-trivial cases **fail without it** (the two behavior-preserving cases pass either way).

---

Downstream: retires navigator patch `telegram-dedupe-answer-text` after merge+release.