### PR TITLE
feat(auth): simple as a full Connection Hub platform provider

### DIFF
--- a/app/ai-app/deployment/assembly.yaml
+++ b/app/ai-app/deployment/assembly.yaml
@@ -67,7 +67,7 @@ ports:
   ingress: "8010"  # CHAT_APP_PORT
   proc: "8020"     # CHAT_PROCESSOR_PORT
   metrics: "8090"
-  ui: "5174"        # local/default public HTTP proxy port unless ports.proxy_http overrides it
+  ui: "5173"        # local/default public HTTP proxy port unless ports.proxy_http overrides it
   ui_ssl: "443"     # legacy/default public HTTPS proxy port unless ports.proxy_https overrides it
   # proxy_http: "80"   # optional explicit public HTTP proxy port
   # proxy_https: "443" # optional explicit public HTTPS proxy port

--- a/app/ai-app/deployment/docker/all_in_one_kdcube/README.md
+++ b/app/ai-app/deployment/docker/all_in_one_kdcube/README.md
@@ -130,7 +130,7 @@ If you use the CLI installer, it pre‑creates `./logs/chat-ingress` and
 - Ingress API: `8010`
 - Processor API: `8020`
 - Metrics: `8090` (bound to localhost)
-- Web UI: `${KDCUBE_UI_PORT}` (default `5174` in sample env)
+- Web UI: `${KDCUBE_UI_PORT}` (default `5173` in sample env)
 - OpenResty: `80` / `443`
 
 ## Bundles

--- a/app/ai-app/docs/configuration/assembly-descriptor-README.md
+++ b/app/ai-app/docs/configuration/assembly-descriptor-README.md
@@ -316,6 +316,13 @@ development auth proxy path or a custom SPA route prefix. `auth.turnstile_develo
 is still read from the `auth` section and is published as
 `auth.turnstileDevelopmentToken` when it is non-placeholder.
 
+`auth.type: simple` is the one mode with a browser credential in this section.
+`kdcube init` and `kdcube config apply --auth-type simple` write
+`frontend.config.auth.authType` and `frontend.config.auth.token`, defaulting the
+token to the development administrator seeded into the SimpleIDP store. The
+other auth types clear the whole block, so a token set for `simple` does not
+survive a switch away and back.
+
 If `frontend.config.auth.authType` is omitted, it is derived from top-level
 auth: `auth.type: simple` emits browser `authType: simple`, `auth.type:
 cognito` emits `authType: cognito`, and `auth.type: delegated` emits

--- a/app/ai-app/docs/next/secrets/kdcube-vm-cli.md
+++ b/app/ai-app/docs/next/secrets/kdcube-vm-cli.md
@@ -84,7 +84,7 @@ Host:
 
 ## Ports
 Expose only required ports to host:
-- UI: 5174
+- UI: 5173
 - Ingress: 8010
 - Optional: pgadmin, metrics
 

--- a/app/ai-app/docs/recipes/connections/platform-authority/setup-platform-authority-README.md
+++ b/app/ai-app/docs/recipes/connections/platform-authority/setup-platform-authority-README.md
@@ -182,11 +182,19 @@ items:
               simple:
                 type: simple_idp
                 enabled: true
+                label: Local SimpleIDP platform identity
                 authenticator:
-                  type: simple_idp_token
+                  id_token_header_name: X-ID-Token
                   cookie:
                     auth_token_cookie_name: __Secure-LATC
+                    id_token_cookie_name: __Secure-LITC
+                    masqueraded_token_cookie_name: __Secure-LMTC
 ```
+
+The user store is not declared here. Every service reads
+`/config/idp_users.json`, pinned by the runtime. The browser credential is
+declared in `assembly.yaml` under `frontend.config.auth.token` and must exist in
+that store.
 
 Expected browser/server behavior:
 

--- a/app/ai-app/docs/recipes/operations/install-clean-README.md
+++ b/app/ai-app/docs/recipes/operations/install-clean-README.md
@@ -59,8 +59,10 @@ origin the browser loads the platform from: the local UI origin and any public
 URL you use. One client holds both.
 
 > The proxy publishes `ports.proxy_http`, falling back to `ports.ui`, then to
-> `80`. Staged defaults set `ports.ui` to **`5174`** and leave `ports.proxy_http`
-> unset, so the local UI origin is `http://localhost:5174`.
+> `80`. Staged defaults set `ports.ui` to **`5173`** and leave `ports.proxy_http`
+> unset, so the local UI origin is `http://localhost:5173`. `ports.ui` is a
+> per-runtime value — confirm yours in the staged `assembly.yaml`, or in what
+> `kdcube start` prints.
 
 Copy the client id (`…apps.googleusercontent.com`).
 
