### PR TITLE
fix(telegram): deliver rewritten same-path files (content-scoped dedup)

### DIFF
--- a/app/ai-app/docs/sdk/agents/react/react-tools-README.md
+++ b/app/ai-app/docs/sdk/agents/react/react-tools-README.md
@@ -240,7 +240,7 @@ Use it when React needs an editable runnable/searchable/testable project tree in
 
 ### `react.write`
 
-Creates or intentionally replaces a current-turn text artifact.
+Creates a new current-turn text artifact.
 
 - input: `path`, `content`, optional `channel`, optional `kind`
 - accepted paths: current-turn relative paths, not logical `conv:fi:` paths
@@ -248,21 +248,23 @@ Creates or intentionally replaces a current-turn text artifact.
 - channels: `canvas`, `timeline_text`, `internal`
 - kinds: `display`, `file`
 - output: local text artifact plus timeline/result blocks
-- same-path behavior: a later successful write in the same turn replaces the
-  current workspace file; the latest version is the one stored and projected
-  as the current assistant file, while the timeline retains both write events
+- same-path behavior: a second `react.write` to a path that already exists in
+  the current turn is interrupted as soon as its streamed `path` is parsed,
+  before the `content` field is processed; the tool handler enforces the same
+  rule before materialization, leaving the existing file unchanged
 - external file behavior: hosts and emits a downloadable file only when external and `kind=file`
 - internal behavior: `channel=internal` writes Internal Memory Beacons as `react.note`
 
 Use it for text artifacts only. For PDFs, PPTX, DOCX, PNG, and other binary deliverables, use `rendering_tools.write_*` or exec tools.
 
-Prefer one complete `react.write`. Use `react.patch` for a targeted correction.
-When a full rewrite is genuinely required later in the turn, write the exact
-same path again; do not invent a second path merely to retry the same artifact.
+Use `react.patch` for an intentional in-place edit to the existing artifact.
+When the agent needs to publish a separate full version, it chooses a different
+filename.
 
 ### `react.patch`
 
-Updates an existing current-turn materialized text file under `git/projects/...`, `files/...`, or `git/snapshots/...`.
+Intentionally edits an existing current-turn materialized text file in place,
+preserving its path. Use it instead of calling `react.write` again for that path.
 
 - input: `path`, `patch`
 - accepted paths: current-turn artifact-root-relative paths; prefer concise paths such as `git/projects/<scope>/file.py` for project edits or `files/<scope>/page.html` for produced artifacts, not logical `conv:fi:` paths

--- a/app/ai-app/docs/sdk/agents/react/react-tools-README.md
+++ b/app/ai-app/docs/sdk/agents/react/react-tools-README.md
@@ -240,7 +240,7 @@ Use it when React needs an editable runnable/searchable/testable project tree in
 
 ### `react.write`
 
-Creates a new text artifact.
+Creates or intentionally replaces a current-turn text artifact.
 
 - input: `path`, `content`, optional `channel`, optional `kind`
 - accepted paths: current-turn relative paths, not logical `conv:fi:` paths
@@ -248,10 +248,17 @@ Creates a new text artifact.
 - channels: `canvas`, `timeline_text`, `internal`
 - kinds: `display`, `file`
 - output: local text artifact plus timeline/result blocks
+- same-path behavior: a later successful write in the same turn replaces the
+  current workspace file; the latest version is the one stored and projected
+  as the current assistant file, while the timeline retains both write events
 - external file behavior: hosts and emits a downloadable file only when external and `kind=file`
 - internal behavior: `channel=internal` writes Internal Memory Beacons as `react.note`
 
 Use it for text artifacts only. For PDFs, PPTX, DOCX, PNG, and other binary deliverables, use `rendering_tools.write_*` or exec tools.
+
+Prefer one complete `react.write`. Use `react.patch` for a targeted correction.
+When a full rewrite is genuinely required later in the turn, write the exact
+same path again; do not invent a second path merely to retry the same artifact.
 
 ### `react.patch`
 

--- a/app/ai-app/docs/sdk/integrations/telegram/telegram-README.md
+++ b/app/ai-app/docs/sdk/integrations/telegram/telegram-README.md
@@ -688,7 +688,10 @@ long-running ReAct, LangGraph, CrewAI, or custom app turn.
 
 Thinking and note deltas are rendered as Telegram HTML blockquotes. The streamer
 tracks already-sent file keys so final delivery does not duplicate files that
-were emitted during the turn.
+were emitted during the turn. The key is content-scoped (delivery path plus the
+artifact `content_sha256`, falling back to size, then the path alone): a true
+duplicate emit is dropped, but a rewrite of the same path with new content is a
+distinct key and is delivered as a new message.
 
 Two bundle properties control this behavior:
 

--- a/app/ai-app/docs/sdk/integrations/telegram/telegram-README.md
+++ b/app/ai-app/docs/sdk/integrations/telegram/telegram-README.md
@@ -691,7 +691,11 @@ tracks already-sent file keys so final delivery does not duplicate files that
 were emitted during the turn. The key is content-scoped (delivery path plus the
 artifact `content_sha256`, falling back to size, then the path alone): a true
 duplicate emit is dropped, but a rewrite of the same path with new content is a
