### PR TITLE
rendering: URL-navigation mode for write_png (additive, default-off)

### DIFF
--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/tools/rendering_tools.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/tools/rendering_tools.py
@@ -528,7 +528,17 @@ class RenderingTools:
             "• For Mermaid text clarity, use mermaid_font_size_px (e.g. 16–22) and/or mermaid_scale (1.1–1.6)\n"
             "• You can pass mermaid_theme_variables or mermaid_config to control Mermaid rendering\n"
             "• Use render_delay_ms=1000–2000 for Mermaid/JS layout to settle\n"
-            "• Use base_dir for relative assets; avoid base64 data URIs in HTML/Markdown\n"
+            "• Use base_dir for relative assets; avoid base64 data URIs in HTML/Markdown\n\n"
+            "=== LIVE-URL MODE (url/eval_js/ready_js) — TRUST BOUNDARY ===\n"
+            "• Set `url` to snapshot a live page instead of rendering `content`.\n"
+            "• SECURITY: `url` is fetched by a SERVER-SIDE headless browser and\n"
+            "  `eval_js` runs ARBITRARY JavaScript in that page. Any scheme is\n"
+            "  accepted — including `file://` (local disk) and internal\n"
+            "  `http://` hosts unreachable from the public internet (SSRF).\n"
+            "• The url is NOT sanitized/allowlisted here; treat it as a\n"
+            "  privileged, server-trusted operation. Only pass URLs the bundle\n"
+            "  itself controls, never raw untrusted end-user input. A future\n"
+            "  KDCUBE_PNG_URL_ALLOWLIST-style knob may restrict schemes/hosts.\n"
         )
     )
     async def write_png(
@@ -558,9 +568,9 @@ class RenderingTools:
         mermaid_font_size_px: Annotated[Optional[int], "Force Mermaid font size in px (improves readability)."] = None,
         mermaid_font_family: Annotated[Optional[str], "Force Mermaid font family (CSS font-family)."] = None,
         mermaid_scale: Annotated[Optional[float], "Scale Mermaid SVG (e.g., 1.1–1.6) before screenshot."] = None,
-        url: Annotated[Optional[str], "Live URL to navigate to instead of writing a temp HTML file. When set, content/format are ignored for navigation."] = None,
-        eval_js: Annotated[Optional[str], "JavaScript expression to evaluate after page load (e.g. inject a token or trigger a render)."] = None,
-        ready_js: Annotated[str, "JS expression that must evaluate to true before screenshotting (polled by wait_for_function)."] = "window.__RENDER_READY__ === true",
+        url: Annotated[Optional[str], "Live URL to navigate to instead of writing a temp HTML file. When set, content/format are ignored for navigation. SECURITY: fetched by a server-side headless browser; any scheme (incl. file:// and internal http://) is accepted and NOT allowlisted — pass only bundle-controlled URLs, never raw untrusted input (SSRF)."] = None,
+        eval_js: Annotated[Optional[str], "JavaScript expression to evaluate after page load (e.g. inject a token or trigger a render). Runs ARBITRARY JS in the fetched page — server-trusted, url-mode only."] = None,
+        ready_js: Annotated[Optional[str], "JS expression that must evaluate to true before screenshotting (polled by wait_for_function). None falls back to the default predicate."] = "window.__RENDER_READY__ === true",
     ) -> Annotated[dict, "Result envelope: {ok: bool, error: null|{code,message,where,managed}}."]:
         import html as html_lib
         import urllib.parse
@@ -748,6 +758,11 @@ class RenderingTools:
                 html_path = outdir / html_filename
                 html_path.write_text(html_content, encoding="utf-8")
 