@@ -162,8 +164,8 @@ reports process/mount state, not per-bundle build outcomes):
 ```shell
 "$KDCUBE" info
 
-# 1) the UI actually answers — the real done-signal (port = ports.ui, 5174 by default):
-curl -s -o /dev/null -w "chat UI -> HTTP %{http_code}\n" http://localhost:5174/platform/chat  # want 200
+# 1) the UI actually answers — the real done-signal (port = ports.ui, 5173 by default):
+curl -s -o /dev/null -w "chat UI -> HTTP %{http_code}\n" http://localhost:5173/platform/chat  # want 200
 
 # 2) staged descriptors are the runtime authority:
 ls "$WORKDIR/config/"

--- a/app/ai-app/docs/sdk/solutions/connections/authority-providers/authority-provider-runtime-README.md
+++ b/app/ai-app/docs/sdk/solutions/connections/authority-providers/authority-provider-runtime-README.md
@@ -78,6 +78,10 @@ authority_registry:
           type: cognito
           enabled: true
           authenticator: ...
+        simple:
+          type: simple_idp
+          enabled: true
+          authenticator: ...
         workspace_google_session:
           type: bundle_session_login
           enabled: true
@@ -285,6 +289,65 @@ Configured SimpleIDP user/token
   -> SimpleIDP verifier resolves kdcube.platform subject
   -> /profile verifies the platform session server-side
 ```
+
+Descriptor selection:
+
+```yaml
+auth:
+  type: simple
+  idp: simple
+  connection_hub:
+    bundle_id: connection-hub@1-0
+    authority_id: kdcube.platform
+    provider_id: simple
+```
+
+- Connection Hub owns provider details under
+  `authority_registry.authorities.kdcube.platform.providers.simple`.
+- The runtime maps that provider into `SimpleIDP`.
+- The provider carries verifier configuration only. It declares no `grants`,
+  `entrypoints`, or `issuer`.
+
+```yaml
+providers:
+  simple:
+    type: simple_idp
+    enabled: true
+    label: Local SimpleIDP platform identity
+    authenticator:
+      id_token_header_name: X-ID-Token
+      cookie:
+        auth_token_cookie_name: __Secure-LATC
+        id_token_cookie_name: __Secure-LITC
+        masqueraded_token_cookie_name: __Secure-LMTC
+```
+
+The user store is not part of the descriptor. Every service reads
+`/config/idp_users.json`, pinned by the runtime and not configurable per
+service or per provider. The JSON file holds the users; Redis holds only a
+cache-version counter keyed by a hash of the path, so services resolving
+different paths, or the same path on unshared volumes, would keep separate user
+sets.
+
+The browser credential is declared in `assembly.yaml`:
+
+```yaml
+frontend:
+  config:
+    auth:
+      authType: simple
+      token: test-admin-token-123
+```
+
+`kdcube init` and `kdcube config apply --auth-type simple` write this block,
+defaulting `token` to the development administrator seeded into every store
+(`DEFAULT_SIMPLE_IDP_USERS`). The token must exist in the store to authenticate.
+The other auth types clear the block, so a token set here does not survive a
+switch away and back.
+
+`frontend.config` is public browser configuration served by
+`/api/cp-frontend-config`. The seeded development token grants
+`kdcube:role:super-admin`.
 
 Use this only when the deployment intentionally wants a simple platform identity
 registry, usually local development, demos, or embedded test surfaces. Production

--- a/app/ai-app/docs/service/auth/bundle-simple-idp-bridge-README.md
+++ b/app/ai-app/docs/service/auth/bundle-simple-idp-bridge-README.md
@@ -63,20 +63,44 @@ Gateway -> SimpleIDP -> UserSession
 
 The platform auth provider must be SimpleIDP:
 
+`assembly.yaml` selects the provider:
+
 ```yaml
 auth:
-  idp: "simple"
-  auth_token_cookie_name: "__Secure-LATC"
-  id_token_cookie_name: "__Secure-LITC"
-
-services:
-  idp:
-    idp_db_path: "/config/idp_users.json"
+  type: simple
+  idp: simple
+  connection_hub:
+    bundle_id: connection-hub@1-0
+    authority_id: kdcube.platform
+    provider_id: simple
 ```
 
-The same descriptor-derived `idp_db_path` must be mounted into every service
-that authenticates through SimpleIDP and every bundle runtime that registers
-SimpleIDP users.
+`bundles.yaml` carries the provider under
+`connection-hub@1-0.config.authority_registry.authorities.kdcube.platform.providers`:
+
+```yaml
+simple:
+  type: simple_idp
+  enabled: true
+  authenticator:
+    cookie:
+      auth_token_cookie_name: __Secure-LATC
+      id_token_cookie_name: __Secure-LITC
+```
+
+## User Store
+
+The store is `/config/idp_users.json` for every service and every bundle runtime
+that registers SimpleIDP users. The path is pinned by the runtime: neither the
+Connection Hub provider nor `platform.services.<service>.idp.idp_db_path`
+configures it, and the CLI removes the latter when it is present.
+
+The JSON file holds the users. Redis holds only a cache-version counter keyed by
+a hash of the path, so a service reading a different file would not see users
+registered elsewhere even while observing the same version counter.
+
+`register_simple_idp_user()` writes to this store when called without an explicit
+path.
 
 For SimpleIDP, the auth token and ID token cookies can carry the same opaque
 platform token. The cookie names come from the selected platform authority
