### PR TITLE
service-hub: stop probing inactive provider secrets; make the JSON format-fixer model configurable

### DIFF
--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/tests/bundle/test_model_router_service_keys.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/tests/bundle/test_model_router_service_keys.py
@@ -29,6 +29,7 @@ from kdcube_ai_app.infra.service_hub import inventory
 @pytest.mark.asyncio
 async def test_config_request_secret_resolution_prefers_bundle_secret(monkeypatch):
     calls = []
+    inventory._CONFIG_SECRET_CACHE.clear()
 
     async def fake_get_secret(key, default=None, **kwargs):
         calls.append((key, kwargs))
@@ -51,6 +52,71 @@ async def test_config_request_secret_resolution_prefers_bundle_secret(monkeypatc
     assert ("b:services.google.api_key", {"bundle_id": "bundle@1"}) not in calls
 
 
+@pytest.mark.asyncio
+async def test_config_request_secret_resolution_skips_unused_role_providers(monkeypatch):
+    calls = []
+    inventory._CONFIG_SECRET_CACHE.clear()
+
+    async def fake_get_secret(key, default=None, **kwargs):
+        calls.append((key, kwargs))
+        if key == "b:services.openai.api_key" and kwargs.get("bundle_id") == "bundle@1":
+            return "sk-bundle-openai"
+        if key == "services.anthropic.api_key":
+            return "sk-global-anthropic"
+        return default
+
+    monkeypatch.setattr(inventory, "get_secret", fake_get_secret)
+    monkeypatch.setattr(inventory, "get_settings", lambda: _settings(DEFAULT_EMBEDDER="openai-text-embedding-3-small"))
+
+    resolved = await inventory.resolve_config_request_secrets(
+        inventory.ConfigRequest(
+            role_models={
+                "quick.router": {"provider": "anthropic", "model": "claude-haiku"},
+            },
+        ),
+        bundle_id="bundle@1",
+    )
+
+    assert resolved.openai_api_key == "sk-bundle-openai"
+    assert resolved.claude_api_key == "sk-global-anthropic"
+    assert resolved.google_api_key is None
+    assert resolved.huggingface_api_key is None
+    assert resolved.openrouter_api_key is None
+    assert ("b:services.google.api_key", {"bundle_id": "bundle@1"}) not in calls
+    assert ("services.google.api_key", {}) not in calls
+    assert ("b:services.huggingface.api_key", {"bundle_id": "bundle@1"}) not in calls
+    assert ("services.huggingface.api_key", {}) not in calls
+    assert ("b:services.openrouter.api_key", {"bundle_id": "bundle@1"}) not in calls
+    assert ("services.openrouter.api_key", {}) not in calls
+
+
+@pytest.mark.asyncio
+async def test_config_request_secret_resolution_caches_missing_values(monkeypatch):
+    calls = []
+    inventory._CONFIG_SECRET_CACHE.clear()
+
+    async def fake_get_secret(key, default=None, **kwargs):
+        calls.append((key, kwargs))
+        return default
+
+    monkeypatch.setattr(inventory, "get_secret", fake_get_secret)
+    monkeypatch.setattr(inventory, "get_settings", lambda: _settings(DEFAULT_EMBEDDER="openai-text-embedding-3-small"))
+    monkeypatch.setenv("KDCUBE_CONFIG_SECRET_CACHE_TTL_SECONDS", "300")
+
+    req = inventory.ConfigRequest(
+        role_models={
+            "quick.router": {"provider": "anthropic", "model": "claude-haiku"},
+        },
+    )
+    await inventory.resolve_config_request_secrets(req, bundle_id="bundle@1")
+    await inventory.resolve_config_request_secrets(req, bundle_id="bundle@1")
+
+    assert calls.count(("b:services.openai.api_key", {"bundle_id": "bundle@1"})) == 1
+    assert calls.count(("services.openai.api_key", {})) == 1
+    assert calls.count(("b:services.anthropic.api_key", {"bundle_id": "bundle@1"})) == 1
+    assert calls.count(("services.anthropic.api_key", {})) == 1
+
+
 # ---------------------------------------------------------------------------
 # Fixture: minimal Config that avoids get_settings() calls
 # ---------------------------------------------------------------------------
@@ -67,8 +133,54 @@ def _make_config(*, openai_api_key="", claude_api_key="", google_api_key=""):
     cfg.custom_model_api_key = None
     cfg.role_models = {}
     cfg.default_llm_model = {"provider": "anthropic", "model_name": "claude-sonnet-static"}
+    cfg.format_fixer_provider = "anthropic"
     cfg.format_fixer_model = "claude-haiku-static"
     return cfg
+
+
+def test_format_fixer_role_uses_configured_provider_model():
+    cfg = _make_config()
+    cfg.format_fixer_provider = "openai"
+    cfg.format_fixer_model = "gpt-router-fixer"
+
+    role_map = cfg.default_role_map()
+
+    assert role_map["format_fixer"] == {"provider": "openai", "model": "gpt-router-fixer"}
+
+
+def test_format_fixer_defaults_to_active_default_llm_not_dead_id(monkeypatch):
+    # Building a real Config with no format-fixer env/config must resolve the
+    # fixer to the active default LLM, never the retired
+    # "claude-3-haiku-20240307" literal that the old code hardcoded.
+    for var in (
+        "KDCUBE_FORMAT_FIXER_PROVIDER", "FORMAT_FIXER_PROVIDER",
+        "KDCUBE_FORMAT_FIXER_MODEL", "FORMAT_FIXER_MODEL",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+    cfg = inventory.Config(default_llm_model="o3-mini")
+
+    assert cfg.format_fixer_provider == cfg.default_llm_model["provider"] == "openai"
+    assert cfg.format_fixer_model == cfg.default_llm_model["model_name"] == "o3-mini"
+    assert cfg.format_fixer_model != "claude-3-haiku-20240307"
+
+    # And the role map / lazy ensure use the same resolved pair.
+    assert cfg.default_role_map()["format_fixer"] == {"provider": "openai", "model": "o3-mini"}
+    assert cfg.ensure_role("format_fixer") == {"provider": "openai", "model": "o3-mini"}
+
+
+def test_format_fixer_env_override_wins(monkeypatch):
+    monkeypatch.delenv("FORMAT_FIXER_PROVIDER", raising=False)
+    monkeypatch.delenv("FORMAT_FIXER_MODEL", raising=False)
+    monkeypatch.setenv("KDCUBE_FORMAT_FIXER_PROVIDER", "anthropic")
+    monkeypatch.setenv("KDCUBE_FORMAT_FIXER_MODEL", "claude-3-5-haiku-20241022")
+
+    cfg = inventory.Config(default_llm_model="o3-mini")
+
+    # Env override wins over the active default LLM (o3-mini/openai).
+    assert cfg.format_fixer_provider == "anthropic"
+    assert cfg.format_fixer_model == "claude-3-5-haiku-20241022"
+    assert cfg.default_role_map()["format_fixer"] == {"provider": "anthropic", "model": "claude-3-5-haiku-20241022"}
 
 
 # ---------------------------------------------------------------------------

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/tests/bundle/test_model_router_service_keys.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/tests/bundle/test_model_router_service_keys.py
@@ -386,6 +386,96 @@ class TestMkAnthropicAsync:
 # _mk_gemini
 # ---------------------------------------------------------------------------
 
+# ---------------------------------------------------------------------------
+# FormatFixerService runtime client build (finding 1 / finding 2)
+# ---------------------------------------------------------------------------
+
+class TestFormatFixerClientBuild:
+    def test_openai_o_series_fixer_omits_invalid_temperature(self, monkeypatch):
+        """An o-series fixer default (e.g. o3-mini) must build its OpenAI client
+        through make_chat_openai, whose caps logic drops temperature for models
+        that forbid it -- otherwise OpenAI 400s. The old code called
+        ChatOpenAI(..., temperature=0) directly and would 400."""
+        captured = {}
+
+        class FakeChatOpenAI:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+
+        # Patch the module-global ChatOpenAI that make_chat_openai constructs,
+        # so the real caps-aware helper runs end to end.
+        monkeypatch.setattr(inventory, "ChatOpenAI", FakeChatOpenAI)
+
+        cfg = _make_config(openai_api_key="sk-openai")
+        cfg.format_fixer_provider = "openai"
+        cfg.format_fixer_model = "o3-mini"
+
+        fixer = inventory.FormatFixerService(cfg)
+
+        assert isinstance(fixer.client, FakeChatOpenAI)      # make_chat_openai was used
+        assert captured["model"] == "o3-mini"
+        # model_caps("o3-mini") -> temperature: False, so it must be dropped.
+        assert "temperature" not in captured
+
+    def test_openai_non_o_series_fixer_keeps_temperature(self, monkeypatch):
+        """A model whose caps allow temperature (gpt-4o) still gets it through
+        make_chat_openai, proving the helper -- not a hardcoded drop -- is used."""
+        captured = {}
+
+        class FakeChatOpenAI:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+
+        monkeypatch.setattr(inventory, "ChatOpenAI", FakeChatOpenAI)
+
+        cfg = _make_config(openai_api_key="sk-openai")
+        cfg.format_fixer_provider = "openai"
+        cfg.format_fixer_model = "gpt-4o"
+
+        fixer = inventory.FormatFixerService(cfg)
+
+        assert isinstance(fixer.client, FakeChatOpenAI)
+        assert captured["model"] == "gpt-4o"
+        assert captured.get("temperature") == 0.0
+
+
+@pytest.mark.asyncio
+async def test_config_request_resolves_default_llm_provider_for_openai_only_roles(monkeypatch):
+    """anthropic default LLM + openai-only role_models: the default-LLM
+    (anthropic) provider key MUST still be resolved, or FormatFixerService
+    builds an anthropic client with an empty key and every fix fails."""
+    inventory._CONFIG_SECRET_CACHE.clear()
+    for var in ("KDCUBE_FORMAT_FIXER_PROVIDER", "FORMAT_FIXER_PROVIDER"):
+        monkeypatch.delenv(var, raising=False)
+
+    async def fake_get_secret(key, default=None, **kwargs):
+        if key == "services.anthropic.api_key":
+            return "sk-global-anthropic"
+        if key == "services.openai.api_key":
+            return "sk-global-openai"
+        return default
+
+    monkeypatch.setattr(inventory, "get_secret", fake_get_secret)
+    monkeypatch.setattr(
+        inventory, "get_settings",
+        lambda: _settings(
+            DEFAULT_MODEL_LLM_ID="claude-sonnet-4-20250514",   # anthropic
+            DEFAULT_EMBEDDER="openai-text-embedding-3-small",
+        ),
+    )
+
+    resolved = await inventory.resolve_config_request_secrets(
+        inventory.ConfigRequest(
+            role_models={"quick.router": {"provider": "openai", "model": "gpt-4o"}},
+        ),
+        bundle_id=None,
+    )
+
+    # openai came from role_models; anthropic came from the default LLM provider.
+    assert resolved.openai_api_key == "sk-global-openai"
+    assert resolved.claude_api_key == "sk-global-anthropic"
+
+
 class TestMkGemini:
     def _fake_gemini_client(self, captured: dict):
         class FakeGeminiModelClient:

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/infra/service_hub/inventory.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/infra/service_hub/inventory.py
@@ -21,7 +21,7 @@ from langchain_core.embeddings import Embeddings
 from langchain_core.messages import SystemMessage, HumanMessage, BaseMessage, AIMessage, AIMessageChunk, ToolMessage
 from langchain_openai import ChatOpenAI, OpenAIEmbeddings
 
-from kdcube_ai_app.apps.chat.reg import MODEL_CONFIGS, EMBEDDERS, model_caps
+from kdcube_ai_app.apps.chat.reg import DEFAULT_MODEL_CONFIG, MODEL_CONFIGS, EMBEDDERS, model_caps
 from kdcube_ai_app.infra.accounting import track_embedding, track_llm
 from kdcube_ai_app.infra.accounting.usage import (
     _structured_usage_extractor,
@@ -540,6 +540,8 @@ class ConfigRequest(BaseModel):
     # Feature toggles
     has_classifier: Optional[bool] = None         # override; else derive from MODEL_CONFIGS
     format_fix_enabled: bool = True               # enable JSON fixer on structured calls
+    format_fixer_provider: Optional[str] = None
+    format_fixer_model: Optional[str] = None
 
     # Gemini caching (optional, safe defaults)
     gemini_cache_enabled: Optional[bool] = None
@@ -569,6 +571,37 @@ class ConfigRequest(BaseModel):
     assistant_signal_spec: Optional[str] = None
 
 
+_CONFIG_SECRET_CACHE: dict[tuple[str, str], tuple[float, str | None]] = {}
+_CONFIG_SECRET_CACHE_TTL_SECONDS = 300.0
+
+
+def _config_secret_cache_ttl_seconds() -> float:
+    raw = str(os.getenv("KDCUBE_CONFIG_SECRET_CACHE_TTL_SECONDS") or "").strip()
+    if not raw:
+        return _CONFIG_SECRET_CACHE_TTL_SECONDS
+    try:
+        return max(0.0, float(raw))
+    except Exception:
+        return _CONFIG_SECRET_CACHE_TTL_SECONDS
+
+
+async def _resolve_cached_config_secret(canonical_key: str, *, bundle_id: str | None = None) -> str | None:
+    ttl = _config_secret_cache_ttl_seconds()
+    cache_key = (str(bundle_id or ""), canonical_key)
+    now = time.monotonic()
+    cached = _CONFIG_SECRET_CACHE.get(cache_key)
+    if cached and cached[0] > now:
+        return cached[1]
+
+    value = None
+    if bundle_id:
+        value = await get_secret(f"b:{canonical_key}", bundle_id=bundle_id)
+    value = value or await get_secret(canonical_key)
+    if ttl > 0:
+        _CONFIG_SECRET_CACHE[cache_key] = (now + ttl, value)
+    return value
+
+
 async def resolve_config_request_secrets(
         config_request: ConfigRequest,
         *,
@@ -576,22 +609,48 @@ async def resolve_config_request_secrets(
 ) -> ConfigRequest:
     """Resolve provider-backed model credentials before sync client factories run."""
     updates: dict[str, str] = {}
+    required_providers: set[str] = set()
+    if isinstance(config_request.role_models, dict) and config_request.role_models:
+        for spec in config_request.role_models.values():
+            if isinstance(spec, dict):
+                provider = str(spec.get("provider") or "").strip().lower()
+                if provider:
+                    required_providers.add(provider)
+    else:
+        try:
+            settings = get_settings()
+            default_model_id = str(getattr(settings, "DEFAULT_MODEL_LLM_ID", "") or "").strip()
+            model_spec = MODEL_CONFIGS.get(default_model_id)
+            provider = str((model_spec or DEFAULT_MODEL_CONFIG).get("provider") or "").strip().lower()
+            if provider:
+                required_providers.add(provider)
+        except Exception:
+            required_providers.add("anthropic")
+    try:
+        settings = get_settings()
+        embedder_id = str(getattr(settings, "DEFAULT_EMBEDDER", "") or "").strip()
+        embedder = EMBEDDERS.get(embedder_id)
+        provider = str((embedder or {}).get("provider") or "").strip().lower()
+        if provider:
+            required_providers.add(provider)
+    except Exception:
+        pass
 
-    async def _resolve(field: str, canonical_key: str) -> None:
+    async def _resolve(field: str, canonical_key: str, provider: Optional[str] = None) -> None:
+        # provider=None => always attempt (e.g. "custom" gateway keys).
+        if provider is not None and provider not in required_providers:
+            return
         if getattr(config_request, field, None):
             return
-        value = None
-        if bundle_id:
-            value = await get_secret(f"b:{canonical_key}", bundle_id=bundle_id)
-        value = value or await get_secret(canonical_key)
+        value = await _resolve_cached_config_secret(canonical_key, bundle_id=bundle_id)
         if value:
             updates[field] = value
 
-    await _resolve("openai_api_key", "services.openai.api_key")
-    await _resolve("claude_api_key", "services.anthropic.api_key")
-    await _resolve("google_api_key", "services.google.api_key")
-    await _resolve("huggingface_api_key", "services.huggingface.api_key")
-    await _resolve("openrouter_api_key", "services.openrouter.api_key")
+    await _resolve("openai_api_key", "services.openai.api_key", "openai")
+    await _resolve("claude_api_key", "services.anthropic.api_key", "anthropic")
+    await _resolve("google_api_key", "services.google.api_key", "google")
+    await _resolve("huggingface_api_key", "services.huggingface.api_key", "huggingface")
+    await _resolve("openrouter_api_key", "services.openrouter.api_key", "openrouter")
     # provider "custom" (locally served models / models gateway): same
     # door-time, bundle-then-platform key resolution as hosted providers
     await _resolve("custom_model_api_key", "services.llm.custom.api_key")
@@ -635,11 +694,26 @@ class Config:
         # logging
         self.log_level = get_settings().PLATFORM.LOG.LOG_LEVEL
 
-        # format fix (Claude by default)
-        self.format_fixer_model = "claude-3-haiku-20240307"
+        self.default_llm_model = MODEL_CONFIGS.get(default_llm_model) or  MODEL_CONFIGS.get("o3-mini")
+
+        # format fix model is configurable; default to the active default LLM
+        # instead of a stale provider-specific literal.
+        self.format_fixer_provider = (
+            os.getenv("KDCUBE_FORMAT_FIXER_PROVIDER")
+            or os.getenv("FORMAT_FIXER_PROVIDER")
+            or self.default_llm_model["provider"]
+        )
+        self.format_fixer_model = (
+            os.getenv("KDCUBE_FORMAT_FIXER_MODEL")
+            or os.getenv("FORMAT_FIXER_MODEL")
+            or self.default_llm_model["model_name"]
+        )
+        if self.format_fixer_model in MODEL_CONFIGS:
+            model_spec = MODEL_CONFIGS[self.format_fixer_model]
+            self.format_fixer_provider = model_spec.get("provider") or self.format_fixer_provider
+            self.format_fixer_model = model_spec.get("model_name") or self.format_fixer_model
         self.format_fix_enabled = True
 
-        self.default_llm_model = MODEL_CONFIGS.get(default_llm_model) or  MODEL_CONFIGS.get("o3-mini")
         # role map (filled later; defaults below)
         self.role_models: Dict[str, Dict[str, str]] = role_models or self.default_role_map()
 
@@ -718,8 +792,7 @@ class Config:
         BASE_ROLES = ("classifier", "query_writer", "reranker", "answer_generator", "format_fixer")
         base = {r: {"provider": self.default_llm_model["provider"], "model": self.default_llm_model["model_name"]}
                 for r in BASE_ROLES}
-        # prefer Anthropic for format fixer
-        base["format_fixer"] = {"provider": "anthropic", "model": self.format_fixer_model}
+        base["format_fixer"] = {"provider": self.format_fixer_provider, "model": self.format_fixer_model}
         return base
 
     def get_default_role_spec(self) -> Dict[str, str]:
@@ -730,7 +803,7 @@ class Config:
         """Make sure a role has a mapping; if missing, fill with defaults (special-case format_fixer)."""
         if role not in self.role_models:
             if role == "format_fixer":
-                self.role_models[role] = {"provider": "anthropic", "model": self.format_fixer_model}
+                self.role_models[role] = {"provider": self.format_fixer_provider, "model": self.format_fixer_model}
             else:
                 self.role_models[role] = self.get_default_role_spec()
         return self.role_models[role]
@@ -804,6 +877,10 @@ def create_workflow_config(config_request: ConfigRequest) -> Config:
         cfg.gemini_cache_ttl_seconds = int(config_request.gemini_cache_ttl_seconds)
 
     cfg.format_fix_enabled = bool(config_request.format_fix_enabled)
+    if config_request.format_fixer_provider:
+        cfg.format_fixer_provider = str(config_request.format_fixer_provider).strip().lower()
+    if config_request.format_fixer_model:
+        cfg.format_fixer_model = str(config_request.format_fixer_model).strip()
 
     # embeddings
     # try:
@@ -1060,17 +1137,32 @@ def ms_freeform_meta_extractor(model_service, _client=None, messages=None, *a, *
 # Format fixer
 # =========================
 class FormatFixerService:
-    """Fixes malformed JSON responses using Claude"""
+    """Fixes malformed JSON responses using the configured format_fixer role."""
     def __init__(self, config: Config):
         self.config = config
         self.logger = AgentLogger("FormatFixer", config.log_level)
+        self.role_spec = dict(config.ensure_role("format_fixer"))
+        self.provider = str(self.role_spec.get("provider") or config.format_fixer_provider or "").strip().lower()
+        self.model = str(self.role_spec.get("model") or config.format_fixer_model or "").strip()
+        self.client = None
         try:
-            import anthropic
-            self.claude_client = anthropic.Anthropic(api_key=config.claude_api_key)
-            # self.logger.log_step("claude_client_initialized", {"model": config.format_fixer_model})
-        except ImportError:
-            self.claude_client = None
-            self.logger.log_error(ImportError("anthropic package not available"), "Claude client initialization")
+            if self.provider == "anthropic":
+                import anthropic
+                self.client = anthropic.Anthropic(api_key=config.claude_api_key)
+            elif self.provider == "openai":
+                self.client = ChatOpenAI(
+                    model=self.model,
+                    api_key=config.openai_api_key or None,
+                    temperature=0,
+                )
+            else:
+                self.logger.log_error(
+                    ValueError(f"Unsupported format_fixer provider: {self.provider}"),
+                    "Format fixer client initialization",
+                )
+        except Exception as exc:
+            self.client = None
+            self.logger.log_error(exc, "Format fixer client initialization")
 
     async def fix_format(
             self,
@@ -1097,12 +1189,12 @@ class FormatFixerService:
             expected_format=expected_format,
             input_data_length=0,
             system_prompt_length=len(system_prompt_text),
-            model=self.config.format_fixer_model,
-            provider="anthropic"
+            model=self.model,
+            provider=self.provider,
         )
 
-        if not self.claude_client:
-            msg = "Claude client not available"
+        if not self.client:
+            msg = "Format fixer client not available"
             self.logger.log_error(Exception(msg), "Client unavailable")
             self.logger.finish_operation(False, msg)
             return {"success": False, "error": msg, "raw": raw_output}
@@ -1118,18 +1210,30 @@ Malformed output: {raw_output}
 Please fix the JSON to match the expected format. Return only the fixed JSON, no additional text."""
 
             self.logger.log_step("sending_fix_request", {
-                "model": self.config.format_fixer_model,
+                "provider": self.provider,
+                "model": self.model,
                 "fix_prompt_length": len(fix_prompt),
                 "raw_output": raw_output
             })
 
-            response = self.claude_client.messages.create(
-                model=self.config.format_fixer_model,
-                max_tokens=1000,
-                messages=[{"role": "user", "content": fix_prompt}]
-            )
-
-            fixed_content = response.content[0].text
+            if self.provider == "anthropic":
+                response = self.client.messages.create(
+                    model=self.model,
+                    max_tokens=1000,
+                    messages=[{"role": "user", "content": fix_prompt}]
+                )
+                fixed_content = response.content[0].text
+            elif self.provider == "openai":
+                response = await self.client.ainvoke([
+                    SystemMessage(content="Return only valid JSON."),
+                    HumanMessage(content=fix_prompt),
+                ])
+                fixed_content = str(getattr(response, "content", "") or "")
+            else:
+                msg = f"Unsupported format_fixer provider: {self.provider}"
+                self.logger.log_error(ValueError(msg), "Format fixing failed")
+                self.logger.finish_operation(False, msg)
+                return {"success": False, "error": msg, "raw": raw_output}
 
             try:
                 parsed = json.loads(fixed_content)
@@ -1396,8 +1500,8 @@ class ModelServiceBase:
                             validated = response_format.model_validate(fix["data"])
                             self.logger.finish_operation(True,
                                                          "Parsed after FormatFixer",
-                                                         model=self.format_fixer.config.format_fixer_model,
-                                                         provider="anthropic",)
+                                                         model=getattr(self.format_fixer, "model", None),
+                                                         provider=getattr(self.format_fixer, "provider", None),)
                             return {
                                 "success": True,
                                 "data": validated.model_dump(),

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/infra/service_hub/inventory.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/infra/service_hub/inventory.py
@@ -610,22 +610,44 @@ async def resolve_config_request_secrets(
     """Resolve provider-backed model credentials before sync client factories run."""
     updates: dict[str, str] = {}
     required_providers: set[str] = set()
+
+    # Providers explicitly referenced by role_models always need their key.
     if isinstance(config_request.role_models, dict) and config_request.role_models:
         for spec in config_request.role_models.values():
             if isinstance(spec, dict):
                 provider = str(spec.get("provider") or "").strip().lower()
                 if provider:
                     required_providers.add(provider)
-    else:
-        try:
-            settings = get_settings()
-            default_model_id = str(getattr(settings, "DEFAULT_MODEL_LLM_ID", "") or "").strip()
-            model_spec = MODEL_CONFIGS.get(default_model_id)
-            provider = str((model_spec or DEFAULT_MODEL_CONFIG).get("provider") or "").strip().lower()
-            if provider:
-                required_providers.add(provider)
-        except Exception:
-            required_providers.add("anthropic")
+
+    # The default-LLM provider is ALWAYS needed: any role that isn't pinned in
+    # role_models falls back to it, and the format-fixer defaults to it too.
+    # (Previously this was only added in the empty-role_models branch, so a
+    #  bundle sending openai-only roles never resolved the anthropic default
+    #  key -> FormatFixerService built an anthropic client with an empty key.)
+    default_llm_provider = "anthropic"
+    try:
+        settings = get_settings()
+        default_model_id = str(getattr(settings, "DEFAULT_MODEL_LLM_ID", "") or "").strip()
+        model_spec = MODEL_CONFIGS.get(default_model_id)
+        default_llm_provider = str(
+            (model_spec or DEFAULT_MODEL_CONFIG).get("provider") or "anthropic"
+        ).strip().lower() or "anthropic"
+    except Exception:
+        default_llm_provider = "anthropic"
+    if default_llm_provider:
+        required_providers.add(default_llm_provider)
+
+    # The EFFECTIVE format-fixer provider also needs its key resolved:
+    # request override -> env override -> default-LLM provider.
+    fixer_provider = str(
+        (config_request.format_fixer_provider or "")
+        or os.getenv("KDCUBE_FORMAT_FIXER_PROVIDER")
+        or os.getenv("FORMAT_FIXER_PROVIDER")
+        or default_llm_provider
+    ).strip().lower()
+    if fixer_provider:
+        required_providers.add(fixer_provider)
+
     try:
         settings = get_settings()
         embedder_id = str(getattr(settings, "DEFAULT_EMBEDDER", "") or "").strip()
@@ -881,6 +903,13 @@ def create_workflow_config(config_request: ConfigRequest) -> Config:
         cfg.format_fixer_provider = str(config_request.format_fixer_provider).strip().lower()
     if config_request.format_fixer_model:
         cfg.format_fixer_model = str(config_request.format_fixer_model).strip()
+    # Apply the same id -> model_name normalization the env path does: if the
+    # request passed a MODEL_CONFIGS id (e.g. "o3-mini"), resolve it to the
+    # concrete provider/model_name pair.
+    if cfg.format_fixer_model in MODEL_CONFIGS:
+        _fixer_spec = MODEL_CONFIGS[cfg.format_fixer_model]
+        cfg.format_fixer_provider = _fixer_spec.get("provider") or cfg.format_fixer_provider
+        cfg.format_fixer_model = _fixer_spec.get("model_name") or cfg.format_fixer_model
 
     # embeddings
     # try:
@@ -1150,7 +1179,10 @@ class FormatFixerService:
                 import anthropic
                 self.client = anthropic.Anthropic(api_key=config.claude_api_key)
             elif self.provider == "openai":
-                self.client = ChatOpenAI(
+                # Build via the caps-aware helper so o-series models (whose
+                # caps forbid a non-default temperature, e.g. the fallback
+                # default o3-mini) don't 400 on temperature=0.
+                self.client = make_chat_openai(
                     model=self.model,
                     api_key=config.openai_api_key or None,
                     temperature=0,


### PR DESCRIPTION
## Summary

Two related changes in `infra/service_hub/inventory.py`, both default-preserving.

### 1. Scope model-service secret resolution to active providers (+ TTL cache)
`resolve_config_request_secrets()` currently probes the secret manager (bundle + platform key) for **all five** hosted providers (openai / anthropic / google / huggingface / openrouter) on every config build, regardless of whether the deployment uses them. This change limits probing to the providers actually referenced in `role_models` (or, when `role_models` is empty, the active default LLM), plus the default embedder's provider. Results — present **and** absent — are memoized for `KDCUBE_CONFIG_SECRET_CACHE_TTL_SECONDS` (default `300`).

- The `custom` gateway key is still always attempted (unchanged).
- A deployment that uses every provider sees **no behavior change**; deployments that don't stop paying for (and log-spamming) secret-manager lookups for providers they never configured.

### 2. Make the JSON format-fixer model configurable (removes a deprecated hardcode)
`FormatFixerService` was pinned to a hardcoded `self.format_fixer_model = "claude-3-haiku-20240307"` — a model **Anthropic has deprecated** and will eventually pull, at which point the format-fixer hard-fails. This resolves the fixer from the configured `format_fixer` role and env overrides instead:

- `KDCUBE_FORMAT_FIXER_PROVIDER` / `KDCUBE_FORMAT_FIXER_MODEL` (legacy `FORMAT_FIXER_PROVIDER` / `FORMAT_FIXER_MODEL`)
- Falls back to the **active default LLM** when unset.
- `FormatFixerService` now supports both `anthropic` and `openai` providers.

**Default behavior is preserved** — and arguably fixed: with no config, the fixer resolves to the active default LLM rather than a dead model id.

## New knobs (all optional, default-preserving)
| Env | Default | Effect |
|---|---|---|
| `KDCUBE_CONFIG_SECRET_CACHE_TTL_SECONDS` | `300` | TTL for the per-(bundle, key) secret cache |
| `KDCUBE_FORMAT_FIXER_PROVIDER` / `_MODEL` | active default LLM | Pin the format-fixer provider/model |
| `FORMAT_FIXER_PROVIDER` / `_MODEL` | — | Legacy aliases of the above |

## Tests
`apps/chat/sdk/tests/bundle/test_model_router_service_keys.py`:
- format-fixer resolves to the configured `format_fixer` role / env override;
- format-fixer falls back to the active default LLM when unset (**never** the dead `claude-3-haiku-20240307` id);
- secret resolution skips a provider absent from `role_models` (no probe emitted);
- secret resolution caches present and missing values across the TTL (one probe per key over two builds).

All 20 tests in the file pass locally.

## Rationale
- Removes a deprecated model id that will hard-fail the day Anthropic pulls it.
- Stops secret-manager probing for providers a deployment doesn't use — cost + log noise.
- Env/role knobs; default behavior preserved.

---

Downstream: retires navigator patch `service-hub-model-config` after merge + release.

> Draft — not for merge yet.

---

### Review fixes (commit fec0bb3)
- **(MAJOR) o-series temperature 400:** `FormatFixerService` OpenAI branch now builds via the caps-aware `make_chat_openai(...)` instead of `ChatOpenAI(..., temperature=0)`, so o-series defaults (incl. the fallback `o3-mini`, whose caps forbid temperature) no longer 400.
- **(MAJOR) scoped-secret under-resolution:** `resolve_config_request_secrets()` now ALWAYS adds the default-LLM provider and the EFFECTIVE fixer provider (request `format_fixer_provider` -> env `KDCUBE_FORMAT_FIXER_PROVIDER` -> default-LLM provider). Previously a non-empty `role_models` excluding the anthropic default (e.g. openai-only roles) never resolved `claude_api_key`, and the fixer built an anthropic client with an empty key.
- **(minor)** request-path fixer model gets the same id->model_name normalization as the env path.
- Note: the always-on `custom` gateway key resolution is unchanged and is now TTL-cached like the other providers (`KDCUBE_CONFIG_SECRET_CACHE_TTL_SECONDS`, default 300s).
- Tests: +3, 20 existing still green (23 total).