+            # ``context`` is created against the long-lived shared browser; it
+            # MUST be closed on every exit path (goto errors, a ready_js 30s
+            # timeout, mermaid early-returns) or Chromium contexts leak in the
+            # shared process. The outer finally guarantees that.
+            context = None
             try:
                 context = await conv._browser.new_context(
                     viewport={"width": width or 1200, "height": height or 800},
@@ -890,9 +905,18 @@ class RenderingTools:
                         await png_context.close()
 
                 if url is not None:
+                    # SSRF/trust note: `url` is navigated by a server-side
+                    # headless browser and `eval_js` runs arbitrary JS in that
+                    # page. Any scheme is accepted (file://, internal http://).
+                    # This is intentional and gated by convention, not
+                    # sanitized here; see the kernel_function description. A
+                    # future allowlist knob could restrict schemes/hosts.
                     await page.goto(url, wait_until="networkidle")
                     if eval_js:
                         await page.evaluate(eval_js)
+                    # Tolerate ready_js=None (explicit override) by falling back
+                    # to the default readiness predicate.
+                    ready_js = ready_js or "window.__RENDER_READY__ === true"
                     await page.wait_for_function(ready_js, timeout=30000)
                     await page.wait_for_timeout(max(int(render_delay_ms or 0), 0))
                     await _apply_background()
@@ -974,8 +998,12 @@ class RenderingTools:
                             screenshot_opts["full_page"] = False
                     await page.screenshot(**screenshot_opts)
 
-                await context.close()
             finally:
+                if context is not None:
+                    try:
+                        await context.close()
+                    except Exception:
+                        pass
                 if html_path is not None:
                     try:
                         html_path.unlink(missing_ok=True)

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/tools/rendering_tools.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/tools/rendering_tools.py
@@ -558,6 +558,9 @@ class RenderingTools:
         mermaid_font_size_px: Annotated[Optional[int], "Force Mermaid font size in px (improves readability)."] = None,
         mermaid_font_family: Annotated[Optional[str], "Force Mermaid font family (CSS font-family)."] = None,
         mermaid_scale: Annotated[Optional[float], "Scale Mermaid SVG (e.g., 1.1–1.6) before screenshot."] = None,
+        url: Annotated[Optional[str], "Live URL to navigate to instead of writing a temp HTML file. When set, content/format are ignored for navigation."] = None,
+        eval_js: Annotated[Optional[str], "JavaScript expression to evaluate after page load (e.g. inject a token or trigger a render)."] = None,
+        ready_js: Annotated[str, "JS expression that must evaluate to true before screenshotting (polled by wait_for_function)."] = "window.__RENDER_READY__ === true",
     ) -> Annotated[dict, "Result envelope: {ok: bool, error: null|{code,message,where,managed}}."]:
         import html as html_lib
         import urllib.parse
@@ -641,7 +644,7 @@ class RenderingTools:
 
             mermaid_css = "\n            ".join(mermaid_css_bits)
 
-            if format == "mermaid":
+            if url is None and format == "mermaid":
                 canvas_pad = max(int(padding_px or 0), 0) if fit == "content" else 0
                 if isinstance(background, str) and background.strip().lower() in {"transparent", "none"}:
                     canvas_bg = "transparent"