@@ -86,7 +110,6 @@ provider:
 |---|---|
 | `authenticator.cookie.auth_token_cookie_name` | Access/auth token cookie consumed by the gateway. |
 | `authenticator.cookie.id_token_cookie_name` | Identity token cookie consumed by the gateway. |
-| `services.idp.idp_db_path` | JSON registry path used by SimpleIDP. |
 
 ## Bundle Endpoint
 

--- a/app/ai-app/src/kdcube-ai-app/builder_plugin/plugins/kdcube-builder/templates/assembly.yaml
+++ b/app/ai-app/src/kdcube-ai-app/builder_plugin/plugins/kdcube-builder/templates/assembly.yaml
@@ -34,7 +34,7 @@ ports:
   ingress: "8010"
   proc: "8020"
   metrics: "8090"
-  ui: "5174"
+  ui: "5173"
   ui_ssl: "443"
   # proxy_http: "80"
   # proxy_https: "443"

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/config.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/config.py
@@ -22,6 +22,7 @@ from kdcube_ai_app.apps.chat.sdk.config_scopes import (
     MetricsCloudWatchConfig, MetricsPrometheusConfig,
     PyExecConfig, ExecConfig, ReactDebugConfig, AccountingConfig, GitBundlesConfig, ApplicationsConfig,
     PlatformConfig, IDPLocalConfig, IDPConfig, AuthConfig, CognitoTrustedProviderConfig, ServicesConfig,
+    SIMPLE_IDP_STORE_PATH,
 )
 from kdcube_ai_app.apps.chat.sdk.solutions.connections.authority_registry_config import (
     DEFAULT_PLATFORM_AUTHORITY_ID,
@@ -1556,7 +1557,13 @@ class Settings(PLATFORM_CONFIG):
             ),
             IDP=IDPConfig(
                 local=IDPLocalConfig(
-                    IDP_DB_PATH=self._resolve_str("IDP_DB_PATH", f"{svc}.idp.idp_db_path"),
+                    # `simple` pins the store so ingress and proc cannot diverge;
+                    # the per-service key stays readable for other providers.
+                    IDP_DB_PATH=(
+                        SIMPLE_IDP_STORE_PATH
+                        if str(platform_auth_cfg.get("auth_provider") or "").strip().lower() == "simple"
+                        else self._resolve_str("IDP_DB_PATH", f"{svc}.idp.idp_db_path")
+                    ),
                     IDP_IMPORT_ENABLED=self._resolve_bool("IDP_IMPORT_ENABLED", f"{svc}.idp.idp_import_enabled", False),
                     IDP_IMPORT_RUN_AT=self._resolve_str("IDP_IMPORT_RUN_AT", f"{svc}.idp.idp_import_run_at"),
                     IDP_IMPORT_SCRIPT_PATH=self._resolve_str("IDP_IMPORT_SCRIPT_PATH", f"{svc}.idp.idp_import_script_path"),

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/config_scopes.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/config_scopes.py
@@ -28,6 +28,13 @@ def _descriptor_path(*, env_name: str, filename: str, default: str) -> Path:
     return Path(default)
 
 
+# SimpleIDP keeps its users in this file while Redis holds only a cache-version
+# counter keyed by a hash of the path. Two services resolving different paths, or
+# the same path on unshared volumes, would silently keep separate user sets, so
+# the location is pinned here instead of being configurable per service.
+SIMPLE_IDP_STORE_PATH = "/config/idp_users.json"
+
+
 # ─── YAML helpers ─────────────────────────────────────────────────────────────
 
 def _descriptor_cache_token(path: Path) -> tuple[str, int, int] | None:
@@ -531,6 +538,7 @@ class PlatformConfig(BaseModel):
 class IDPLocalConfig(BaseModel):
     """Local (simple-auth) identity provider settings."""
     IDP_DB_PATH: str | None = None
+    """Resolved SimpleIDP user store. Pinned to SIMPLE_IDP_STORE_PATH for `simple`."""
     IDP_IMPORT_ENABLED: bool = False
     IDP_IMPORT_RUN_AT: str | None = None
     IDP_IMPORT_SCRIPT_PATH: str | None = None

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/authority_registry_config.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/authority_registry_config.py
@@ -322,6 +322,15 @@ def platform_authority_auth_config(provider_result: Mapping[str, Any] | None) ->
             "provider": provider,
             "authority": _dict(result.get("authority")),
         }
+    if provider_type in {"simple_idp", "simple-idp", "simple"}:
+        # The store path is not configurable: the runtime pins it so every service
+        # reads the same file. See SIMPLE_IDP_STORE_PATH.
+        return {
+            "auth_provider": "simple",
+            **_token_transport_config(provider),
+            "provider": provider,
+            "authority": _dict(result.get("authority")),
+        }
     return {}
 
 

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/tests/test_authority_registry_config.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/tests/test_authority_registry_config.py
@@ -47,6 +47,17 @@ def _registry():
                             },
                         },
                     },