-distinct key and is delivered as a new message.
+distinct key and is delivered as a new message. Built-in artifact hosting adds
+the fingerprint automatically and keeps it in transport metadata, outside the
+model-facing artifact digest. Custom `chat.files` producers should provide
+`content_sha256` when same-path rewrites are possible; without it, the size/path
+fallback cannot distinguish a same-size rewrite.
 
 Two bundle properties control this behavior:
 

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/examples/bundles/with-isoruntime@2026-02-16-14-00/timeline.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/examples/bundles/with-isoruntime@2026-02-16-14-00/timeline.py
@@ -20,6 +20,7 @@ import pathlib
 from typing import Any, Dict, List
 
 from kdcube_ai_app.apps.chat.sdk.solutions.react.artifacts import (
+    artifact_transport_metadata,
     build_artifact_meta_block,     # Metadata block for an artifact (filename, mime, etc.)
     build_artifact_binary_block,   # Binary content block (images, PDFs)
     build_artifact_view,           # Unified artifact view (normalizes different output formats)
@@ -188,6 +189,7 @@ async def build_exec_timeline(
         raw_val = artifact_view.raw or {}
         raw_value = raw_val.get("value") if isinstance(raw_val.get("value"), dict) else {}
         meta_extra = {"tool_call_id": tool_call_id, "turn_id": runtime_ctx.turn_id or ""}
+        meta_extra.update(artifact_transport_metadata(meta_block))
         try:
             meta_text = meta_block.get("text") if isinstance(meta_block, dict) else None
             if isinstance(meta_text, str) and meta_text.strip():

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/integrations/telegram/bot.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/integrations/telegram/bot.py
@@ -656,7 +656,10 @@ def _append_file(files: list[dict[str, Any]], seen: set[str], file_item: dict[st
 
 
 def _file_delivery_key(file_item: Mapping[str, Any]) -> str:
-    return str(
+    # Key on (path, content): a rewrite of the same path is a new delivery, a
+    # true duplicate is dropped. content_sha256 preferred; size is the fallback;
+    # neither present falls back to the legacy path-only key.
+    path = str(
         file_item.get("url")
         or file_item.get("hosted_uri")
         or file_item.get("rn")
@@ -666,6 +669,15 @@ def _file_delivery_key(file_item: Mapping[str, Any]) -> str:
         or file_item.get("filename")
         or ""
     ).strip()
+    if not path:
+        return ""
+    signature = str(
+        file_item.get("content_sha256")
+        or file_item.get("size")
+        or file_item.get("size_bytes")
+        or ""
+    ).strip()
+    return f"{path}::{signature}" if signature else path
 
 
 def _file_item_from_meta(meta: Mapping[str, Any], *, logical_path: str) -> dict[str, Any]:
@@ -696,6 +708,7 @@ def _file_item_from_meta(meta: Mapping[str, Any], *, logical_path: str) -> dict[
             "key": str(meta.get("key") or "").strip(),
             "base64": str(meta.get("base64") or "").strip(),
             "size_bytes": meta.get("size_bytes"),
+            "content_sha256": str(meta.get("content_sha256") or "").strip(),
         }.items()
         if value not in ("", None)
     }

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/integrations/telegram/bot.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/integrations/telegram/bot.py
@@ -606,7 +606,36 @@ def _sources_text_from_timeline(timeline: Mapping[str, Any], *, answer_texts: li
 def _artifact_files_from_timeline(timeline: Mapping[str, Any]) -> list[dict[str, Any]]:
     files: list[dict[str, Any]] = []
     seen: set[str] = set()
+    represented_paths: set[str] = set()
     turn_id = _timeline_turn_id(timeline)
+
+    blocks = timeline.get("blocks") if isinstance(timeline, Mapping) else None
+    if isinstance(blocks, list):
+        # Artifact blocks are authoritative because they carry the hosted
+        # content fingerprint. Process them before sources_pool, which may hold
+        # a second, presentation-only representation of the same image.
+        for block in blocks:
+            if not isinstance(block, Mapping):
+                continue
+            path = str(block.get("path") or "").strip()
+            if not path.startswith("conv:fi:"):
+                continue
+            if not _matches_timeline_turn(block, turn_id):
+                continue
+            if ".user.attachments/" in path or ".external." in path:
+                continue
+            meta = _merged_block_file_meta(block)
+            visibility = str(meta.get("visibility") or block.get("visibility") or "external").strip().lower()
+            if visibility == "internal":
+                continue
+            if not (".files/" in path or ".git/projects/" in path or meta.get("hosted_uri") or meta.get("url")):
+                continue
+            logical_path = str(meta.get("artifact_path") or path).strip()
+            file_item = _file_item_from_meta(meta, logical_path=logical_path)
+            represented_path = _file_delivery_path(file_item)
+            if represented_path:
+                represented_paths.add(represented_path)
+            _append_file(files, seen, file_item)
 
     sources_pool = timeline.get("sources_pool") if isinstance(timeline, Mapping) else None
     if isinstance(sources_pool, list):
@@ -618,30 +647,9 @@ def _artifact_files_from_timeline(timeline: Mapping[str, Any]) -> list[dict[str,
             if not _matches_timeline_turn(row, turn_id):
                 continue
             file_item = _file_item_from_meta(dict(row), logical_path=str(row.get("artifact_path") or ""))
+            if _file_delivery_path(file_item) in represented_paths:
+                continue
             _append_file(files, seen, file_item)
-
-    blocks = timeline.get("blocks") if isinstance(timeline, Mapping) else None
-    if not isinstance(blocks, list):
-        return files
-    for block in blocks:
-        if not isinstance(block, Mapping):
-            continue
-        path = str(block.get("path") or "").strip()
-        if not path.startswith("conv:fi:"):
-            continue
-        if not _matches_timeline_turn(block, turn_id):
-            continue
-        if ".user.attachments/" in path or ".external." in path:
-            continue
-        meta = _merged_block_file_meta(block)
-        visibility = str(meta.get("visibility") or block.get("visibility") or "external").strip().lower()
-        if visibility == "internal":
-            continue
-        if not (".files/" in path or ".git/projects/" in path or meta.get("hosted_uri") or meta.get("url")):
-            continue
-        logical_path = str(meta.get("artifact_path") or path).strip()
-        file_item = _file_item_from_meta(meta, logical_path=logical_path)
-        _append_file(files, seen, file_item)
     return files
 
 
@@ -655,11 +663,8 @@ def _append_file(files: list[dict[str, Any]], seen: set[str], file_item: dict[st
     files.append(file_item)
 
 
-def _file_delivery_key(file_item: Mapping[str, Any]) -> str:
-    # Key on (path, content): a rewrite of the same path is a new delivery, a
-    # true duplicate is dropped. content_sha256 preferred; size is the fallback;
-    # neither present falls back to the legacy path-only key.
-    path = str(
+def _file_delivery_path(file_item: Mapping[str, Any]) -> str:
+    return str(
         file_item.get("url")
         or file_item.get("hosted_uri")
         or file_item.get("rn")
@@ -669,6 +674,13 @@ def _file_delivery_key(file_item: Mapping[str, Any]) -> str:
         or file_item.get("filename")
         or ""
     ).strip()
+
+
+def _file_delivery_key(file_item: Mapping[str, Any]) -> str:
+    # Key on (path, content): a rewrite of the same path is a new delivery, a
+    # true duplicate is dropped. content_sha256 preferred; size is the fallback;
+    # neither present falls back to the legacy path-only key.
+    path = _file_delivery_path(file_item)
     if not path:
         return ""
     signature = str(

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/integrations/telegram/stream.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/integrations/telegram/stream.py
@@ -293,12 +293,22 @@ class TelegramActivityStreamer:
             return str(index)
         data = item.get("data") if isinstance(item.get("data"), Mapping) else {}
         meta = data.get("meta") if isinstance(data.get("meta"), Mapping) else {}
-        for source in (item, meta, data):
-            for key in ("hosted_uri", "url", "rn", "key", "artifact_path", "logical_path", "physical_path", "filename", "sid", "href", "title"):
-                value = source.get(key) if isinstance(source, Mapping) else None
-                if value not in ("", None):
-                    return str(value)
-        return str(index)
+
+        def _first(*keys: str) -> str:
+            for source in (item, meta, data):
+                for key in keys:
+                    value = source.get(key) if isinstance(source, Mapping) else None
+                    if value not in ("", None):
+                        return str(value)
+            return ""
+
+        path = _first("hosted_uri", "url", "rn", "key", "artifact_path", "logical_path", "physical_path", "filename", "sid", "href", "title")
+        if not path:
+            return str(index)
+        # A rewrite reuses the path; fold in a content fingerprint so an updated
+        # file yields a distinct signature and is not debounced as a duplicate.
+        signature = _first("content_sha256", "size", "size_bytes")
+        return f"{path}::{signature}" if signature else path
 
     async def _run(self) -> None:
         while True:
@@ -509,6 +519,7 @@ class TelegramActivityStreamer:
             "base64",
             "size",
             "size_bytes",
+            "content_sha256",
         ):
             if item.get(key) not in ("", None) and meta.get(key) in ("", None):
                 meta[key] = item.get(key)

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/integrations/telegram/tests/test_telegram_integration.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/integrations/telegram/tests/test_telegram_integration.py
@@ -975,6 +975,52 @@ def test_telegram_renderer_skips_already_delivered_artifacts():
     assert [message.kind for message in messages] == ["text"]
 
 
+def test_telegram_renderer_final_delivery_dedup_is_content_scoped():
+    """Live delivery records content-scoped keys (path::content_sha256); final
+    delivery must exclude the SAME content (no duplicate) but still deliver a
+    rewrite of the same path (different content) that was not streamed live."""
+    from kdcube_ai_app.apps.chat.sdk.integrations.telegram.bot import render_telegram_messages_from_timeline
+
+    sha = "c" * 64
+    hosted_uri = "file:///store/turn_1/files/tx/tx.md"
+
+    def _timeline():
+        return {
+            "blocks": [
+                {"path": "tc:turn_1.react.final_answer.0", "text": "done"},
+                {
+                    "path": "conv:fi:conv-1.turn_1.files/tx/tx.md",
+                    "type": "react.tool.result",
+                    "meta": {
+                        "artifact_path": "conv:fi:conv-1.turn_1.files/tx/tx.md",
+                        "hosted_uri": hosted_uri,
+                        "filename": "tx.md",
+                        "mime": "text/markdown",
+                        "visibility": "external",
+                        "size_bytes": 500,
+                        "content_sha256": sha,
+                    },
+                },
+            ],
+            "sources_pool": [],
+        }
+
+    # Same content already delivered live -> final delivery excludes it (no duplicate).
+    same = render_telegram_messages_from_timeline(
+        timeline=_timeline(),
+        exclude_file_keys={f"{hosted_uri}::{sha}"},
+    )
+    assert [message.kind for message in same] == ["text"]
+
+    # A rewrite (different content) that was NOT streamed live -> delivered at final.
+    rewritten = render_telegram_messages_from_timeline(
+        timeline=_timeline(),
+        exclude_file_keys={f"{hosted_uri}::{'d' * 64}"},
+    )
+    assert [message.kind for message in rewritten] == ["text", "document"]
+    assert rewritten[1].files[0].get("content_sha256") == sha
+
+
 @pytest.mark.asyncio
 async def test_telegram_activity_streamer_sends_timeline_notes():
     from kdcube_ai_app.apps.chat.sdk.integrations.telegram.stream import TelegramActivityStreamer
@@ -1317,6 +1363,78 @@ async def test_telegram_activity_streamer_does_not_dedupe_different_file_events(
         await comm.emit("two.pdf", "https://example.test/two.pdf")
 
     assert [message.files[0]["filename"] for message in sent] == ["one.pdf", "two.pdf"]
+
+
+@pytest.mark.asyncio
+async def test_telegram_activity_streamer_delivers_rewritten_same_path_file():
+    """A rewrite of the same artifact path within a turn must be delivered, not
+    dropped as a duplicate. Telegram is a copy channel, so dedup keys on
+    (path, content) — a different content_sha256 is a new delivery; the same
+    content stays deduped through both the activity signature and the file key."""
+    from kdcube_ai_app.apps.chat.sdk.integrations.telegram.stream import TelegramActivityStreamer
+
+    class _FakeComm:
+        def __init__(self):
+            self.listeners = []
+
+        def add_activity_listener(self, cb):
+            self.listeners.append(cb)
+
+        def remove_activity_listener(self, cb):
+            self.listeners.remove(cb)
+
+        async def emit(self, activity):
+            for cb in list(self.listeners):
+                await cb(activity)
+
+    sent = []
+
+    async def _send(messages):
+        sent.extend(messages)
+        return {"ok": True}
+
+    def _files_event(*, sha: str, size: int):
+        # Same hosted path across all revisions; only the content fingerprint moves.
+        item = {
+            "filename": "tx.md",
+            "mime": "text/markdown",
+            "hosted_uri": "file:///store/turn-1/files/tx/tx.md",
+            "key": "store/turn-1/files/tx/tx.md",
+            "physical_path": "turn-1/files/tx/tx.md",
+            "artifact_path": "conv:fi:conv-1.turn-1.files/tx/tx.md",
+            "size": size,
+            "content_sha256": sha,
+            "visibility": "external",
+        }
+        return {
+            "event": "chat_step",
+            "data": {
+                "type": "chat.files",
+                "conversation": {"session_id": "conv-1", "conversation_id": "conv-1", "turn_id": "turn-1"},
+                "event": {"step": "files", "status": "completed", "title": "Files Ready (1)"},
+                "data": {"count": 1, "items": [item]},
+            },
+        }
+
+    comm = _FakeComm()
+    async with TelegramActivityStreamer(
+        comm=comm,
+        bot_token="token",
+        chat_id="chat",
+        turn_id="turn-1",
+        send_messages=_send,
+    ) as streamer:
+        await comm.emit(_files_event(sha="a" * 64, size=100))   # v1
+        await comm.emit(_files_event(sha="b" * 64, size=500))   # v2: same path, new content
+        await comm.emit(_files_event(sha="a" * 64, size=100))   # exact duplicate of v1
+
+    docs = [message for message in sent if message.kind == "document"]
+    # v1 and v2 both delivered; the exact duplicate is not re-sent.
+    assert [doc.files[0].get("content_sha256") for doc in docs] == ["a" * 64, "b" * 64]
+    assert streamer.delivered_file_keys() == {
+        f"file:///store/turn-1/files/tx/tx.md::{'a' * 64}",
+        f"file:///store/turn-1/files/tx/tx.md::{'b' * 64}",
+    }
 
 
 @pytest.mark.asyncio

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/integrations/telegram/tests/test_telegram_integration.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/integrations/telegram/tests/test_telegram_integration.py
@@ -1021,6 +1021,58 @@ def test_telegram_renderer_final_delivery_dedup_is_content_scoped():
     assert rewritten[1].files[0].get("content_sha256") == sha
 
 
+def test_telegram_renderer_coalesces_image_source_and_artifact_representations():
+    """The image sources_pool row and its artifact block describe one file.
+
+    sources_pool intentionally has no transport fingerprint; the authoritative
+    artifact block must win so final delivery neither duplicates the image nor
+    defeats the live-delivery exclusion key.
+    """
+    from kdcube_ai_app.apps.chat.sdk.integrations.telegram.bot import render_telegram_messages_from_timeline
+
+    sha = "e" * 64
+    hosted_uri = "file:///store/turn_1/files/chart.png"
+    artifact_path = "conv:fi:conv-1.turn_1.files/chart.png"
+    timeline = {
+        "turn_id": "turn_1",
+        "blocks": [
+            {"path": "tc:turn_1.react.final_answer.0", "text": "done"},
+            {
+                "path": artifact_path,
+                "type": "react.tool.result",
+                "meta": {
+                    "digest": (
+                        '{"artifact_path":"' + artifact_path + '",'
+                        '"hosted_uri":"' + hosted_uri + '",'
+                        '"mime":"image/png","visibility":"external","size_bytes":100}'
+                    ),
+                    "content_sha256": sha,
+                },
+            },
+        ],
+        "sources_pool": [
+            {
+                "source_type": "file",
+                "url": hosted_uri,
+                "artifact_path": artifact_path,
+                "mime": "image/png",
+                "size_bytes": 100,
+                "turn_id": "turn_1",
+            }
+        ],
+    }
+
+    rendered = render_telegram_messages_from_timeline(timeline=timeline)
+    assert [message.kind for message in rendered] == ["text", "photo"]
+    assert rendered[1].files[0]["content_sha256"] == sha
+
+    after_live_delivery = render_telegram_messages_from_timeline(
+        timeline=timeline,
+        exclude_file_keys={f"{hosted_uri}::{sha}"},
+    )
+    assert [message.kind for message in after_live_delivery] == ["text"]
+
+
 @pytest.mark.asyncio
 async def test_telegram_activity_streamer_sends_timeline_notes():
     from kdcube_ai_app.apps.chat.sdk.integrations.telegram.stream import TelegramActivityStreamer

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/runtime/harness/timeline/turn_view.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/runtime/harness/timeline/turn_view.py
@@ -245,10 +245,10 @@ def extract_user_attachments_from_blocks(
 def extract_assistant_files_from_blocks(
     blocks: list[dict[str, Any]],
 ) -> list[dict[str, Any]]:
-    """Extract externally visible file records from result metadata blocks."""
+    """Project the latest externally visible file record for each path."""
     out: list[dict[str, Any]] = []
     seen: set[str] = set()
-    for block in blocks or []:
+    for block in reversed(blocks or []):
         if not isinstance(block, dict):
             continue
         if (
@@ -320,6 +320,7 @@ def extract_assistant_files_from_blocks(
         if summary:
             payload["summary"] = summary
         out.append(payload)
+    out.reverse()
     return out
 
 

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/runtime/harness/workspace/artifacts.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/runtime/harness/workspace/artifacts.py
@@ -132,13 +132,10 @@ class WorkspaceArtifact:
                 file_path = pathlib.Path(path)
                 if not file_path.is_absolute():
                     file_path = workdir / file_path
-                text = value.get("text")
-                if text is None:
-                    text = value.get("content")
-                # Inline content is authoritative. A later write to the same
-                # current-turn path replaces the current workspace bytes; a
-                # path-only artifact still leaves an existing file untouched.
-                if text is not None or not file_path.exists():
+                if not file_path.exists():
+                    text = value.get("text")
+                    if text is None:
+                        text = value.get("content")
                     if text is None:
                         try:
                             text = json.dumps(

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/runtime/harness/workspace/artifacts.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/runtime/harness/workspace/artifacts.py
@@ -132,10 +132,13 @@ class WorkspaceArtifact:
                 file_path = pathlib.Path(path)
                 if not file_path.is_absolute():
                     file_path = workdir / file_path
-                if not file_path.exists():
-                    text = value.get("text")
-                    if text is None:
-                        text = value.get("content")
+                text = value.get("text")
+                if text is None:
+                    text = value.get("content")
+                # Inline content is authoritative. A later write to the same
+                # current-turn path replaces the current workspace bytes; a
+                # path-only artifact still leaves an existing file untouched.
+                if text is not None or not file_path.exists():
                     if text is None:
                         try:
                             text = json.dumps(

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/react/artifacts.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/react/artifacts.py
@@ -66,6 +66,10 @@ def build_artifact_meta_block(
     size_bytes = (artifact.get("value") or {}).get("size_bytes") or artifact.get("size_bytes")
     if size_bytes is not None:
         meta_json["size_bytes"] = size_bytes
+    # Content fingerprint for delivery-side dedup. Not added to meta.digest.
+    content_sha256 = (artifact.get("value") or {}).get("content_sha256") or artifact.get("content_sha256")
+    if content_sha256:
+        meta_json["content_sha256"] = content_sha256
     text_symbols = (artifact.get("value") or {}).get("text_symbols") or artifact.get("text_symbols")
     if text_symbols is not None:
         meta_json["text_symbols"] = text_symbols

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/react/artifacts.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/react/artifacts.py
@@ -66,10 +66,9 @@ def build_artifact_meta_block(
     size_bytes = (artifact.get("value") or {}).get("size_bytes") or artifact.get("size_bytes")
     if size_bytes is not None:
         meta_json["size_bytes"] = size_bytes
-    # Content fingerprint for delivery-side dedup. Not added to meta.digest.
+    # Delivery fingerprint stays in block metadata, outside the model-facing
+    # artifact digest stored in this block's text.
     content_sha256 = (artifact.get("value") or {}).get("content_sha256") or artifact.get("content_sha256")
-    if content_sha256:
-        meta_json["content_sha256"] = content_sha256
     text_symbols = (artifact.get("value") or {}).get("text_symbols") or artifact.get("text_symbols")
     if text_symbols is not None:
         meta_json["text_symbols"] = text_symbols
@@ -107,6 +106,8 @@ def build_artifact_meta_block(
     block_meta = {
         "tool_call_id": tool_call_id,
     }
+    if content_sha256:
+        block_meta["content_sha256"] = str(content_sha256).strip()
     return {
         "turn": turn_id,
         "type": "react.tool.result",
@@ -117,6 +118,15 @@ def build_artifact_meta_block(
         "ts": ts,
         "meta": block_meta,
     }
+
+
+def artifact_transport_metadata(meta_block: Dict[str, Any]) -> Dict[str, Any]:
+    """Return non-model-facing metadata that must follow an artifact block."""
+    meta = meta_block.get("meta") if isinstance(meta_block, dict) else None
+    if not isinstance(meta, dict):
+        return {}
+    content_sha256 = str(meta.get("content_sha256") or "").strip()
+    return {"content_sha256": content_sha256} if content_sha256 else {}
 
 
 def build_artifact_binary_block(
@@ -355,12 +365,12 @@ class ReactArtifactView(WorkspaceArtifact):
     @staticmethod
     def extract_files_from_contrib_log(contrib_log: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
         """
-        Build assistant file records from contrib_log blocks.
+        Build the latest assistant file record per path from contrib_log blocks.
         We only include external files (visibility=external, kind=file).
         """
         files: List[Dict[str, Any]] = []
         seen: set[str] = set()
-        for blk in contrib_log or []:
+        for blk in reversed(contrib_log or []):
             if not isinstance(blk, dict):
                 continue
             if (blk.get("type") or "") != "react.tool.result":
@@ -403,6 +413,7 @@ class ReactArtifactView(WorkspaceArtifact):
                 "tool_call_id": meta.get("tool_call_id") or "",
             }
             files.append(rec)
+        files.reverse()
         return files
 
     def to_historical_format(self, *, max_tokens: int = 200) -> List[str]:

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/react/events/artifact_production.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/react/events/artifact_production.py
@@ -16,6 +16,7 @@ from kdcube_ai_app.apps.chat.sdk.runtime.harness.workspace.references import (
     qualify_conversation_ref,
 )
 from kdcube_ai_app.apps.chat.sdk.solutions.react.artifacts import (
+    artifact_transport_metadata,
     build_artifact_binary_block,
     build_artifact_meta_block,
     build_artifact_view,
@@ -525,6 +526,7 @@ async def emit_policy_artifact_blocks(
         raw_val = artifact_view.raw or {}
         raw_value = raw_val.get("value") if isinstance(raw_val.get("value"), dict) else {}
         meta_extra = {"tool_call_id": tool_call_id, "turn_id": turn_id, "visibility": visibility}
+        meta_extra.update(artifact_transport_metadata(meta_block))
         items_stats = _items_stats_for_output(output)
         if items_stats:
             meta_extra["items_stats"] = items_stats

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/react/solution_workspace.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/react/solution_workspace.py
@@ -1355,7 +1355,7 @@ class ApplicationHostingService:
     ) -> List[Dict[str, Any]]:
         """
         Copy deliverable file artifacts from local outdir → ConversationStore.
-        Returns rows: [{slot, key, hosted_uri, filename, mime, size, tool_id, description, owner_id, rn, physical_path}]
+        Returns rows: [{slot, key, hosted_uri, filename, mime, size, content_sha256, tool_id, description, owner_id, rn, physical_path}]
 
         The file OWNER (``user``) is the download-critical key component: it must be
         the same user the download resolver reconstructs. When a caller omits it, it
@@ -1365,6 +1365,7 @@ class ApplicationHostingService:
         explicitly, so this default only fills in for callers that don't.
         """
         import pathlib as _pathlib
+        import hashlib as _hashlib
 
         if not str(user or "").strip():
             from kdcube_ai_app.apps.chat.sdk.event_identity import resolve_request_identity
@@ -1394,6 +1395,8 @@ class ApplicationHostingService:
             except Exception as ex:
                 self.log.log(f"[host_files] Failed to read file {p}: {ex}", level="ERROR")
                 continue
+            # Content fingerprint over the bytes already read (no extra I/O).
+            content_sha256 = _hashlib.sha256(data).hexdigest()
 
             name = p.name
             physical_path = str(p)
@@ -1444,6 +1447,7 @@ class ApplicationHostingService:
                 "filename": name,
                 "mime": info.get("mime") or "application/octet-stream",
                 "size": len(data),
+                "content_sha256": content_sha256,
                 "tool_id": info.get("tool_id") or "",
                 "description": info.get("description") or "",
                 "owner_id": user,

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/react/tools/common.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/react/tools/common.py
@@ -903,6 +903,7 @@ async def host_artifact_file(
         hosted_rn = (h0.get("rn") or "").strip()
         hosted_physical = (h0.get("physical_path") or h0.get("local_path") or "").strip()
         hosted_size = h0.get("size")
+        hosted_sha = (h0.get("content_sha256") or "").strip()
         if isinstance(artifact.get("value"), dict):
             if hosted_uri:
                 artifact["value"]["hosted_uri"] = hosted_uri
@@ -914,6 +915,8 @@ async def host_artifact_file(
                 artifact["value"]["physical_path"] = hosted_physical
             if hosted_size is not None and artifact["value"].get("size_bytes") is None:
                 artifact["value"]["size_bytes"] = hosted_size
+            if hosted_sha and not artifact["value"].get("content_sha256"):
+                artifact["value"]["content_sha256"] = hosted_sha
             enrich_artifact_file_metadata(
                 artifact=artifact,
                 outdir=outdir,

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/react/tools/common.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/react/tools/common.py
@@ -913,9 +913,9 @@ async def host_artifact_file(
                 artifact["value"]["rn"] = hosted_rn
             if hosted_physical:
                 artifact["value"]["physical_path"] = hosted_physical
-            if hosted_size is not None and artifact["value"].get("size_bytes") is None:
+            if hosted_size is not None:
                 artifact["value"]["size_bytes"] = hosted_size
-            if hosted_sha and not artifact["value"].get("content_sha256"):
+            if hosted_sha:
                 artifact["value"]["content_sha256"] = hosted_sha
             enrich_artifact_file_metadata(
                 artifact=artifact,
@@ -923,6 +923,10 @@ async def host_artifact_file(
                 physical_path=hosted_physical or str(artifact["value"].get("path") or ""),
                 mime=str(artifact_log.get("mime") or ""),
             )
+        if hosted_size is not None:
+            artifact["size_bytes"] = hosted_size
+        if hosted_sha:
+            artifact["content_sha256"] = hosted_sha
         if hosted_uri:
             artifact["hosted_uri"] = hosted_uri
         if hosted_key:

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/react/tools/external.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/react/tools/external.py
@@ -269,6 +269,7 @@ def _declared_files_to_tool_items(
             "filename": filename,
             "mime": mime,
             "size": row.get("size") if row.get("size") is not None else row.get("size_bytes"),
+            "content_sha256": row.get("content_sha256") or "",
             "tool_id": tool_id,
             "description": description,
             "owner_id": row.get("owner_id") or "",

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/react/tools/external.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/react/tools/external.py
@@ -16,6 +16,7 @@ from kdcube_ai_app.apps.chat.sdk.runtime.harness.workspace.references import (
     qualify_conversation_ref,
 )
 from kdcube_ai_app.apps.chat.sdk.solutions.react.artifacts import (
+    artifact_transport_metadata,
     build_artifact_meta_block,
     build_artifact_binary_block,
     build_artifact_view,
@@ -1764,6 +1765,7 @@ async def _handle_external_tool_legacy(*,
         raw_val = artifact_view.raw or {}
         raw_value = raw_val.get("value") if isinstance(raw_val.get("value"), dict) else {}
         meta_extra = {"tool_call_id": tool_call_id, "turn_id": turn_id, "visibility": visibility}
+        meta_extra.update(artifact_transport_metadata(meta_block))
         items_stats = _items_stats_for_output(output)
         if items_stats:
             meta_extra["items_stats"] = items_stats
@@ -2044,6 +2046,7 @@ async def _handle_external_tool_legacy(*,
         raw_val = artifact_view.raw or {}
         raw_value = raw_val.get("value") if isinstance(raw_val.get("value"), dict) else {}
         meta_extra = {"tool_call_id": tool_call_id, "turn_id": turn_id, "visibility": visibility}
+        meta_extra.update(artifact_transport_metadata(meta_block))
         try:
             meta_text = meta_block.get("text") if isinstance(meta_block, dict) else None
             if isinstance(meta_text, str) and meta_text.strip():

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/react/tools/patch.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/react/tools/patch.py
@@ -45,7 +45,8 @@ from kdcube_ai_app.apps.chat.sdk.runtime.harness.workspace import resolve_artifa
 TOOL_SPEC = {
     "id": "react.patch",
     "purpose": (
-        "Apply a text patch to an existing current-turn materialized text file under the canonical turn_<current>/files/... or turn_<current>/git/projects/... namespace and stream the patch to the user. "
+        "Intentionally edit an existing current-turn text artifact in place, preserving its path; use react.patch instead of calling react.write again for that path. "
+        "The target must be materialized under the canonical turn_<current>/files/... or turn_<current>/git/projects/... namespace, and the change is streamed to the user. "
         "If patch starts with ---/+++/@@ it is treated as unified diff and generated hunk counts are normalized, otherwise replaces the whole file. "
         "Unified diffs are applied against exact old/context bytes; hunk line counts may be wrong, but old/context lines must match the actual current file. "
         "Keep targeted hunks small and anchored by nearby exact context from the target file. "

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/react/tools/patch.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/react/tools/patch.py
@@ -21,6 +21,7 @@ from kdcube_ai_app.apps.chat.sdk.runtime.harness.workspace.references import (
     split_physical_artifact_path,
 )
 from kdcube_ai_app.apps.chat.sdk.solutions.react.artifacts import (
+    artifact_transport_metadata,
     build_artifact_meta_block,
     build_artifact_view,
     detect_edit,
@@ -455,6 +456,7 @@ async def handle_react_patch(*, react: Any, ctx_browser: Any, state: Dict[str, A
     )
     add_block(ctx_browser, meta_block)
     meta_extra = {"tool_call_id": tool_call_id, "turn_id": turn_id, "tool_id": tool_id}
+    meta_extra.update(artifact_transport_metadata(meta_block))
     try:
         meta_text = meta_block.get("text") if isinstance(meta_block, dict) else None
         if isinstance(meta_text, str) and meta_text.strip():

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/react/tools/write.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/react/tools/write.py
@@ -34,12 +34,19 @@ from kdcube_ai_app.apps.chat.sdk.solutions.react.tools.common import (
     infer_format_from_path,
     enrich_artifact_file_metadata,
 )
+from kdcube_ai_app.apps.chat.sdk.solutions.react.tools.write_path_policy import (
+    WRITE_PATH_ALREADY_EXISTS,
+    duplicate_write_message,
+    react_write_target_is_materialized,
+    react_write_target_is_visible,
+    resolve_react_write_target,
+)
 
 TOOL_SPEC = {
     "id": "react.write",
     "purpose": (
-        "Author content and stream it to the user. Prefer one complete write and use react.patch for targeted revisions. "
-        "A later successful same-turn write to the exact same path replaces that file's current stored version. "
+        "Create one new text artifact and stream it to the user. A current-turn path may be created by react.write once; "
+        "use react.patch for a targeted edit or choose a different filename for a separate full version. "
         "If kind='display', content is streamed only; if kind='file', content is streamed and also shared as a file. "
         "Pick the channel by the SHAPE of the content, not by a default. "
         "Use channel='canvas' for LARGE MARKDOWN OR any non‑markdown (HTML/JSON/YAML/XML/Mermaid) — produced as an external artifact that the connected interface presents to the user somewhere outside the inline chat stream. Markdown is first-class on canvas: full reports, multi-section briefs, big markdown tables, slide sources all live here. For short inline, mid-turn information the user should see now (an observation, an early finding, a milestone), use the action's root `notes` instead of an artifact. "
@@ -201,6 +208,32 @@ async def handle_react_write(*, react: Any, ctx_browser: Any, state: Dict[str, A
     artifact_namespace = infer_artifact_namespace(artifact_name, default=ARTIFACT_NAMESPACE_FILES)
     artifact_display_path = f"{artifact_namespace}/{rel_path}" if rel_path else artifact_name
 
+    turn_id = str(ctx_browser.runtime_ctx.turn_id or "").strip()
+    conversation_id = str(getattr(getattr(ctx_browser, "runtime_ctx", None), "conversation_id", "") or "").strip()
+    write_target = resolve_react_write_target(
+        path=artifact_name,
+        turn_id=turn_id,
+        conversation_id=conversation_id,
+    )
+    if write_target is not None and (
+        react_write_target_is_visible(ctx_browser=ctx_browser, target=write_target)
+        or react_write_target_is_materialized(
+            outdir=pathlib.Path(state["outdir"]),
+            target=write_target,
+        )
+    ):
+        notice_block(
+            ctx_browser=ctx_browser,
+            tool_call_id=tool_call_id,
+            code=f"protocol_violation.{WRITE_PATH_ALREADY_EXISTS}",
+            message=duplicate_write_message(write_target),
+            extra={**write_target.violation_extra(), "protocol_violation": True},
+            rel="call",
+        )
+        state["retry_decision"] = True
+        state["last_tool_result"] = []
+        return state
+
     text = None
     if isinstance(generated_data, str):
         text = generated_data
@@ -210,8 +243,6 @@ async def handle_react_write(*, react: Any, ctx_browser: Any, state: Dict[str, A
         except Exception:
             text = str(generated_data)
 
-    turn_id = (ctx_browser.runtime_ctx.turn_id or "")
-    conversation_id = str(getattr(getattr(ctx_browser, "runtime_ctx", None), "conversation_id", "") or "").strip()
     artifact_rel = (rel_path or "").strip()
     artifact_path = (
         qualify_conversation_ref(

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/react/tools/write.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/react/tools/write.py
@@ -20,6 +20,7 @@ from kdcube_ai_app.apps.chat.sdk.runtime.harness.workspace.references import (
     qualify_conversation_ref,
 )
 from kdcube_ai_app.apps.chat.sdk.solutions.react.artifacts import (
+    artifact_transport_metadata,
     materialize_inline_artifact_to_file,
     build_artifact_view,
 )
@@ -37,7 +38,8 @@ from kdcube_ai_app.apps.chat.sdk.solutions.react.tools.common import (
 TOOL_SPEC = {
     "id": "react.write",
     "purpose": (
-        "Author content and stream it to the user. "
+        "Author content and stream it to the user. Prefer one complete write and use react.patch for targeted revisions. "
+        "A later successful same-turn write to the exact same path replaces that file's current stored version. "
         "If kind='display', content is streamed only; if kind='file', content is streamed and also shared as a file. "
         "Pick the channel by the SHAPE of the content, not by a default. "
         "Use channel='canvas' for LARGE MARKDOWN OR any non‑markdown (HTML/JSON/YAML/XML/Mermaid) — produced as an external artifact that the connected interface presents to the user somewhere outside the inline chat stream. Markdown is first-class on canvas: full reports, multi-section briefs, big markdown tables, slide sources all live here. For short inline, mid-turn information the user should see now (an observation, an early finding, a milestone), use the action's root `notes` instead of an artifact. "
@@ -350,6 +352,7 @@ async def handle_react_write(*, react: Any, ctx_browser: Any, state: Dict[str, A
         tokens=tokens_written,
     )
     meta_extra = {"tool_call_id": tool_call_id, "turn_id": turn_id}
+    meta_extra.update(artifact_transport_metadata(meta_block))
     try:
         meta_text = meta_block.get("text") if isinstance(meta_block, dict) else None
         if isinstance(meta_text, str) and meta_text.strip():

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/react/tools/write_path_policy.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/react/tools/write_path_policy.py
@@ -1,0 +1,106 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Elena Viter
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Optional
+
+from kdcube_ai_app.apps.chat.sdk.runtime.harness.workspace import resolve_artifact_path
+from kdcube_ai_app.apps.chat.sdk.runtime.harness.workspace.references import (
+    ARTIFACT_NAMESPACE_FILES,
+    normalize_physical_path,
+    physical_path_to_logical_path,
+    qualify_conversation_ref,
+    split_physical_artifact_path,
+)
+
+
+WRITE_PATH_ALREADY_EXISTS = "write_path_already_exists"
+
+
+@dataclass(frozen=True)
+class ReactWriteTarget:
+    physical_path: str
+    logical_path: str
+    relpath: str
+
+    def violation_extra(self) -> dict[str, str]:
+        return {
+            "path": self.physical_path,
+            **({"artifact_path": self.logical_path} if self.logical_path else {}),
+        }
+
+
+def duplicate_write_message_for_path(path: str) -> str:
+    return (
+        f"`react.write` cannot create `{path}` because that current-turn path already exists. "
+        "The existing file was not changed. Use `react.patch` for an intentional in-place edit, or choose a "
+        "different filename for a separate full version."
+    )
+
+
+def duplicate_write_message(target: ReactWriteTarget) -> str:
+    return duplicate_write_message_for_path(target.physical_path)
+
+
+def resolve_react_write_target(
+    *,
+    path: str,
+    turn_id: str,
+    conversation_id: str = "",
+) -> Optional[ReactWriteTarget]:
+    physical_path, relpath, _ = normalize_physical_path(
+        path,
+        turn_id=turn_id,
+        default_namespace=ARTIFACT_NAMESPACE_FILES,
+    )
+    if not physical_path or not relpath:
+        return None
+    physical_turn_id, _, _ = split_physical_artifact_path(physical_path)
+    if not physical_turn_id or physical_turn_id != turn_id:
+        return None
+    local_logical_path = physical_path_to_logical_path(physical_path)
+    logical_path = qualify_conversation_ref(local_logical_path, conversation_id)
+    return ReactWriteTarget(
+        physical_path=physical_path,
+        logical_path=logical_path,
+        relpath=relpath,
+    )
+
+
+def react_write_target_is_visible(*, ctx_browser: Any, target: ReactWriteTarget) -> bool:
+    try:
+        visible_paths = set(ctx_browser.timeline_visible_paths() or set())
+    except Exception:
+        return False
+    candidates = {target.physical_path}
+    if target.logical_path:
+        candidates.add(target.logical_path)
+    local_logical_path = physical_path_to_logical_path(target.physical_path)
+    if local_logical_path:
+        candidates.add(local_logical_path)
+    return bool(candidates.intersection(visible_paths))
+
+
+def react_write_target_is_materialized(*, outdir: Path, target: ReactWriteTarget) -> bool:
+    try:
+        return resolve_artifact_path(
+            Path(outdir),
+            target.physical_path,
+            create_root=False,
+        ).exists()
+    except Exception:
+        return False
+
+
+__all__ = [
+    "ReactWriteTarget",
+    "WRITE_PATH_ALREADY_EXISTS",
+    "duplicate_write_message",
+    "duplicate_write_message_for_path",
+    "react_write_target_is_materialized",
+    "react_write_target_is_visible",
+    "resolve_react_write_target",
+]

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/react/v3/runtime.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/react/v3/runtime.py
@@ -75,6 +75,13 @@ from kdcube_ai_app.apps.chat.sdk.runtime.tool_traits import (
 from kdcube_ai_app.apps.chat.sdk.solutions.react.v3.action_overseer import (
     RoundActionOverseer,
 )
+from kdcube_ai_app.apps.chat.sdk.solutions.react.v3.write_stream_guard import (
+    ReactWriteStreamGuard,
+)
+from kdcube_ai_app.apps.chat.sdk.solutions.react.tools.write_path_policy import (
+    WRITE_PATH_ALREADY_EXISTS,
+    duplicate_write_message_for_path,
+)
 from kdcube_ai_app.apps.chat.sdk.solutions.react.v3.early_tool_execution import (
     EarlyToolExecutionListener,
     consumed_early_tool_record,
@@ -1065,6 +1072,7 @@ class ReactSolverV2:
         sources_list: Optional[List[Dict[str, object]]] = None,
         artifact_name: Optional[str] = None,
         emit_delta: Optional[Callable[..., Awaitable[None]]] = None,
+        on_react_write_path: Optional[Callable[[str], Awaitable[None]]] = None,
     ) -> tuple[List[Callable[[str], Awaitable[None]]], List[Any]]:
         safe_name = artifact_name or f"react.record.{uuid.uuid4().hex[:8]}"
         sources_getter = None
@@ -1081,6 +1089,7 @@ class ReactSolverV2:
         react_streamer = ReactWriteContentStreamer(
             **base_args,
             stream_tool_id="react.write",
+            on_write_path=on_react_write_path,
         )
         patch_streamer = ReactPatchContentStreamer(
             **base_args,
@@ -1305,6 +1314,9 @@ class ReactSolverV2:
             return f"Action '{action}' is not allowed. Allowed: call_tool | complete | exit."
         if code == "final_answer_required":
             return "final_answer is required for action=complete/exit."
+        if code == WRITE_PATH_ALREADY_EXISTS:
+            path = str((extra or {}).get("path") or "that path").strip()
+            return duplicate_write_message_for_path(path)
         if code == "decision_preamble_before_first_channel":
             return (
                 "Your response started with text outside the ReAct channel protocol, so the runtime interrupted generation before channel parsing. "
@@ -3492,6 +3504,12 @@ class ReactSolverV2:
             artifact_suffix = f"{pending_tool_call_id}.i{safe_idx}"
             action_gate = action_overseer.gate_for(action_index=safe_idx, emit_delta=self.comm.delta, lane="action")
             answer_gate = action_overseer.gate_for(action_index=safe_idx, emit_delta=self.comm.delta, lane="final_answer")
+            write_stream_guard = ReactWriteStreamGuard(
+                ctx_browser=self.ctx_browser,
+                action_gate=action_gate,
+                answer_gate=answer_gate,
+                action_index=safe_idx,
+            )
 
             async def _timeline_emit_delta(**kwargs: Any) -> None:
                 marker = str(kwargs.get("marker") or "")
@@ -3520,10 +3538,14 @@ class ReactSolverV2:
                     sources_list=sources_list,
                     artifact_name=f"react.record.{artifact_suffix}",
                     emit_delta=action_gate.emit_delta,
+                    on_react_write_path=write_stream_guard.observe_path,
                 )
             except TypeError as exc:
-                if "emit_delta" not in str(exc):
+                unsupported = str(exc)
+                if "emit_delta" not in unsupported and "on_react_write_path" not in unsupported:
                     raise
+                # Compatibility overrides without the stream hook still get
+                # the authoritative duplicate check in handle_react_write.
                 record_streamer_fns, instance_record_streamers = self._mk_content_streamers(
                     f"decision.record ({iteration}).{safe_idx}",
                     sources_list=sources_list,

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/react/v3/test_solution_workspace.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/react/v3/test_solution_workspace.py
@@ -30,6 +30,7 @@ async def test_emit_solver_artifacts_preserves_transport_fields():
                 "hosted_uri": "s3://bucket/cb/tenants/t/projects/p/attachments/u/conv_1/turn_1/diagram-scene-hub.svg",
                 "key": "cb/tenants/t/projects/p/attachments/u/conv_1/turn_1/diagram-scene-hub.svg",
                 "rn": "rn:file",
+                "content_sha256": "a" * 64,
             }
         ],
         citations=[],
@@ -44,5 +45,88 @@ async def test_emit_solver_artifacts_preserves_transport_fields():
     assert item["hosted_uri"].startswith("s3://bucket/")
     assert item["key"].startswith("cb/tenants/")
     assert item["rn"] == "rn:file"
+    assert item["content_sha256"] == "a" * 64
     assert item["object_ref"] == item["logical_path"]
     assert item["ref"] == item["logical_path"]
+
+
+@pytest.mark.asyncio
+async def test_host_artifact_file_overwrites_stale_content_metadata(tmp_path):
+    from types import SimpleNamespace
+
+    from kdcube_ai_app.apps.chat.sdk.solutions.react.tools.common import host_artifact_file
+
+    authoritative_sha = "b" * 64
+
+    class _FakeHosting:
+        async def host_files_to_conversation(self, **_kwargs):
+            return [
+                {
+                    "hosted_uri": "file:///store/turn_1/files/report.md",
+                    "key": "store/turn_1/files/report.md",
+                    "rn": "rn:file",
+                    "physical_path": "turn_1/files/report.md",
+                    "size": 23,
+                    "content_sha256": authoritative_sha,
+                }
+            ]
+
+    comm = SimpleNamespace(
+        service={
+            "tenant": "tenant",
+            "project": "project",
+            "user": "user",
+            "conversation_id": "conv_1",
+        },
+        user_id="user",
+        user_type="user",
+    )
+    artifact = {
+        "path": "turn_1/files/report.md",
+        "content_sha256": "stale-top-level",
+        "size_bytes": 1,
+        "value": {
+            "path": "turn_1/files/report.md",
+            "content_sha256": "stale-nested",
+            "size_bytes": 1,
+        },
+    }
+
+    hosted = await host_artifact_file(
+        hosting_service=_FakeHosting(),
+        comm=comm,
+        runtime_ctx=SimpleNamespace(conversation_id="conv_1", turn_id="turn_1"),
+        artifact=artifact,
+        outdir=tmp_path,
+    )
+
+    assert hosted[0]["content_sha256"] == authoritative_sha
+    assert artifact["content_sha256"] == authoritative_sha
+    assert artifact["value"]["content_sha256"] == authoritative_sha
+    assert artifact["size_bytes"] == 23
+    assert artifact["value"]["size_bytes"] == 23
+
+
+def test_artifact_content_fingerprint_is_transport_only():
+    import json
+
+    from kdcube_ai_app.apps.chat.sdk.solutions.react.artifacts import (
+        artifact_transport_metadata,
+        build_artifact_meta_block,
+    )
+
+    sha = "c" * 64
+    block = build_artifact_meta_block(
+        turn_id="turn_1",
+        tool_call_id="tc_1",
+        artifact={
+            "value": {"content_sha256": sha, "size_bytes": 12},
+            "visibility": "external",
+        },
+        artifact_path="conv:fi:conv_1.turn_1.files/report.md",
+        physical_path="turn_1/files/report.md",
+    )
+
+    assert "content_sha256" not in json.loads(block["text"])
+    assert block["meta"]["content_sha256"] == sha
+    assert artifact_transport_metadata(block) == {"content_sha256": sha}

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/react/v3/test_write_stream_guard.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/react/v3/test_write_stream_guard.py
@@ -1,0 +1,75 @@
+# SPDX-License-Identifier: MIT
+
+import pytest
+
+from kdcube_ai_app.apps.chat.sdk.solutions.react.proto import RuntimeCtx
+from kdcube_ai_app.apps.chat.sdk.solutions.react.v2.tools.tests.helpers import FakeBrowser
+from kdcube_ai_app.apps.chat.sdk.solutions.react.v3.action_overseer import ActionStreamGate
+from kdcube_ai_app.apps.chat.sdk.solutions.react.v3.write_stream_guard import ReactWriteStreamGuard
+from kdcube_ai_app.apps.chat.sdk.streaming.stream_policy import StreamPolicyViolation
+
+
+async def _discard_delta(**_kwargs):
+    return None
+
+
+@pytest.mark.asyncio
+async def test_write_stream_guard_rejects_visible_current_turn_path():
+    runtime = RuntimeCtx(
+        turn_id="turn_cur",
+        conversation_id="conversation_1",
+        outdir="/tmp/out",
+        workdir="/tmp/out",
+    )
+    ctx = FakeBrowser(runtime)
+    ctx.contribute(
+        [
+            {
+                "turn": "turn_cur",
+                "type": "react.tool.result",
+                "path": "conv:fi:conv_conversation_1.turn_cur.files/report.md",
+                "text": "first version",
+            }
+        ]
+    )
+    action_gate = ActionStreamGate(emit_delta=_discard_delta, action_index=0)
+    answer_gate = ActionStreamGate(emit_delta=_discard_delta, action_index=0, lane="final_answer")
+    guard = ReactWriteStreamGuard(
+        ctx_browser=ctx,
+        action_gate=action_gate,
+        answer_gate=answer_gate,
+        action_index=0,
+    )
+
+    with pytest.raises(StreamPolicyViolation) as exc:
+        await guard.observe_path("turn_cur/files/report.md")
+
+    assert exc.value.code == "write_path_already_exists"
+    assert exc.value.extra["path"] == "turn_cur/files/report.md"
+    assert exc.value.extra["artifact_path"] == "conv:fi:conv_conversation_1.turn_cur.files/report.md"
+    assert action_gate.status == "denied"
+    assert answer_gate.status == "denied"
+
+
+@pytest.mark.asyncio
+async def test_write_stream_guard_allows_new_current_turn_path():
+    runtime = RuntimeCtx(
+        turn_id="turn_cur",
+        conversation_id="conversation_1",
+        outdir="/tmp/out",
+        workdir="/tmp/out",
+    )
+    ctx = FakeBrowser(runtime)
+    action_gate = ActionStreamGate(emit_delta=_discard_delta, action_index=0)
+    answer_gate = ActionStreamGate(emit_delta=_discard_delta, action_index=0, lane="final_answer")
+    guard = ReactWriteStreamGuard(
+        ctx_browser=ctx,
+        action_gate=action_gate,
+        answer_gate=answer_gate,
+        action_index=0,
+    )
+
+    await guard.observe_path("turn_cur/files/report.md")
+
+    assert action_gate.status == "pending"
+    assert answer_gate.status == "pending"

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/react/v3/tools/tests/test_write.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/react/v3/tools/tests/test_write.py
@@ -11,6 +11,18 @@ from kdcube_ai_app.apps.chat.sdk.runtime.harness.timeline.turn_view import (
 )
 from kdcube_ai_app.apps.chat.sdk.solutions.react.v2.tools.write import handle_react_write
 from kdcube_ai_app.apps.chat.sdk.solutions.react.v2.tools.tests.helpers import FakeBrowser, FakeReact
+from kdcube_ai_app.apps.chat.sdk.solutions.react.tools.patch import TOOL_SPEC as PATCH_TOOL_SPEC
+from kdcube_ai_app.apps.chat.sdk.solutions.react.tools.write import TOOL_SPEC as WRITE_TOOL_SPEC
+
+
+def test_write_and_patch_tool_specs_expose_create_once_vs_in_place_edit_contract():
+    write_purpose = str(WRITE_TOOL_SPEC.get("purpose") or "")
+    patch_purpose = str(PATCH_TOOL_SPEC.get("purpose") or "")
+
+    assert "path may be created by react.write once" in write_purpose
+    assert "Intentionally edit" in patch_purpose
+    assert "preserving its path" in patch_purpose
+    assert "instead of calling react.write again" in patch_purpose
 
 
 @pytest.mark.asyncio
@@ -226,7 +238,7 @@ async def test_write_unqualified_path_defaults_to_files_namespace(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_write_same_path_keeps_latest_successful_version(tmp_path):
+async def test_write_same_path_is_rejected_and_keeps_original_version(tmp_path):
     runtime = RuntimeCtx(turn_id="turn_cur", outdir=str(tmp_path), workdir=str(tmp_path))
     ctx = FakeBrowser(runtime)
     state = {"outdir": str(tmp_path)}
@@ -259,13 +271,14 @@ async def test_write_same_path_keeps_latest_successful_version(tmp_path):
     )
 
     path = tmp_path / "workdir" / "turn_cur" / "files" / "report.md"
-    assert path.read_text() == "corrected final version\n"
+    assert path.read_text() == "first version\n"
+    assert state["retry_decision"] is True
 
     artifact_ref = "conv:fi:turn_cur.files/report.md"
     resolved = ctx.timeline.resolve_artifact(artifact_ref)
     assert resolved is not None
-    assert resolved["text"] == "corrected final version\n"
-    assert resolved["tool_call_id"] == "write_second"
+    assert resolved["text"] == "first version\n"
+    assert resolved["tool_call_id"] == "write_first"
 
     write_meta = []
     for block in ctx.timeline.blocks:
@@ -277,12 +290,51 @@ async def test_write_same_path_keeps_latest_successful_version(tmp_path):
             continue
         if meta.get("artifact_path") == artifact_ref:
             write_meta.append(meta)
-    assert [row["tool_call_id"] for row in write_meta] == [
-        "write_first",
-        "write_second",
-    ]
+    assert [row["tool_call_id"] for row in write_meta] == ["write_first"]
+    assert any(
+        block.get("type") == "react.notice"
+        and "protocol_violation.write_path_already_exists" in str(block.get("text") or "")
+        and block.get("call_id") == "write_second"
+        for block in ctx.timeline.blocks
+    )
 
     assistant_files = extract_assistant_files_from_blocks(ctx.timeline.blocks)
     assert len(assistant_files) == 1
     assert assistant_files[0]["artifact_path"] == artifact_ref
-    assert assistant_files[0]["tool_call_id"] == "write_second"
+    assert assistant_files[0]["tool_call_id"] == "write_first"
+
+
+@pytest.mark.asyncio
+async def test_write_rejects_materialized_path_missing_from_timeline(tmp_path):
+    runtime = RuntimeCtx(turn_id="turn_cur", outdir=str(tmp_path), workdir=str(tmp_path))
+    ctx = FakeBrowser(runtime)
+    state = {
+        "outdir": str(tmp_path),
+        "last_decision": {
+            "tool_call": {
+                "params": {
+                    "path": "turn_cur/files/report.md",
+                    "channel": "canvas",
+                    "content": "replacement\n",
+                    "kind": "file",
+                }
+            }
+        },
+    }
+    path = tmp_path / "workdir" / "turn_cur" / "files" / "report.md"
+    path.parent.mkdir(parents=True)
+    path.write_text("created by another current-turn tool\n")
+
+    await handle_react_write(
+        react=FakeReact(),
+        ctx_browser=ctx,
+        state=state,
+        tool_call_id="write_duplicate",
+    )
+
+    assert path.read_text() == "created by another current-turn tool\n"
+    assert state["retry_decision"] is True
+    assert any(
+        "protocol_violation.write_path_already_exists" in str(block.get("text") or "")
+        for block in ctx.timeline.blocks
+    )

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/react/v3/tools/tests/test_write.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/react/v3/tools/tests/test_write.py
@@ -1,9 +1,14 @@
 # SPDX-License-Identifier: MIT
 
+import json
+
 import pytest
 
 from kdcube_ai_app.apps.chat.sdk.solutions.react.proto import RuntimeCtx
 from kdcube_ai_app.apps.chat.sdk.solutions.react.events import block_event_id, block_event_source_id
+from kdcube_ai_app.apps.chat.sdk.runtime.harness.timeline.turn_view import (
+    extract_assistant_files_from_blocks,
+)
 from kdcube_ai_app.apps.chat.sdk.solutions.react.v2.tools.write import handle_react_write
 from kdcube_ai_app.apps.chat.sdk.solutions.react.v2.tools.tests.helpers import FakeBrowser, FakeReact
 
@@ -218,3 +223,66 @@ async def test_write_unqualified_path_defaults_to_files_namespace(tmp_path):
 
     assert (tmp_path / "workdir" / "turn_cur" / "files" / "demo_proj" / "report.md").read_text() == "# Report\n"
     assert any(b.get("path") == "conv:fi:turn_cur.files/demo_proj/report.md" for b in ctx.timeline.blocks)
+
+
+@pytest.mark.asyncio
+async def test_write_same_path_keeps_latest_successful_version(tmp_path):
+    runtime = RuntimeCtx(turn_id="turn_cur", outdir=str(tmp_path), workdir=str(tmp_path))
+    ctx = FakeBrowser(runtime)
+    state = {"outdir": str(tmp_path)}
+
+    def _decision(content: str) -> dict:
+        return {
+            "tool_call": {
+                "params": {
+                    "path": "turn_cur/files/report.md",
+                    "channel": "canvas",
+                    "content": content,
+                    "kind": "file",
+                }
+            }
+        }
+
+    state["last_decision"] = _decision("first version\n")
+    await handle_react_write(
+        react=FakeReact(),
+        ctx_browser=ctx,
+        state=state,
+        tool_call_id="write_first",
+    )
+    state["last_decision"] = _decision("corrected final version\n")
+    await handle_react_write(
+        react=FakeReact(),
+        ctx_browser=ctx,
+        state=state,
+        tool_call_id="write_second",
+    )
+
+    path = tmp_path / "workdir" / "turn_cur" / "files" / "report.md"
+    assert path.read_text() == "corrected final version\n"
+
+    artifact_ref = "conv:fi:turn_cur.files/report.md"
+    resolved = ctx.timeline.resolve_artifact(artifact_ref)
+    assert resolved is not None
+    assert resolved["text"] == "corrected final version\n"
+    assert resolved["tool_call_id"] == "write_second"
+
+    write_meta = []
+    for block in ctx.timeline.blocks:
+        if block.get("mime") != "application/json":
+            continue
+        try:
+            meta = json.loads(block.get("text") or "")
+        except json.JSONDecodeError:
+            continue
+        if meta.get("artifact_path") == artifact_ref:
+            write_meta.append(meta)
+    assert [row["tool_call_id"] for row in write_meta] == [
+        "write_first",
+        "write_second",
+    ]
+
+    assistant_files = extract_assistant_files_from_blocks(ctx.timeline.blocks)
+    assert len(assistant_files) == 1
+    assert assistant_files[0]["artifact_path"] == artifact_ref
+    assert assistant_files[0]["tool_call_id"] == "write_second"

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/react/v3/write_stream_guard.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/react/v3/write_stream_guard.py
@@ -1,0 +1,57 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Elena Viter
+
+from __future__ import annotations
+
+from typing import Any
+
+from kdcube_ai_app.apps.chat.sdk.solutions.react.tools.write_path_policy import (
+    WRITE_PATH_ALREADY_EXISTS,
+    duplicate_write_message,
+    react_write_target_is_visible,
+    resolve_react_write_target,
+)
+from kdcube_ai_app.apps.chat.sdk.streaming.stream_policy import StreamPolicyViolation
+
+
+class ReactWriteStreamGuard:
+    """Interrupt a duplicate current-turn react.write before content streams."""
+
+    def __init__(
+        self,
+        *,
+        ctx_browser: Any,
+        action_gate: Any,
+        answer_gate: Any,
+        action_index: int,
+    ) -> None:
+        self._ctx_browser = ctx_browser
+        self._action_gate = action_gate
+        self._answer_gate = answer_gate
+        self._action_index = int(action_index or 0)
+
+    async def observe_path(self, path: str) -> None:
+        runtime_ctx = getattr(self._ctx_browser, "runtime_ctx", None)
+        turn_id = str(getattr(runtime_ctx, "turn_id", "") or "").strip()
+        conversation_id = str(getattr(runtime_ctx, "conversation_id", "") or "").strip()
+        target = resolve_react_write_target(
+            path=path,
+            turn_id=turn_id,
+            conversation_id=conversation_id,
+        )
+        if target is None or not react_write_target_is_visible(
+            ctx_browser=self._ctx_browser,
+            target=target,
+        ):
+            return
+
+        await self._action_gate.deny()
+        await self._answer_gate.deny()
+        raise StreamPolicyViolation(
+            code=WRITE_PATH_ALREADY_EXISTS,
+            message=duplicate_write_message(target),
+            extra={"index": self._action_index, **target.violation_extra()},
+        )
+
+
+__all__ = ["ReactWriteStreamGuard"]

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/widgets/canvas.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/widgets/canvas.py
@@ -592,6 +592,34 @@ class ToolContentStreamerBase:
 
 
 class ReactWriteContentStreamer(ToolContentStreamerBase):
+    def __init__(
+        self,
+        *,
+        on_write_path: Optional[Callable[[str], Awaitable[None]]] = None,
+        **kwargs: Any,
+    ) -> None:
+        self.on_write_path = on_write_path
+        self._write_path_reported = False
+        super().__init__(**kwargs)
+
+    def _start_tool_call(self) -> None:
+        super()._start_tool_call()
+        self._write_path_reported = False
+
+    async def _close_active_string(self) -> None:
+        if (
+            not self._write_path_reported
+            and self.on_write_path is not None
+            and self.active_key
+            and self._matches_path_path()
+            and self.current_tool_id == self.stream_tool_id
+        ):
+            path = self.active_value_buf.strip()
+            if path:
+                self._write_path_reported = True
+                await self.on_write_path(path)
+        await super()._close_active_string()
+
     def _tool_allows_stream(self) -> bool:
         return self.current_tool_id == self.stream_tool_id
 

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/streaming/test_workspace_streamer_v3.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/streaming/test_workspace_streamer_v3.py
@@ -656,6 +656,73 @@ async def test_stream_policy_interrupts_before_denied_action_channel_closes():
 
 
 @pytest.mark.asyncio
+async def test_react_write_path_guard_interrupts_before_content_is_processed():
+    content = "CONTENT_THAT_MUST_NOT_BE_GENERATED_" * 40
+    action = {
+        "action": "call_tool",
+        "notes": "writing report",
+        "tool_call": {
+            "tool_id": "react.write",
+            "params": {
+                "path": "turn_1/files/report.md",
+                "channel": "canvas",
+                "content": content,
+                "kind": "file",
+            },
+        },
+        "final_answer": None,
+        "suggested_followups": None,
+    }
+    chunks = _chunk_text(_json_channel("action", action), size=7)
+    svc = _InterruptAwareService(chunks)
+    collector = _Collector()
+    observed_paths = []
+
+    async def _reject_existing_path(path: str) -> None:
+        observed_paths.append(path)
+        raise StreamPolicyViolation(
+            code="write_path_already_exists",
+            message="existing path",
+            extra={"path": path},
+        )
+
+    def _factory(channel: str, instance_idx: int):
+        del channel
+        streamer = ReactWriteContentStreamer(
+            emit_delta=collector.emit,
+            agent=f"test.write.{instance_idx}",
+            artifact_name=f"react.record.{instance_idx}",
+            turn_id="turn_1",
+            stream_tool_id="react.write",
+            on_write_path=_reject_existing_path,
+        )
+        return [_wrap_json_widget(streamer)]
+
+    with pytest.raises(StreamPolicyViolation) as exc:
+        await stream_with_channels(
+            svc=svc,
+            messages=["sys", "user"],
+            role="answer.generator.regular",
+            channels=[
+                ChannelSpec(name="action", format="json", replace_citations=False, emit_marker="answer"),
+            ],
+            emit=collector.emit,
+            agent="test.agent",
+            artifact_name="react.decision",
+            subscribers=ChannelSubscribers().subscribe_factory("action", _factory),
+            max_tokens=500,
+            temperature=0.0,
+            return_full_raw=True,
+        )
+
+    assert exc.value.code == "write_path_already_exists"
+    assert observed_paths == ["turn_1/files/report.md"]
+    assert not svc.stream_finished
+    assert content not in "".join(svc.yielded)
+    assert collector.text_for_artifact("report.md") == ""
+
+
+@pytest.mark.asyncio
 async def test_raw_stream_policy_interrupts_before_channel_parser_and_subscribers():
     chunks = [
         "Draft outside the protocol.",


### PR DESCRIPTION
Telegram is a copy channel: each send is a physical snapshot, so a file emitted
twice in one turn was deduped by PATH and the updated version was dropped. When an
agent rewrote the same artifact path (e.g. a followup that expands a document), the
first version reached the chat and the newer one was silently discarded — the
`react.patch`/second-`react.write` emit collapsed onto the first delivery.

Two path-only dedup layers in the streamer caused this:
- `_event_item_signature` (activity-level debounce in `_on_activity`) returned the
  first path field, so the second `chat.files` event was dropped before delivery.
- `_file_delivery_key` (file-level dedup, also used by final delivery) keyed on path.

Both now key on (path, content): a content fingerprint distinguishes a genuine
rewrite (deliver it) from a true duplicate emit or a live-vs-final re-send (drop it).
The documented live↔final dedup is preserved; a rewrite is delivered as a new
message.

The fingerprint is `content_sha256`, computed in `host_files_to_conversation` over
the bytes it already reads (no extra I/O) and threaded to both delivery paths:
- hosted row → `emit_solver_artifacts` → streamer whitelist → live delivery;
- hosted row → `artifact["value"]` → `build_artifact_meta_block` meta → timeline →
  final delivery.
It is operational metadata: kept out of the model-facing safe digest, and the web
adapter ignores it (it keeps its own path-keyed upsert). Falls back to size, then to
the legacy path-only key for events that predate the field.

Adds a regression test (same path + different content → both delivered; exact
duplicate → deduped) and updates the streamer dedup doc.