@@ -732,17 +735,18 @@ class RenderingTools:
     </body>
     </html>"""
 
-            elif format == "html":
+            elif url is None and format == "html":
                 html_content = _ensure_html_wrapper(content, title=title)
 
-            else:
+            elif url is None:
                 base_href = conv._base_href_for(pathlib.Path(base_dir) if base_dir else None)
                 html_content = conv.markdown_to_html(content, base_href, title or "Document")
 
-            import time
-            html_filename = f"_render_{int(time.time() * 1000000)}.html"
-            html_path = outdir / html_filename
-            html_path.write_text(html_content, encoding="utf-8")
+            if url is None:
+                import time
+                html_filename = f"_render_{int(time.time() * 1000000)}.html"
+                html_path = outdir / html_filename
+                html_path.write_text(html_content, encoding="utf-8")
 
             try:
                 context = await conv._browser.new_context(
@@ -885,7 +889,21 @@ class RenderingTools:
                     finally:
                         await png_context.close()
 
-                if format == "mermaid":
+                if url is not None:
+                    await page.goto(url, wait_until="networkidle")
+                    if eval_js:
+                        await page.evaluate(eval_js)
+                    await page.wait_for_function(ready_js, timeout=30000)
+                    await page.wait_for_timeout(max(int(render_delay_ms or 0), 0))
+                    await _apply_background()
+                    await _apply_zoom()
+                    if fit == "content":
+                        box = await _compute_bbox(content_selector)
+                        if box:
+                            screenshot_opts["clip"] = _clip_from_box(box)
+                            screenshot_opts["full_page"] = False
+                    await page.screenshot(**screenshot_opts)
+                elif format == "mermaid":
                     try:
                         await page.goto(f"file://{html_path}", wait_until="networkidle")
                         await page.wait_for_function("window.__RENDER_READY__ === true", timeout=30000)
@@ -932,7 +950,7 @@ class RenderingTools:
                         else:
                             svg_content = await svg_element.evaluate("(el) => el.outerHTML")
                             await _screenshot_serialized_svg(svg_content)
-                        
+
                     except Exception as e:
                         print(f"⚠️ Mermaid SVG extraction failed: {e}")
                         return _error_result(

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/tools/tests/test_rendering_url_navigation.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/tools/tests/test_rendering_url_navigation.py
@@ -1,0 +1,194 @@
+# SPDX-License-Identifier: MIT
+"""Tests for the additive URL-navigation mode of ``RenderingTools.write_png``.
+
+Three optional kwargs (``url``, ``eval_js``, ``ready_js``) let ``write_png``
+capture a live/headless URL instead of rendering inline ``content``. The tests
+cover the two contracts that matter:
+
+* ``url`` set   -> the page is navigated, ``eval_js`` runs before the readiness
+  gate, ``ready_js`` is awaited, and the ``eval_js`` side-effect is visible in
+  the PNG.
+* ``url is None`` -> the legacy path is byte-identical: ``content`` is written to
+  a temp ``_render_*.html`` and screenshotted; no navigation happens.
+
+The browser-backed tests are marked ``playwright`` and skip cleanly where no
+Chromium is available (e.g. slim CI images). ``importorskip`` keeps collection
+working where the package itself is not installed.
+"""
+
+import asyncio
+import functools
+import inspect
+
+import pytest
+
+# Skip the whole module when the SDK package is not importable (e.g. a bare
+# checkout without the app installed). In CI where kdcube_ai_app is installed
+# this imports normally.
+rendering_tools = pytest.importorskip(
+    "kdcube_ai_app.apps.chat.sdk.tools.rendering_tools"
+)
+RenderingTools = rendering_tools.RenderingTools
+
+from kdcube_ai_app.apps.chat.sdk.runtime.run_ctx import OUTDIR_CV, WORKDIR_CV
+from kdcube_ai_app.apps.chat.sdk.runtime.workdir_discovery import resolve_output_dir
+
+
+@functools.lru_cache(maxsize=1)
+def _browser_available() -> bool:
+    """True iff Playwright + a launchable Chromium are present locally."""
+    try:
+        from playwright.async_api import async_playwright
+    except Exception:
+        return False
+
+    async def _probe() -> bool:
+        try:
+            async with async_playwright() as pw:
+                browser = await pw.chromium.launch()
+                await browser.close()
+            return True
+        except Exception:
+            return False
+
+    try:
+        return asyncio.run(_probe())
+    except Exception:
+        return False
+
+
+requires_browser = pytest.mark.skipif(
+    not _browser_available(),
+    reason="Playwright Chromium not available",
+)
+
+
+def _load_png_colors(png_path):
+    """Return the set of RGB pixels in a PNG (Pillow), or None if unavailable."""
+    try:
+        from PIL import Image
+    except Exception:
+        return None
+    with Image.open(png_path) as im:
+        return set(im.convert("RGB").getdata())
+
+
+def test_write_png_signature_is_default_off():
+    """Additive contract: the new kwargs exist and default to the no-op path.
+
+    Runs anywhere the package imports (no browser needed). Guards the promise
+    that existing callers see zero behaviour change: ``url`` defaults to None.
+    """
+    params = inspect.signature(RenderingTools.write_png).parameters
+    assert "url" in params and "eval_js" in params and "ready_js" in params
+    assert params["url"].default is None
+    assert params["eval_js"].default is None
+    # ready_js has a sensible default predicate and is only consulted in URL mode.
+    assert isinstance(params["ready_js"].default, str)
+    assert params["ready_js"].default.strip() != ""
+
+
+@pytest.mark.playwright
+@requires_browser
+def test_write_png_url_navigation_runs_eval_js_before_ready_gate(tmp_path):
+    """url mode: navigate a local file, run eval_js, gate on ready_js, capture.
+
+    The fixture never sets the readiness flag itself, and paints nothing. Only
+    ``eval_js`` sets ``window.__RENDER_READY__`` (so a screenshot can only be
+    reached if eval_js ran) *and* injects a uniquely-coloured element (so the
+    side-effect is provably visible in the PNG).
+    """
+    runtime_outdir = tmp_path / "out"
+    workdir = tmp_path / "work"
+    runtime_outdir.mkdir()
+    workdir.mkdir()
+    OUTDIR_CV.set(str(runtime_outdir))
+    WORKDIR_CV.set(str(workdir))
+
+    # Fixture: no ready flag, no visible content of its own.
+    fixture = tmp_path / "widget.html"
+    fixture.write_text(
+        "<!doctype html><html><head><meta charset='utf-8'></head>"
+        "<body style='margin:0'></body></html>",
+        encoding="utf-8",
+    )
+
+    marker_rgb = (12, 34, 200)  # distinctive blue, not the default white bg
+    eval_js = (
+        "() => {"
+        "  const d = document.createElement('div');"
+        "  d.id = 'injected';"
+        "  d.style.width = '120px'; d.style.height = '120px';"
+        f"  d.style.background = 'rgb({marker_rgb[0]},{marker_rgb[1]},{marker_rgb[2]})';"
+        "  document.body.appendChild(d);"
+        "  window.__RENDER_READY__ = true;"
+        "}"
+    )
+
+    result = asyncio.run(
+        RenderingTools().write_png(
+            path="turn_test/outputs/widget.png",
+            content="",  # ignored in url mode
+            format="html",
+            url=fixture.as_uri(),
+            eval_js=eval_js,
+            ready_js="window.__RENDER_READY__ === true",
+            render_delay_ms=0,
+            content_selector="#injected",
+        )
+    )
+
+    assert result.get("ok") is True, result
+
+    png_path = resolve_output_dir() / "turn_test/outputs/widget.png"
+    assert png_path.exists() and png_path.stat().st_size > 0
+
+    # url mode must NOT write a temp render file (that is the content path).
+    assert not list(resolve_output_dir().glob("_render_*.html"))
+
+    colors = _load_png_colors(png_path)
+    if colors is not None:
+        # The eval_js-injected element must be present in the captured pixels.
+        assert marker_rgb in colors, "eval_js side-effect not visible in PNG"
+
+
+@pytest.mark.playwright
+@requires_browser
+def test_write_png_url_none_still_renders_from_content(tmp_path):
+    """url=None: the legacy content path is unchanged.
+
+    A temp ``_render_*.html`` is written from ``content`` and screenshotted; no
+    navigation seam is exercised.
+    """
+    runtime_outdir = tmp_path / "out"
+    workdir = tmp_path / "work"
+    runtime_outdir.mkdir()
+    workdir.mkdir()
+    OUTDIR_CV.set(str(runtime_outdir))
+    WORKDIR_CV.set(str(workdir))
+
+    marker_rgb = (200, 20, 40)  # distinctive red
+    html = (
+        "<div id='content' style='width:100px;height:100px;"
+        f"background:rgb({marker_rgb[0]},{marker_rgb[1]},{marker_rgb[2]})'></div>"
+    )
+
+    result = asyncio.run(
+        RenderingTools().write_png(
+            path="turn_test/outputs/inline.png",
+            content=html,
+            format="html",
+            # url omitted -> defaults to None -> legacy path
+            render_delay_ms=0,
+            content_selector="#content",
+        )
+    )
+
+    assert result.get("ok") is True, result
+
+    png_path = resolve_output_dir() / "turn_test/outputs/inline.png"
+    assert png_path.exists() and png_path.stat().st_size > 0
+
+    colors = _load_png_colors(png_path)
+    if colors is not None:
+        assert marker_rgb in colors, "inline content not visible in PNG"

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/tools/tests/test_rendering_url_navigation.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/tools/tests/test_rendering_url_navigation.py
@@ -11,14 +11,32 @@ cover the two contracts that matter:
 * ``url is None`` -> the legacy path is byte-identical: ``content`` is written to
   a temp ``_render_*.html`` and screenshotted; no navigation happens.
 
-The browser-backed tests are marked ``playwright`` and skip cleanly where no
-Chromium is available (e.g. slim CI images). ``importorskip`` keeps collection
-working where the package itself is not installed.
+Event-loop contract
+-------------------
+``write_png`` reaches Chromium through the process-global shared browser
+(``get_shared_browser()``), which caches a Playwright browser bound to the event
+loop that first launched it. pytest-asyncio (``asyncio_mode = auto``) gives every
+test a *fresh* function-scoped loop, so a second browser-backed test in the same
+session would otherwise reuse a browser bound to the first test's now-closed
+loop. The ``_reset_shared_browser`` autouse fixture closes+resets that singleton
+after every test *in the same loop that used it*, so each browser-backed test
+re-initialises Chromium on its own loop. The two browser tests are therefore
+``async def`` (they run on the managed loop) rather than nesting ``asyncio.run``.
+
+The browser-backed tests are marked ``playwright`` and, via the
+``requires_browser`` fixture, skip cleanly where no Chromium is available (e.g.
+slim CI images) -- unless ``KDCUBE_REQUIRE_BROWSER=1`` is set, in which case a
+missing browser is a hard failure so a CI job can assert the playwright tests
+actually ran. The Chromium probe lives in that fixture (not at collection time),
+so ``-m "not playwright"`` never launches a browser. ``importorskip`` keeps
+collection working where the package itself is not installed.
 """
 
 import asyncio
 import functools
 import inspect