+                    "simple": {
+                        "type": "simple_idp",
+                        "authenticator": {
+                            "id_token_header_name": "X-ID-Token",
+                            "cookie": {
+                                "auth_token_cookie_name": "__Secure-LATC",
+                                "id_token_cookie_name": "__Secure-LITC",
+                                "masqueraded_token_cookie_name": "__Secure-LMTC",
+                            },
+                        },
+                    },
                     "workspace_google_session": {
                         "type": "bundle_session_login",
                         "entrypoints": {
@@ -118,6 +129,7 @@ def test_authority_provider_instances_flatten_configured_instances():
         for row in rows
     ] == [
         ("kdcube.platform", "cognito", "multi-cognito", True),
+        ("kdcube.platform", "simple", "simple_idp", True),
         ("kdcube.platform", "workspace_google_session", "bundle_session_login", True),
         ("telegram.kdcube_ref", "telegram_bot_init_data", "telegram_init_data", False),
         ("google.accounts", "google_oidc", "google_id_token", False),
@@ -175,6 +187,25 @@ def test_platform_authority_auth_config_normalizes_bundle_session_provider():
     assert config["auth_token_cookie_name"] == "__Secure-SESSION-AUTH"
     assert config["id_token_cookie_name"] == "__Secure-SESSION-ID"
     assert config["masqueraded_token_cookie_name"] == "__Secure-SESSION-MASK"
+
+
+def test_platform_authority_auth_config_normalizes_simple_idp_provider():
+    resolved = resolve_platform_authority_provider(
+        _registry(),
+        authority_id="kdcube.platform",
+        provider_id="simple",
+    )
+
+    config = platform_authority_auth_config(resolved)
+
+    assert config["auth_provider"] == "simple"
+    assert config["id_token_header_name"] == "X-ID-Token"
+    assert config["auth_token_cookie_name"] == "__Secure-LATC"
+    assert config["masqueraded_token_cookie_name"] == "__Secure-LMTC"
+    # Platform-managed token authorities carry verifier configuration only.
+    assert "grants" not in config["provider"]
+    # The user store is pinned by the runtime, never taken from the descriptor.
+    assert "idp_db_path" not in config
 
 
 def test_resolve_authority_provider_instance_by_consent_entrypoint():

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/middleware/platform_auth.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/middleware/platform_auth.py
@@ -25,6 +25,18 @@ def normalize_platform_auth_provider(value: str) -> str:
     return aliases.get(provider, provider or "simple")
 
 
+def _connection_hub_provider(settings: Any) -> str:
+    """Provider the Connection Hub registry resolves, or "" when it resolves none."""
+    try:
+        config = settings.connection_hub_platform_auth_config()
+    except Exception:
+        logger.debug("Connection Hub platform provider lookup failed", exc_info=True)
+        return ""
+    if not isinstance(config, Mapping):
+        return ""
+    return str(config.get("auth_provider") or "").strip().lower()
+
+
 def platform_authenticator_descriptor(settings: Any | None = None) -> dict[str, Any]:
     """Normalize the descriptor for the platform role-providing authority.
 
@@ -66,12 +78,28 @@ def platform_authenticator_descriptor(settings: Any | None = None) -> dict[str, 
             }
 
     descriptor_provider = str(getattr(settings, "AUTH_PROVIDER", "") or "").strip().lower()
+    source = ""
+    if descriptor_provider:
+        # AUTH_PROVIDER is populated from the Connection Hub provider whenever no
+        # env var supplied it, so a provider resolved there is what selected this
+        # authenticator. Reporting `auth.idp` for every case hid that distinction.
+        if str(os.getenv("AUTH_PROVIDER", "") or "").strip():
+            source = "env:AUTH_PROVIDER"
+        elif _connection_hub_provider(settings):
+            source = "auth.connection_hub"
+        else:
+            source = "auth.idp"
     if not descriptor_provider:
         descriptor_provider = str(settings.plain("auth.idp", default="") or "").strip().lower()
+        if descriptor_provider:
+            source = "auth.idp"
     if not descriptor_provider:
         descriptor_provider = str(settings.plain("auth.type", default="") or "").strip().lower()
+        if descriptor_provider:
+            source = "auth.type"
     if not descriptor_provider:
         descriptor_provider = "simple"
+        source = "default"
     provider = normalize_platform_auth_provider(descriptor_provider)
     trusted_providers = list(getattr(settings.AUTH, "COGNITO_TRUSTED_PROVIDERS", None) or [])
     if provider == "cognito" and len(trusted_providers) > 1:
@@ -80,7 +108,7 @@ def platform_authenticator_descriptor(settings: Any | None = None) -> dict[str, 
         "authenticator_id": f"kdcube.{provider}",
         "authority_id": "kdcube.platform",
         "provider": provider,
-        "source": "auth.idp",
+        "source": source or "auth.idp",
     }
 
 
@@ -147,9 +175,18 @@ def create_platform_auth_manager(
 
     from kdcube_ai_app.apps.middleware.simple_idp import SimpleIDP
 
-    logger.info("Using SimpleIDP for %s platform authentication", service_label)
+    idp_db_path = str(getattr(settings.AUTH.IDP.local, "IDP_DB_PATH", "") or "").strip() or None
+    logger.info(
+        "Using SimpleIDP for %s platform authentication idp_db_path=%s",
+        service_label,
+        idp_db_path or "<default>",
+    )
     return with_authenticator_metadata(
-        SimpleIDP(send_validation_error_details=send_validation_error_details, service_user_token=os.getenv("SERVICE_USER_TOKEN")),
+        SimpleIDP(
+            send_validation_error_details=send_validation_error_details,
+            service_user_token=os.getenv("SERVICE_USER_TOKEN"),
+            idp_db_path=idp_db_path,
+        ),
         descriptor,
     )
 

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/middleware/simple_idp.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/middleware/simple_idp.py
@@ -9,6 +9,7 @@ from typing import Dict, Optional
 
 from kdcube_ai_app.auth.AuthManager import AuthManager, User, AuthenticationError
 from kdcube_ai_app.apps.chat.sdk.config import get_settings
+from kdcube_ai_app.apps.chat.sdk.config_scopes import SIMPLE_IDP_STORE_PATH
 from kdcube_ai_app.apps.middleware.simple_idp_registry import (
     DEFAULT_SIMPLE_IDP_USERS,
     SimpleIDPRegistry,
@@ -17,7 +18,7 @@ from kdcube_ai_app.apps.middleware.simple_idp_registry import (
 
 
 # Simple user database - stored as JSON file
-IDP_DB_PATH = get_settings().AUTH.IDP.local.IDP_DB_PATH or "./idp_users.json"
+IDP_DB_PATH = get_settings().AUTH.IDP.local.IDP_DB_PATH or SIMPLE_IDP_STORE_PATH
 
 # Default users
 DEFAULT_USERS = DEFAULT_SIMPLE_IDP_USERS

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/middleware/simple_idp_registry.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/middleware/simple_idp_registry.py
@@ -19,6 +19,7 @@ except Exception:  # pragma: no cover - non-POSIX fallback
     fcntl = None
 
 from kdcube_ai_app.apps.chat.sdk.config import get_settings
+from kdcube_ai_app.apps.chat.sdk.config_scopes import SIMPLE_IDP_STORE_PATH
 from kdcube_ai_app.infra.redis.client import get_async_redis_client
 from kdcube_ai_app.storage.observed_redis_locks import observed_redis_lock_async
 
@@ -52,7 +53,7 @@ DEFAULT_SIMPLE_IDP_USERS: Dict[str, Dict[str, Any]] = {
 
 
 def _default_idp_path() -> str:
-    return get_settings().AUTH.IDP.local.IDP_DB_PATH or "./idp_users.json"
+    return get_settings().AUTH.IDP.local.IDP_DB_PATH or SIMPLE_IDP_STORE_PATH
 
 
 def _copy_users(users: Mapping[str, Mapping[str, Any]]) -> Dict[str, Dict[str, Any]]:

--- a/app/ai-app/src/kdcube-ai-app/kdcube_cli/src/kdcube_cli/installer.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_cli/src/kdcube_cli/installer.py
@@ -3852,7 +3852,7 @@ def gather_configuration(
                 ui_port = str(
                     _get_nested(assembly_data, "ports", "ui")
                     or env_main.entries.get("KDCUBE_UI_PORT", (None, None))[1]
-                    or "5174"
+                    or "5173"
                 ).strip()
                 if ui_port in ("80", "443"):
                     proxy_domain = "localhost"

--- a/app/ai-app/src/kdcube-ai-app/kdcube_cli/src/kdcube_cli/installer.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_cli/src/kdcube_cli/installer.py
@@ -15,7 +15,7 @@ import tempfile
 import sys
 import time
 from pathlib import Path
-from typing import Dict, List, Optional, Set, Tuple
+from typing import Dict, List, Mapping, Optional, Set, Tuple
 from urllib.parse import unquote, urlparse, urlsplit, urlunsplit
 
 from rich.console import Console
@@ -615,6 +615,58 @@ def _ensure_connection_hub_cognito_provider(
     )
 
 
+def _ensure_connection_hub_simple_provider(
+    bundles_data: Dict[str, object],
+    *,
+    id_token_header_name: str,
+    auth_token_cookie_name: str,
+    id_token_cookie_name: str,
+    masqueraded_token_cookie_name: str,
+) -> None:
+    """Write the SimpleIDP platform authority provider into the Connection Hub descriptor.
+
+    SimpleIDP is a platform-managed token authority: the verifier validates the
+    browser's platform token directly, so the provider carries verifier
+    configuration only and declares no grants or entrypoints.
+
+    The user-store path is not part of the descriptor: the runtime pins it so
+    every service reads the same file.
+    """
+    connection_hub = _ensure_bundle_item(bundles_data, "connection-hub@1-0")
+    config = connection_hub.get("config")
+    if not isinstance(config, dict):
+        config = {}
+        connection_hub["config"] = config
+    authenticator: Dict[str, object] = {
+        "id_token_header_name": id_token_header_name,
+        "cookie": {
+            "auth_token_cookie_name": auth_token_cookie_name,
+            "id_token_cookie_name": id_token_cookie_name,
+            "masqueraded_token_cookie_name": masqueraded_token_cookie_name,
+        },
+    }
+    _set_nested(
+        config,
+        ["authority_registry", "authorities", "kdcube.platform", "label"],
+        "KDCube platform authority",
+    )
+    _set_nested(
+        config,
+        ["authority_registry", "authorities", "kdcube.platform", "platform"],
+        True,
+    )
+    _set_nested(
+        config,
+        ["authority_registry", "authorities", "kdcube.platform", "providers", _SIMPLE_PLATFORM_PROVIDER_ID],
+        {
+            "type": "simple_idp",
+            "enabled": True,
+            "label": "Local SimpleIDP platform identity",
+            "authenticator": authenticator,
+        },
+    )
+
+
 def _bundle_session_default_grants() -> Dict[str, object]:
     """Default and assignable platform grants for a bundle-session provider."""
     return {
@@ -759,6 +811,40 @@ def _ensure_connection_hub_bundle_session_provider(
 
 # Provider key the cognito auth type writes under the platform authority.
 _COGNITO_PLATFORM_PROVIDER_ID = "cognito"
+
+# Provider key the simple auth type writes under the platform authority.
+_SIMPLE_PLATFORM_PROVIDER_ID = "simple"
+
+# Development credential seeded into every SimpleIDP store (DEFAULT_SIMPLE_IDP_USERS).
+_SIMPLE_DEV_ADMIN_TOKEN = "test-admin-token-123"
+
+
+def _simple_browser_token(assembly_data: Dict[str, object]) -> str:
+    """Browser token declared under frontend.config.auth, or "" when unset.
+
+    Only `simple` uses this block. The other auth types clear it, so a token set
+    for `simple` does not survive a switch away and back.
+    """
+    value = _get_nested(assembly_data, "frontend", "config", "auth", "token")
+    return value.strip() if isinstance(value, str) and value.strip() else ""
+
+
+
+def _service_declared_idp_stores(services_block: object) -> Dict[str, str]:
+    """Map service name -> SimpleIDP store path declared under platform.services."""
+    declared: Dict[str, str] = {}
+    if not isinstance(services_block, dict):
+        return declared
+    for service_name, service_cfg in services_block.items():
+        if not isinstance(service_cfg, dict):
+            continue
+        idp_cfg = service_cfg.get("idp")
+        if not isinstance(idp_cfg, dict):
+            continue
+        path = idp_cfg.get("idp_db_path")
+        if isinstance(path, str) and path.strip():
+            declared[str(service_name)] = path.strip()
+    return declared
 
 
 def _find_bundle_item(payload: Dict[str, object] | None, bundle_id: str) -> Optional[Dict[str, object]]:
@@ -3833,17 +3919,103 @@ def gather_configuration(
             _set_nested(assembly_data, ["auth", "proxy_login", "http_urlbase"], http_urlbase)
 
     if auth_provider == "simple":
+        auth_block_simple = _get_nested(assembly_data, "auth")
+        auth_block_simple = auth_block_simple if isinstance(auth_block_simple, dict) else {}
+        registry_simple = _get_nested(
+            bundles_data,
+            "connection-hub@1-0",
+            "config",
+            "authority_registry",
+            "authorities",
+            "kdcube.platform",
+            "providers",
+            _SIMPLE_PLATFORM_PROVIDER_ID,
+            "authenticator",
+        )
+        registry_simple = registry_simple if isinstance(registry_simple, dict) else {}
+        registry_simple_cookie = (
+            registry_simple.get("cookie") if isinstance(registry_simple.get("cookie"), dict) else {}
+        )
+
+        def _simple_pick(*candidates: object) -> str:
+            for candidate in candidates:
+                if isinstance(candidate, str) and candidate.strip():
+                    return candidate.strip()
+            return ""
+
+        _ensure_connection_hub_simple_provider(
+            bundles_data,
+            id_token_header_name=_simple_pick(
+                auth_block_simple.get("id_token_header_name"),
+                registry_simple.get("id_token_header_name"),
+            )
+            or "X-ID-Token",
+            auth_token_cookie_name=_simple_pick(
+                auth_block_simple.get("auth_token_cookie_name"),
+                registry_simple_cookie.get("auth_token_cookie_name"),
+            )
+            or "__Secure-LATC",
+            id_token_cookie_name=_simple_pick(
+                auth_block_simple.get("id_token_cookie_name"),
+                registry_simple_cookie.get("id_token_cookie_name"),
+            )
+            or "__Secure-LITC",
+            masqueraded_token_cookie_name=_simple_pick(
+                auth_block_simple.get("masqueraded_token_cookie_name"),
+                registry_simple_cookie.get("masqueraded_token_cookie_name"),
+            )
+            or "__Secure-LMTC",
+        )
         _set_nested(assembly_data, ["auth", "idp"], "simple")
-        _set_nested(assembly_data, ["auth", "authenticators", "connection_hub", "enabled"], False)
-        _delete_nested(assembly_data, ["auth", "connection_hub"])
-        # The frontend derives authType from assembly.auth; drop a stale override.
-        _delete_nested(assembly_data, ["frontend", "config", "auth"])
+        _set_nested(
+            assembly_data,
+            ["auth", "connection_hub"],
+            {
+                "bundle_id": "connection-hub@1-0",
+                "authority_id": "kdcube.platform",
+                "provider_id": _SIMPLE_PLATFORM_PROVIDER_ID,
+            },
+        )
+        _set_nested(
+            assembly_data,
+            ["auth", "authenticators", "connection_hub"],
+            {"enabled": True, "app_id": "connection-hub@1-0", "operation": "request_authenticate"},
+        )
         _prune_foreign_platform_login(
             bundles_data,
             connection_hub_bundle_id="connection-hub@1-0",
             authority_id="kdcube.platform",
-            keep_provider_ids=set(),
+            keep_provider_ids={_SIMPLE_PLATFORM_PROVIDER_ID},
             keep_bootstrap_rules=False,
+        )
+        # The store path is pinned by the runtime, so per-service declarations are
+        # dead config; drop them rather than leave a key that no longer applies.
+        for service_name in _service_declared_idp_stores(
+            _get_nested(assembly_data, "platform", "services")
+        ):
+            _delete_nested(assembly_data, ["platform", "services", service_name, "idp", "idp_db_path"])
+        for legacy_path in (
+            # Token transport now belongs to the Connection Hub provider, which was
+            # seeded from these values above and is read ahead of the assembly.
+            ["auth", "id_token_header_name"],
+            ["auth", "auth_token_cookie_name"],
+            ["auth", "id_token_cookie_name"],
+            ["auth", "masqueraded_token_cookie_name"],
+            # Cognito-only settings; the proxy_login inputs stay in .env.proxylogin,
+            # which the delegated branch reads when reconciling back to that type.
+            ["auth", "jwks_cache_ttl_seconds"],
+            ["auth", "cognito"],
+            ["auth", "providers"],
+            ["auth", "proxy_login"],
+        ):
+            _delete_nested(assembly_data, legacy_path)
+        # Write the browser auth block explicitly rather than letting the frontend
+        # builder substitute a token that appears nowhere in the descriptor.
+        _set_nested(assembly_data, ["frontend", "config", "auth", "authType"], "simple")
+        _set_nested(
+            assembly_data,
+            ["frontend", "config", "auth", "token"],
+            _simple_browser_token(assembly_data) or _SIMPLE_DEV_ADMIN_TOKEN,
         )
 
     # Optional Telegram companion, offered for every auth type. The browser login

--- a/app/ai-app/src/kdcube-ai-app/kdcube_cli/tests/test_cli_descriptors.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_cli/tests/test_cli_descriptors.py
@@ -47,6 +47,8 @@ from kdcube_cli.installer import (
     TELEGRAM_SECRET_STEM,
     apply_bundle_session_auth,
     _ensure_connection_hub_cognito_provider,
+    _ensure_connection_hub_simple_provider,
+    _service_declared_idp_stores,
     _ensure_cors_allow_origin,
     _origin_from_url,
     _prune_foreign_platform_login,
@@ -3881,19 +3883,34 @@ def test_reconcile_to_cognito_removes_bundle_session_login_artifacts():
     assert "telegram.kdcube_ref" in authorities
 
 
-def test_reconcile_to_simple_removes_all_platform_login_providers():
+def test_reconcile_to_simple_removes_bundle_session_login_artifacts():
     bundles = _polluted_bundle_session_bundles()
 
+    _ensure_connection_hub_simple_provider(
+        bundles,
+        id_token_header_name="X-ID-Token",
+        auth_token_cookie_name="__Secure-LATC",
+        id_token_cookie_name="__Secure-LITC",
+        masqueraded_token_cookie_name="__Secure-LMTC",
+    )
     _prune_foreign_platform_login(
         bundles,
         connection_hub_bundle_id="connection-hub@1-0",
         authority_id="kdcube.platform",
-        keep_provider_ids=set(),
+        keep_provider_ids={"simple"},
         keep_bootstrap_rules=False,
     )
 
     authorities = _ch_authorities(bundles)
-    assert authorities["kdcube.platform"]["providers"] == {}
+    platform_providers = authorities["kdcube.platform"]["providers"]
+    # simple is a full platform authority provider, and it replaces the
+    # bundle-session login provider rather than leaving the authority empty.
+    assert platform_providers["simple"]["type"] == "simple_idp"
+    assert platform_providers["simple"]["enabled"] is True
+    assert "workspace_google_session" not in platform_providers
+    # It is a platform-managed token authority: verifier config only, no policy.
+    assert "grants" not in platform_providers["simple"]
+    assert "entrypoints" not in platform_providers["simple"]
     assert "google.accounts" not in authorities
     assert "bootstrap_rules" not in authorities["kdcube.platform"]["grants"]
     assert authorities["kdcube.platform"]["grants"]["subjects"] == {
@@ -3901,6 +3918,39 @@ def test_reconcile_to_simple_removes_all_platform_login_providers():
     }
     assert "consent_ui" not in bundles["bundles"]["items"][0]["config"]["connections"]["delegated_credentials"]["oauth"]
     assert "telegram.kdcube_ref" in authorities
+
+
+def test_service_declared_idp_stores_are_reported_for_cleanup():
+    # The runtime pins the store path, so these declarations are dead config the
+    # simple branch removes rather than values it has to reconcile.
+    services = {
+        "ingress": {"idp": {"idp_db_path": "/kdcube-storage/a.json"}},
+        "proc": {"idp": {"idp_db_path": "/kdcube-storage/b.json"}},
+        "metrics": {"idp": {"idp_db_path": ""}},
+    }
+
+    declared = _service_declared_idp_stores(services)
+
+    assert declared == {"ingress": "/kdcube-storage/a.json", "proc": "/kdcube-storage/b.json"}
+    assert _service_declared_idp_stores({}) == {}
+
+
+def test_simple_provider_never_declares_a_store_path():
+    # The store path is pinned by the runtime; exposing it in the descriptor would
+    # let two services be pointed at different user sets.
+    bundles = _polluted_bundle_session_bundles()
+
+    _ensure_connection_hub_simple_provider(
+        bundles,
+        id_token_header_name="X-ID-Token",
+        auth_token_cookie_name="__Secure-LATC",
+        id_token_cookie_name="__Secure-LITC",
+        masqueraded_token_cookie_name="__Secure-LMTC",
+    )
+
+    authenticator = _ch_authorities(bundles)["kdcube.platform"]["providers"]["simple"]["authenticator"]
+    assert "idp_db_path" not in authenticator
+    assert authenticator["cookie"]["auth_token_cookie_name"] == "__Secure-LATC"
 
 
 def test_reconcile_drops_empty_platform_grants():


### PR DESCRIPTION
  `auth.type: simple` now selects its verifier through the authority registry, the
  same way cognito and bundle-session already do. Connection Hub is the source of
  provider configuration only: the registry is read from disk at startup, the
  verifier is built once, and requests are verified locally.

  The verifier itself is unchanged; the wiring was missing.
  `platform_authority_auth_config` returned `{}` for `simple_idp`, so a declared
  provider was inert; `SimpleIDP` was built with no arguments and fell back to a
  module constant evaluated at import; the CLI deleted `auth.connection_hub` and
  pruned every platform provider from the registry.

  The user store is pinned to `/config/idp_users.json` and is not configurable —
  not by the provider, not per service. The file holds the users while Redis holds
  only a cache-version counter keyed by a hash of the path, so any way of setting
  it differently is a way for services to keep separate user sets. Previously
  ingress and proc each mutated their own container-local copy.

  The browser credential is declared instead of substituted: the CLI writes
  `frontend.config.auth.authType` and `.token`, so the effective token is visible
  in the descriptor. Other auth types clear the block.

  The startup log's `source` was hard-coded to `auth.idp` even when the provider
  came from the registry; it now names the real source. `authority_id` and
  `authenticator_id` are left alone — they reach `identity_authority` and
  accounting envelopes.