+import os
+import pathlib
 
 import pytest
 
@@ -34,9 +52,24 @@ from kdcube_ai_app.apps.chat.sdk.runtime.run_ctx import OUTDIR_CV, WORKDIR_CV
 from kdcube_ai_app.apps.chat.sdk.runtime.workdir_discovery import resolve_output_dir
 
 
+def _require_browser_env() -> bool:
+    """True iff KDCUBE_REQUIRE_BROWSER asks CI to hard-require a real browser."""
+    return os.getenv("KDCUBE_REQUIRE_BROWSER", "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
+
 @functools.lru_cache(maxsize=1)
 def _browser_available() -> bool:
-    """True iff Playwright + a launchable Chromium are present locally."""
+    """True iff Playwright + a launchable Chromium are present locally.
+
+    Only ever called from the ``requires_browser`` fixture (test setup time),
+    never at import/collection time -- so collecting or running
+    ``-m "not playwright"`` never launches a browser.
+    """
     try:
         from playwright.async_api import async_playwright
     except Exception:
@@ -57,10 +90,44 @@ def _browser_available() -> bool:
         return False
 
 
-requires_browser = pytest.mark.skipif(
-    not _browser_available(),
-    reason="Playwright Chromium not available",
-)
+@pytest.fixture
+def requires_browser():
+    """Gate a browser-backed test on a launchable Chromium.
+
+    Skips when no browser is available, so slim CI images stay green. Set
+    ``KDCUBE_REQUIRE_BROWSER=1`` to turn that skip into a hard failure -- a CI
+    job can then prove the playwright tests actually executed rather than
+    silently skipping (green-with-nothing-verified).
+    """
+    if _browser_available():
+        return
+    if _require_browser_env():
+        pytest.fail(
+            "KDCUBE_REQUIRE_BROWSER is set but no launchable Chromium is "
+            "available; the browser-backed write_png tests did not run."
+        )
+    pytest.skip("Playwright Chromium not available")
+
+
+@pytest.fixture(autouse=True)
+async def _reset_shared_browser():
+    """Reset the process-global shared browser after every test.
+
+    The shared browser is cached against the loop that first launched it;
+    pytest-asyncio hands each test a fresh loop, so without this a second
+    browser-backed test would reuse a browser bound to a closed loop. Tearing it
+    down here -- in the same loop that used it -- lets the next test re-init
+    Chromium cleanly. No-op when nothing touched the browser (e.g. the sync
+    signature test).
+    """
+    yield
+    try:
+        from kdcube_ai_app.infra.rendering.shared_browser import (
+            close_shared_browser,
+        )
+        await close_shared_browser()
+    except Exception:
+        pass
 
 
 def _load_png_colors(png_path):
@@ -89,8 +156,9 @@ def test_write_png_signature_is_default_off():
 
 
 @pytest.mark.playwright
-@requires_browser
-def test_write_png_url_navigation_runs_eval_js_before_ready_gate(tmp_path):
+async def test_write_png_url_navigation_runs_eval_js_before_ready_gate(
+    tmp_path, monkeypatch, requires_browser
+):
     """url mode: navigate a local file, run eval_js, gate on ready_js, capture.
 
     The fixture never sets the readiness flag itself, and paints nothing. Only
@@ -104,6 +172,20 @@ def test_write_png_url_navigation_runs_eval_js_before_ready_gate(tmp_path):
     workdir.mkdir()
     OUTDIR_CV.set(str(runtime_outdir))
     WORKDIR_CV.set(str(workdir))
+
+    # Spy on temp-HTML writes so the "url mode writes no _render_ file" claim is
+    # non-vacuous: the legacy content path unlinks its temp file in a finally, so
+    # a post-hoc glob would pass even if the temp file *had* been written. We
+    # instead assert write_text was never invoked for a _render_ file at all.
+    render_writes: list[str] = []
+    real_write_text = pathlib.Path.write_text
+
+    def _spy_write_text(self, *args, **kwargs):
+        if "_render_" in self.name:
+            render_writes.append(str(self))
+        return real_write_text(self, *args, **kwargs)
+
+    monkeypatch.setattr(pathlib.Path, "write_text", _spy_write_text)
 
     # Fixture: no ready flag, no visible content of its own.
     fixture = tmp_path / "widget.html"
@@ -125,17 +207,15 @@ def test_write_png_url_navigation_runs_eval_js_before_ready_gate(tmp_path):
         "}"
     )
 
-    result = asyncio.run(
-        RenderingTools().write_png(
-            path="turn_test/outputs/widget.png",
-            content="",  # ignored in url mode
-            format="html",
-            url=fixture.as_uri(),
-            eval_js=eval_js,
-            ready_js="window.__RENDER_READY__ === true",
-            render_delay_ms=0,
-            content_selector="#injected",
-        )
+    result = await RenderingTools().write_png(
+        path="turn_test/outputs/widget.png",
+        content="",  # ignored in url mode
+        format="html",
+        url=fixture.as_uri(),
+        eval_js=eval_js,
+        ready_js="window.__RENDER_READY__ === true",
+        render_delay_ms=0,
+        content_selector="#injected",
     )
 
     assert result.get("ok") is True, result
@@ -144,7 +224,7 @@ def test_write_png_url_navigation_runs_eval_js_before_ready_gate(tmp_path):
     assert png_path.exists() and png_path.stat().st_size > 0
 
     # url mode must NOT write a temp render file (that is the content path).
-    assert not list(resolve_output_dir().glob("_render_*.html"))
+    assert render_writes == [], render_writes
 
     colors = _load_png_colors(png_path)
     if colors is not None:
@@ -153,12 +233,15 @@ def test_write_png_url_navigation_runs_eval_js_before_ready_gate(tmp_path):
 
 
 @pytest.mark.playwright
-@requires_browser
-def test_write_png_url_none_still_renders_from_content(tmp_path):
+async def test_write_png_url_none_still_renders_from_content(
+    tmp_path, requires_browser
+):
     """url=None: the legacy content path is unchanged.
 
     A temp ``_render_*.html`` is written from ``content`` and screenshotted; no
-    navigation seam is exercised.
+    navigation seam is exercised. This runs *after* a browser-backed test in the
+    same session, exercising the shared-browser reset (a second launch on a
+    fresh loop must succeed).
     """
     runtime_outdir = tmp_path / "out"
     workdir = tmp_path / "work"
@@ -173,15 +256,13 @@ def test_write_png_url_none_still_renders_from_content(tmp_path):
         f"background:rgb({marker_rgb[0]},{marker_rgb[1]},{marker_rgb[2]})'></div>"
     )
 
-    result = asyncio.run(
-        RenderingTools().write_png(
-            path="turn_test/outputs/inline.png",
-            content=html,
-            format="html",
-            # url omitted -> defaults to None -> legacy path
-            render_delay_ms=0,
-            content_selector="#content",
-        )
+    result = await RenderingTools().write_png(
+        path="turn_test/outputs/inline.png",
+        content=html,
+        format="html",
+        # url omitted -> defaults to None -> legacy path
+        render_delay_ms=0,
+        content_selector="#content",
     )
 
     assert result.get("ok") is True, result

--- a/app/ai-app/src/kdcube-ai-app/setup.cfg
+++ b/app/ai-app/src/kdcube-ai-app/setup.cfg
@@ -118,3 +118,4 @@ console_scripts =
 asyncio_mode = auto
 markers =
     asyncio: run the test in an asyncio event loop
+    playwright: test drives a headless browser; skipped where no Chromium is available


### PR DESCRIPTION
## What

Adds three optional kwargs to `RenderingTools.write_png` (`apps/chat/sdk/tools/rendering_tools.py`) for headless live-URL capture:

- **`url`** — navigate a headless page to a live URL (`wait_until="networkidle"`) instead of rendering inline `content` to a temp HTML file.
- **`eval_js`** — a JS expression evaluated after load, *before* the readiness gate (e.g. inject an auth token, or trigger a client-side render).
- **`ready_js`** — a JS predicate polled via `wait_for_function` before the screenshot. Default: `window.__RENDER_READY__ === true`. Tolerates an explicit `None` (falls back to the default predicate).

When set, the method navigates to `url`, optionally runs `eval_js`, waits on `ready_js`, then reuses the existing background / zoom / bbox-crop screenshot path.

## Default-off (no behavior change)

When **`url is None`** the capture path is **byte-identical to today**: `content` is written to a temp `_render_*.html` and screenshotted. The `mermaid` / `html` / `markdown` branches are simply guarded by `url is None`, and the temp-file write is likewise guarded. Existing callers see zero change.

## Why

Generally useful for any bundle that needs to **snapshot a live widget or dashboard** rather than re-rendering content inline: authenticate the page via `eval_js`, and signal readiness (fonts/data/animation settled) via `ready_js`, before the capture.

## Security / trust boundary (url mode)

`url` mode is a **server-trusted, privileged** operation, documented in the tool description rather than sanitized:

- The URL is fetched by a **server-side headless browser**; **any scheme is accepted**, including `file://` (local disk) and internal `http://` hosts (SSRF surface).
- `eval_js` runs **arbitrary JavaScript** in the fetched page.
- There is **no allowlist**; callers must pass only bundle-controlled URLs, never raw untrusted end-user input. A future `KDCUBE_PNG_URL_ALLOWLIST`-style knob could restrict schemes/hosts. The `write_png` `kernel_function` description and the `url`/`eval_js` param annotations spell this out.

## Robustness

- **Context leak guard:** the shared browser is long-lived, so the per-render Playwright `context` is now closed in a `finally` on **every** exit path (goto errors, a `ready_js` 30s timeout, mermaid early-returns) — previously a failed url-mode `goto`/`ready_js` could leak a Chromium context in the shared process.

## Tests

`apps/chat/sdk/tools/tests/test_rendering_url_navigation.py`:

- **`test_write_png_signature_is_default_off`** — no browser needed; asserts the new kwargs exist and `url`/`eval_js` default to the no-op path (`ready_js` has a non-empty default predicate).
- **`test_write_png_url_navigation_runs_eval_js_before_ready_gate`** (`@pytest.mark.playwright`) — navigates a local `file://` fixture whose readiness flag is set *only* by `eval_js`, which also injects a uniquely-coloured element; asserts the element colour is present in the captured PNG (side-effect provably visible) and — via a `write_text` spy — that **no temp `_render_*.html` was ever written** (the legacy path deletes its temp file in a `finally`, so a post-hoc glob would be vacuous).
- **`test_write_png_url_none_still_renders_from_content`** (`@pytest.mark.playwright`) — asserts the `url=None` path still renders inline `content` to a PNG; runs *after* a browser-backed test to exercise the shared-browser reset.

**Single-event-loop fix.** `write_png` reaches Chromium through the process-global `get_shared_browser()`, which caches a browser bound to the loop that first launched it. pytest-asyncio (`asyncio_mode = auto`) gives each test a fresh function-scoped loop, so two browser-backed tests in one session would otherwise reuse a browser bound to a closed loop. The two browser tests are now `async def` (run on the managed loop) and an **autouse `_reset_shared_browser` fixture** calls `close_shared_browser()` after each test *in the same loop that used it*, so the next test re-inits Chromium on its own loop.

**CI knob — `KDCUBE_REQUIRE_BROWSER`.** Browser-backed tests skip cleanly where no Chromium is available (slim CI images), gated by a `requires_browser` fixture that runs the Chromium probe at **setup time** (not collection — so `-m "not playwright"` never launches a browser). Set **`KDCUBE_REQUIRE_BROWSER=1`** to turn that skip into a hard failure, so a dedicated CI job can assert the playwright tests actually executed rather than silently skipping (green-with-nothing-verified). The `playwright` marker is registered in `setup.cfg`.

> Note: the pixel-level assertions (eval_js side-effect visible in PNG) still require one CI run with a real Chromium — they cannot be exercised in a browserless environment. Run that job with `KDCUBE_REQUIRE_BROWSER=1 pytest -m playwright`.

## Downstream

Retires navigator patch `render-png-url-eval` (+ its cloud `[render-png-hotpatch]`) after merge + release.

---
Draft — not for merge yet.
