### PR TITLE
Persist delegated-card authority and active catalog lifecycle

### DIFF
--- a/app/ai-app/deployment/bundles.yaml
+++ b/app/ai-app/deployment/bundles.yaml
@@ -34,6 +34,12 @@ bundles:
         oauth:
           public_base_url: https://<PUBLIC_HOST>
         delegated_credentials:
+          catalog:
+            active_cache_seconds: 300
+            version_cache_seconds: 3600
+          cards:
+            updating_marker_seconds: 15
+            revoked_tombstone_seconds: 60
           oauth:
             enabled: true
             brand: KDCube

--- a/app/ai-app/docs/sdk/solutions/connections/delegated-cards/delegated-cards-README.md
+++ b/app/ai-app/docs/sdk/solutions/connections/delegated-cards/delegated-cards-README.md
@@ -29,9 +29,9 @@ The card is the user's live delegated-authority record, not a cached
 illustration of a token. Pointer-backed credentials identify the card, and the
 managed guard resolves its current contents on each call. Editing or revoking
 the card therefore changes the next call made with an already-issued bearer.
-The deployment descriptor is intended to remain the ceiling around that user
-decision. The descriptor-drift section below records where the current
-implementation does not yet preserve that invariant.
+The deployment descriptor, published as the delegated catalog, is the ceiling
+around that user decision: every governed call intersects the card with the
+active catalog, so a withdrawn capability is denied without editing the card.
 
 The card is also not a copy of the entire current service catalog. It stores
 the user's selected authority. Connection Hub separately reads the live
@@ -78,31 +78,7 @@ different authorization model.
 
 ## Stored Record
 
-### Current Redis-only implementation
-
-The current implementation stores each record in Redis:
-
-```text
-{tenant}:{project}:kdcube:delegated-access:automation:{access_id}
-{tenant}:{project}:kdcube:delegated-access:automation-by-grantor:{subject_hash}
-```
-
-The first key holds the record with a TTL. The second is the grantor's set of
-card ids. Expired or missing ids are pruned from the set during list.
-
-This is not sufficient as the durable card model. The record key is written
-with `SETEX`, so expiry erases the only copy of the authorization decision.
-Manual and hosted-agent cards default to one hour and are bounded to seven
-days. OAuth cards use the refresh-token lifetime, currently 180 days, and renew
-on token issuance. Runtime safely denies a missing or expired record, but no
-card provenance remains.
-
-The grantor index is also assigned a fixed seven-day TTL. An idle OAuth card can
-therefore disappear from Connection Hub's list while its card record and
-refresh authority remain live. Later OAuth issuance adds it to the index again,
-but the user may lose the visible revocation path in the meantime.
-
-### Required durable record and live cache
+### Durable record and live cache
 
 Connection Hub bundle storage is the durable source of truth. Redis is the
 TTL-managed live projection of the latest committed card revision:
@@ -180,7 +156,7 @@ outage blocks cache-miss recovery and every mutation; a governed request whose
 validated card and active catalog are already hot in Redis does not perform a
 durable read.
 
-### Current record fields
+### Record fields
 
 | Field | Meaning | Public list response |
 | --- | --- | --- |
@@ -189,34 +165,34 @@ durable read.
 | `grantor_subject`, `delegate_subject` | User who granted and integration principal that acts. | yes; list is also owner-scoped to the authenticated grantor. |
 | `operations` | Allowed outer API/MCP operation names derived at issuance or save. | yes |
 | `resource_grants` | Exact selected KDCube claims per resource. | yes |
-| `named_service_operations` | Exact selected namespace operations per resource. This is the selection the UI renders. | yes when non-empty; the current public serializer drops explicit `{}`. |
-| `named_services` | Materialized boundary tree derived from the descriptor and `named_service_operations`. The proc-side bridge consumes it. | no |
+| `named_service_operations` | The card's selection: `"*"`, `{}`, or an exact resource -> namespace -> operation map. | yes, verbatim, including `{}` and `"*"` |
+| `named_services` | Materialized boundary tree derived from the descriptor and `named_service_operations`. The proc-side bridge consumes it. | no; its expansion surfaces as `effective_named_service_operations` |
+| `effective_named_service_operations` | The selection expanded under the catalog version the card was saved against. Derived, never authority. | yes when the card covers any operation |
+| `catalog_version`, `card_revision` | The catalog generation this card was last saved against, and its monotonic revision. | yes |
 | `account_scope` | Provider -> account -> exact connected-account claims this caller may use. | yes when non-empty |
 | `identity_scope` | Which identity boundary the delegated resource uses. | yes |
 | `created_at`, `expires_at`, `last_issued_at` | Lifecycle timestamps. | yes when present |
 | `last_four`, `source` | Token fingerprint and card family. | yes |
 | `session_id`, `access_token`, `refresh_token` | Internal credential/revocation handles, according to source. | no |
 
-In the target split, every authority and lifecycle field above is copied into
-the immutable durable revision except `session_id`, `access_token`, and
-`refresh_token`. Those three fields may exist only in dedicated TTL-managed
-live stores, separate from the reconstructable card-authority projection.
+Every authority and lifecycle field above is copied into the immutable durable
+revision except `session_id`, `access_token`, and `refresh_token`. Those three
+live only in dedicated TTL-managed stores, separate from the reconstructable
+card-authority projection.
 
 `to_public_dict()` removes all token material, `session_id`, and the internal
 `named_services` boundary. A public card exposes the selection, never the
 provider credential or the materialized enforcement tree.
 
-The current record shape has one important ambiguity. Deserialization maps a
-missing selection and an explicit empty selection to the same `{}`, while the
-public serializer also drops `{}`. The code can therefore distinguish
-"unrestricted" from "disabled" during the update that receives the input, but
-not reliably on a later update that omits the field. This is a current defect,
-not part of the intended contract described below.
+The selection is retained verbatim, so a refetch preserves the difference
+between the four states:
 
-Consequently, after a list/refetch, absence of a public Services selection can
-currently mean either "use the full descriptor policy" or "no named-service
-operation is allowed." The read-only card and editor need the durable mode
-described under edit semantics before they can label those states reliably.
+| Stored | Meaning |
+| --- | --- |
+| `"*"` | Every named-service operation present in the referenced `catalog_version`. Operations added later are not included. |
+| `{}` | No named-service operation. |
+| exact map | That resource -> namespace -> operation selection. |
+| field absent | A record written before this encoding. Its prior set is derived from the materialized boundary. |
 
 Connected provider credentials are stored by the delegated-to-KDCube account
 system, not in these cards. `account_scope` contains ids and claims only.
@@ -408,21 +384,24 @@ This produces two deliberately different views:
 - Available resources, claims, namespaces, and operations come from the live
   descriptor-backed catalogs.
 - Check states begin from the stored card selection during edit.
-- Claim editing currently unions the card's stored claims with the current
-  resource claim catalog, so a removed stored claim remains visible and can be
-  unchecked.
-- Named-service operation rows currently come only from the live catalog. A
-  stored operation removed from that catalog has no row in the picker.
+- Claim editing unions the card's stored claims with the current resource claim
+  catalog, so a removed stored claim remains visible and can be unchecked.
+- Named-service operation rows come from the live catalog, ticked from the
+  card's coverage (`effective_named_service_operations`) intersected with what
+  the catalog still offers. An operation the catalog added after the card was
+  saved appears unchecked.
+- The picker is offered for every card family.
 - Account rows come from current connected accounts. A disconnected account is
   visible in read-only mode but is not seeded into the edit picker.
 
 The direct answer to "where does the Services list come from?" is therefore:
 
 ```text
-read-only Services row    -> card.named_service_operations (stored selection)
+read-only Services row    -> card.effective_named_service_operations (coverage)
 create/edit Services rows -> resources[].named_services (live descriptor catalog)
+edit check states         -> coverage ∩ what the catalog still offers
 provider prerequisites    -> live named-service discovery metadata
-account choices            -> live delegated-to-KDCube account catalog
+account choices           -> live delegated-to-KDCube account catalog
 ```
 
 ## Creation Lifecycle
@@ -444,10 +423,11 @@ authenticated user opens create form
 
 ```text
 agent attempts a governed operation
-  -> denial names deterministic kdcube-agent:<app>:<agent> client
-  -> user approves the demand in Connection Hub
+  -> denial names the deterministic kdcube-agent:<app>:<agent> client, the
+     namespace and the operation it was refused
+  -> user approves the demand in Connection Hub, with that operation pre-selected
   -> create_access deduplicates by grantor + client + resources
-  -> ordinary consent merges newly approved authority
+  -> approval merges exactly the approved authority
   -> explicit edit uses replace semantics
   -> reusable agent bearer and card are stored server-side
 ```
@@ -456,9 +436,13 @@ agent attempts a governed operation
 
 ```text
 external client completes OAuth consent
+  -> consent submits its contract version, the catalog version it was rendered
+     from, and the operation selection
+  -> authorization code carries that selection
   -> token endpoint issues access/refresh material
-  -> record_oauth_grant upserts one card per grantor + client + resource
-  -> refresh rotation updates current token handles and last_issued_at
+  -> record_oauth_grant writes one card per grantor + client + resource, born
+     with the submitted selection and the catalog version
+  -> refresh rotation updates token handles, expiry and last_issued_at only
   -> user edits or revokes the same visible card later
 ```
 
@@ -466,15 +450,59 @@ A reconnecting dynamic client may receive a new client id. Connection Hub can
 supersede a matching older card, carry its account binding forward, and revoke
 the old token handles.
 
+### Consent view model
+
+Connection Hub builds one view model per authorize request and hands it to
+whichever renderer serves the page — the built-in one or a bundle-hosted
+`consent_ui`. A custom renderer changes presentation, never the authorization
+contract.
+
+```text
+consent_contract.version
+catalog_version
+platform_grants
+tools                       (outer operations)
+named_service_operations    (namespace, operation, required claims)
+connected_accounts
+seeded_account_scope
+request / oauth_request     (client and PKCE metadata)
+```
+
+A renderer returns the contract version it implements alongside its HTML. An
+absent or mismatched version is refused with `consent_ui_contract_mismatch`
+before the page is shown, so a page that never rendered a dimension cannot
+report a choice about it.
+
+The submitted form carries `consent_contract_version`,
+`expected_catalog_version`, and the operation selection:
+
+| Submitted | Result |
+| --- | --- |
+| Every offered operation selected | `"*"`, bound to the catalog version shown on the page. |
+| Some operations selected | That exact selection, re-validated against the catalog. |
+| None selected | `{}`. The connection is created without named-service access and can be widened later in Connection Hub. |
+| `consent_contract_version` absent | No authorization code and no card. |
+| `expected_catalog_version` no longer active | `consent_catalog_changed`; authorization restarts rather than reinterpreting the selection. |
+
 ## Edit Semantics
 
 The card's selected authority is changed in place. No new manual token is
 issued, and a pointer-backed caller observes the change on its next request.
 
-### Manual card
+Authority is changed by the grantor, under their KDCube identity, wherever the
+edit was initiated from. A caller authenticated as the delegate
+(`integration:<client>:<grantor>`) is refused with
+`delegated_access_requires_grantor`.
 
-`delegated_access_update` is intended to validate and rewrite the record with
-this contract:
+### Any card: `delegated_access_update`
+
+One source-neutral edit serves all three families. The card keeps its
+`access_id` and its credential material — an agent's reusable bearer, an OAuth
+client's token handles, a manual card's client-side token — and the new
+authority applies on the caller's next request, with no re-mint and no
+re-authorization.
+
+`delegated_access_update` validates and rewrites the record with this contract:
 
 | Input | Meaning |
 | --- | --- |
@@ -494,12 +522,6 @@ that materialized tree contains the exact operation set present at Save time;
 governed execution can therefore intersect the card with current
 `active.json.connections` without loading catalog history.
 
-At the current PR head, non-empty preservation and an immediate explicit clear
-work, but the clear state is not represented durably. After
-`named_service_operations: {}` stores an empty selection, a later update that
-omits the field can interpret that empty value as "no narrowing" and rebuild
-the full descriptor policy.
-
 The persisted `named_service_operations` field carries the complete policy:
 
 | Stored value | Meaning |
@@ -508,18 +530,28 @@ The persisted `named_service_operations` field carries the complete policy:
 | `{}` | Permit no named-service operation. |
 | Resource/namespace/operation map | Permit exactly the named entries. |
 
-The list response must retain both `"*"` and `{}`. New records always persist
-one of the three forms; field omission remains an update-request instruction,
-not stored policy. A **pre-migration card record** is an ordinary card written
-before `catalog_version`, `card_revision`, and this unambiguous encoding were
-introduced. Such a record cannot be interpreted from an empty
-`named_service_operations` map alone because older full-boundary records
-serialized the same value. Lazy migration inspects raw field presence and the
-persisted materialized `named_services` boundary, derives the prior exact
-operation set, and does not mutate on GET. If those facts conflict, GET
-preserves the effective narrowed selection and asks for an explicit choice on
-Save; it does not guess. The next successful Save writes the explicit new
-representation.
+The list response retains both `"*"` and `{}`. New records always persist one of
+the three forms.
+
+Omission means different things per direction:
+
+| Direction | Omitted `named_service_operations` |
+| --- | --- |
+| create | `{}`. Claims do not select operations; `"*"` is stored only when the user chose every operation the current catalog offers. |
+| update | Preserve the card's own policy. A preserved `"*"` is written out as the exact set it already meant, so an unrelated save cannot re-pin it to a newer catalog. |
+
+A **pre-migration card record** is an ordinary card written before
+`catalog_version`, `card_revision`, and this encoding were introduced. Its prior
+set is derived from the persisted materialized `named_services` boundary; GET
+does not mutate it. Where that derivation would change authority silently, the
+server reports `migration_confirmation_required` and refuses a save that carries
+no explicit selection:
+
+| Condition | Why it is not derivable |
+| --- | --- |
+| The boundary names no operation. | Deriving yields `{}`, indistinguishable from a deliberate empty selection. |
+| The derived set is empty against the active catalog. | The migration would revoke without an operator decision. |
+| The card holds more than one named-service resource. | The boundary is stored as one merged tree; per-resource attribution is not recoverable. |
 
 When an existing `"*"` card is saved after catalog drift without an explicit
 new wildcard choice, the backend expands the wildcard against the saved
@@ -529,24 +561,29 @@ from the current catalog and binds that wildcard to the new version.
 
 ### Agent card
 
-Demand-driven approval merges by default so separate approved demands
-accumulate. An edit calls the same creation service with
-`merge_existing=False`; submitted resource claims replace that resource's
-selection, while omitted `account_scope` and `named_service_operations`
-preserve their stored values. Explicit empty maps clear those dimensions.
+An agent card has a second entrance: the consent demand. It MERGES exactly the
+capability that was refused — the namespace and operation the demand names, with
+the claims and account binding they need — into the card's existing selection.
+The card's own side is frozen into what it already meant before the merge, so a
+one-click approval never re-pins a `"*"` to a newer catalog.
 
-The current ordinary agent-card editor exposes resource claims and account
-scope. Pending consent can submit exact named-service operations. The backend
-supports the same absent/empty/content contract when that field is supplied.
-The same wildcard/empty/exact persisted contract resolves the current
-empty-versus-absent ambiguity.
+`delegated_agent_grant_create` merges by default, so separate approved demands
+accumulate. With `replace: true` the submitted resource claims replace that
+resource's selection; omitted `account_scope` and `named_service_operations`
+preserve their stored values, and explicit empty maps clear those dimensions.
 
 ### OAuth card
 
 `extend_client_access` merges a one-click extension or replaces one resource's
-claims during edit. It also merges or replaces `account_scope`. The current
-OAuth card edit path does not rewrite `named_service_operations`; its
-named-service boundary remains the one established by OAuth consent.
+claims, and merges or replaces `account_scope`. It resolves authority through
+the same path as every other save, so it also rewrites
+`named_service_operations`, the materialized boundary, and the catalog stamp.
+
+Re-authorization is not required to change an OAuth card: the edit rewrites the
+live card and the existing pointer-backed bearer sees the new authority on its
+next call. A refresh rotation updates credential handles, expiry, and
+`last_issued_at` only — it neither restores an older operation selection nor
+widens one.
 
 ## Runtime Enforcement Lifecycle
 
@@ -566,7 +603,7 @@ request bearer
        flattened grants/scopes
        operations
        account_scope
-       named_services materialized boundary, when present
+       named_services materialized boundary, always set
   -> enforce outer resource/tool gate
   -> enforce named-service namespace/operation boundary
   -> resolve a permitted connected account and its claims, when required
@@ -578,9 +615,12 @@ authority fails closed. Revocation deletes the card and invalidates the
 source-specific session/token records, so an in-flight bearer cannot recover
 authority from its older embedded snapshot.
 
-Legacy bindings without `registry_access_id` retain embedded-snapshot
-semantics. A card written before the internal `named_services` field keeps the
-binding's original named-service snapshot until its first compatible save.
+Legacy bindings without `registry_access_id` retain embedded-snapshot semantics
+for the card's own facts; the active-catalog intersection still applies to them.
+
+The named-service boundary is always carried, including when it is empty. An
+absent boundary would leave the descriptor as the only ceiling, so a card that
+materialized nothing permits nothing.
 
 ## Descriptor And Catalog Drift
 
@@ -592,43 +632,30 @@ current catalog        = what the deployment offers now
 effective authority    = never more than both permit
 ```
 
-The current implementation does not yet satisfy that last equation for every
-dimension after a descriptor change.
-
-### Current behavior
+### Behavior on a descriptor change
 
 | Descriptor change | Card/list behavior | Runtime behavior |
 | --- | --- | --- |
-| A claim or operation is added | It appears in the live create/edit catalog. Existing cards do not select it automatically. | Existing explicit selections do not gain it. |
-| A stored top-level claim is removed | Claim edit unions stored and current values, so the stale claim remains visible and removable. | The live guard currently copies stored `resource_grants` without clamping them to the current resource ceiling. |
-| A stored named-service operation is removed | Read-only view still shows the stored operation. The edit picker omits it because rows come from the live catalog. Strict save then rejects the invisible stale value as unknown. | The card's materialized `named_services` snapshot still includes the operation, so the inner bridge can continue to admit it. |
-| A whole stored resource is removed | The card still names it, while current resource metadata is absent. A normal save fails current-resource validation. | Pointer resolution still projects the stored resource grant. |
+| A claim or operation is added | It appears in the live create/edit catalog, unchecked. Existing cards do not select it automatically. | Existing selections do not gain it; a card holding `"*"` is bound to the catalog version it was saved against. |
+| A stored top-level claim is removed | Drift marks it removed; the claim editor still renders it so it can be unticked, and Save prunes it. | The governed call intersects the card with the active catalog and denies it. |
+| A stored named-service operation is removed | Drift marks it removed and states that it is already ineffective. | Denied immediately, even while provider code still implements the operation. |
+| A whole stored resource is removed | Drift marks the resource removed; Save prunes it, and a card left with no authority is revoked rather than kept. | Denied immediately. |
 
-The named-service case makes the card a dead end: the operator cannot untick an
-operation that the picker no longer renders, and unrelated edits fail until
-the descriptor is restored or the card is revoked.
+Two mechanisms hold that together:
 
-### Required reconciliation contract
+1. **Enforcement clamps immediately.** A governed call reads complete cached
+   `active.json` from Redis and intersects its embedded `connections` mapping
+   with the card. A Redis TTL miss reads through to the committed durable
+   `active.json` and repopulates Redis with the configured fixed TTL. It returns
+   `503 temporarily_unavailable` when that document cannot be obtained or its
+   `content_hash` does not match its embedded mapping.
+2. **The editor explains and repairs stored drift.** List and edit return a
+   server-computed drift projection. The UI shows **Service access changed since
+   this grant was last saved**, with details: removed selections are already
+   ineffective and are removed on save; newly available choices stay unchecked
+   until explicitly granted.
 
-The fix has two independent parts and both are required:
-
-1. **Enforcement clamps immediately.** A descriptor removal must reduce
-   effective authority before the user opens or saves the card. The enforcing
-   path needs an authoritative current ceiling without coupling a generic
-   surface guard to Connection Hub's storage or transport details. A governed
-   call reads complete cached `active.json` from Redis and intersects its
-   embedded `connections` mapping with the card. A Redis TTL miss may read
-   through to complete committed durable `active.json` and repopulate Redis
-   with the configured fixed TTL. It returns `503 temporarily_unavailable` if
-   that document cannot be obtained or its `content_hash` does not match its
-   embedded mapping.
-2. **The editor explains and repairs stored drift.** List/edit should return a
-   server-computed drift projection. The UI shows a visible warning such as
-   **Service access changed since this grant was last saved**, with details:
-   removed selections are no longer effective and will be removed on save;
-   newly available choices remain unchecked until explicitly granted.
-
-Save should reconcile in this order:
+Save reconciles in this order:
 
 ```text
 stored selection
@@ -746,10 +773,8 @@ instance for process-local reconciliation; `on_bundle_load` remains
 per-process initialization and does not publish catalog state. The same event
 also invokes coordinated `on_app_deploy` regardless of singleton mode.
 
-A future Access Map mutation persists the authoritative props and awaits the
-generic app-deployment coordinator before reporting success. Card list/create/
-update and governed-operation paths never publish or modify durable catalog
-history. They may restore an expired Redis cache entry from an already
+Card list/create/update and governed-operation paths never publish or modify
+durable catalog history. They may restore an expired Redis cache entry from an already
 committed document. They consume the registered active catalog represented by
 cached `active.json`.
 Effective props participate only in `on_app_deploy` alignment; they are not a
@@ -877,15 +902,15 @@ Those fields come from three request-time inputs:
 | Claim | The exact current resource/operation policy check that failed. |
 
 The managed REST/MCP guard checks resource, claims, and outer operation. The
-common named-service dispatcher performs the inner resource/namespace/
-operation check after request decoding and before provider selection or call.
-This placement supplies the same complete path for MCP, direct API, and native
-agent named-service calls.
+inner resource/namespace/operation check runs after request decoding and before
+provider selection, at each entrance a delegated call can take:
 
-The current outer MCP helper extracts only RPC id and tool name and discards
-tool arguments. Therefore implementation must carry the validated card context
-into common named-service dispatch and check the parsed `NamedServiceRequest`.
-It must not infer namespace or inner operation by parsing a tool name.
+| Entrance | Where the inner check runs |
+| --- | --- |
+| MCP door | `kdcube-services@1-0` named-services bridge, on the parsed `NamedServiceRequest`. |
+| Native agent turn | The per-agent gate, on the namespace and operation the tool call names. |
+
+Neither infers namespace or inner operation by parsing a tool name.
 
 No historical catalog body is required on this request path. Exact membership
 in the card proves the capability belonged to its stored selection; absence
@@ -927,14 +952,17 @@ grant operation, not a pointer move to a historical revision.
 | Concern | Implementation |
 | --- | --- |
 | Capability/resource vocabulary and parser aliases | `kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.oauth.config` |
-| Current Redis-only record, keys, and operation orchestration | `kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.automation_access` |
-| Required durable revisions and current pointer | planned `...delegated_credentials.cards.store.DelegatedCardStore` over Connection Hub bundle storage |
-| Required TTL live projection and read-through | planned `...delegated_credentials.cards.cache` |
-| Durable catalog history | planned `...delegated_credentials.catalog.store` and `.publisher`, using immutable version documents and complete `active.json` |
-| Request-serving catalog cache | planned async `...delegated_credentials.catalog.runtime_cache.DelegatedCatalogRuntimeCache`; Redis stores complete TTL-cached `active.json` and historical version documents, with atomic no-downgrade active updates |
-| Current catalog resolution | planned `...delegated_credentials.catalog.resolver`, reading complete Redis `active.json` on each request; no props input, second active-body lookup, or process catalog cache |
-| Runtime-cache recovery | planned request-time durable read-through in `...delegated_credentials.catalog.resolver`; `on_app_deploy` publication remains in `.publisher` |
-| Current-capability denial shaping | planned shared `authorize_current_capability(...)`, called by the managed REST/MCP guard and common named-service dispatcher with the complete parsed capability path |
+| Card operations and authority orchestration | `kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.automation_access` |
+| Authority resolution shared by every save | `automation_access.AutomationAccessService._resolve_card_authority` |
+| Durable revisions and current pointer | `...delegated_credentials.cards.store.DelegatedCardStore` over Connection Hub bundle storage |
+| Persistence port, TTL live projection and read-through | `...delegated_credentials.cards.persistence`, `.cache`, `.handles`, `.resolver` |
+| Stored selection states and card model | `...delegated_credentials.cards.model` |
+| Pre-encoding record interpretation | `...delegated_credentials.cards.migration` |
+| Durable catalog history and publication | `...delegated_credentials.catalog.store` and `.publisher`, immutable version documents and complete `active.json` |
+| Current catalog resolution and read-through recovery | `...delegated_credentials.catalog.resolver` |
+| Current-capability denial shaping | `...delegated_credentials.catalog.authorization.authorize_current_capability` and `card_boundary_denial` |
+| Save-time drift and reconciliation | `...delegated_credentials.catalog.drift`, `.reconcile` |
+| OAuth consent view model and contract | `...delegated_credentials.oauth.consent`, `.http.routes` |
 | Named-service strict narrowing and materialization | `...delegated_credentials.named_service_policy` |
 | Descriptor namespace/operation projection | `...solutions.named_services_providers.boundary_policy.NamedServiceBoundaryCatalog` |
 | Live provider requirement enrichment | `automation_access.AutomationAccessService._named_service_options` plus provider discovery `spec.metadata.connected_accounts` |

--- a/app/ai-app/docs/sdk/solutions/connections/delegated-cards/delegated-cards-README.md
+++ b/app/ai-app/docs/sdk/solutions/connections/delegated-cards/delegated-cards-README.md
@@ -462,11 +462,21 @@ consent_contract.version
 catalog_version
 platform_grants
 tools                       (outer operations)
-named_service_operations    (namespace, operation, required claims)
+named_service_operations    (namespace, operation, required claims, held)
 connected_accounts
 seeded_account_scope
+seeded_named_service_operations
 request / oauth_request     (client and PKCE metadata)
 ```
+
+`seeded_named_service_operations` is what the client's card covers today, read
+from its materialized boundary — so a wildcard card seeds the expansion it is
+pinned to, not the current catalog. Each `named_service_operations` row carries
+`held` for the same fact per row. A submission REPLACES the card's selection,
+so a renderer that cannot tell a held operation from a newly offered one cannot
+offer an informed choice: it would present an empty picker whose quiet
+submission removes the whole grant. The built-in page checks held operations and
+lists the rest under "added since this client was last approved".
 
 A renderer returns the contract version it implements alongside its HTML. An
 absent or mismatched version is refused with `consent_ui_contract_mismatch`
@@ -480,7 +490,7 @@ The submitted form carries `consent_contract_version`,
 | --- | --- |
 | Every offered operation selected | `"*"`, bound to the catalog version shown on the page. |
 | Some operations selected | That exact selection, re-validated against the catalog. |
-| None selected | `{}`. The connection is created without named-service access and can be widened later in Connection Hub. |
+| None selected | `{}`. On a first consent the connection is created without named-service access; on a re-consent this REMOVES every operation the card held. Both can be widened later in Connection Hub. |
 | `consent_contract_version` absent | No authorization code and no card. |
 | `expected_catalog_version` no longer active | `consent_catalog_changed`; authorization restarts rather than reinterpreting the selection. |
 

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/ingress/web_app.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/ingress/web_app.py
@@ -290,6 +290,20 @@ async def lifespan(app: FastAPI):
         )
     except Exception as e:
         logger.warning("Failed to install Connection Hub authentication surface: %s", e)
+
+    try:
+        from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.serving import (
+            install_delegated_serving_resolvers,
+        )
+
+        await install_delegated_serving_resolvers(
+            app,
+            redis=getattr(app.state, "redis_async", None),
+            tenant=settings.TENANT,
+            project=settings.PROJECT,
+        )
+    except Exception as e:
+        logger.warning("Failed to install delegated serving resolvers: %s", e)
     try:
         from kdcube_ai_app.apps.middleware.economics_role import EconomicsRoleResolver
         _econ_role_resolver = EconomicsRoleResolver(

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/proc/web_app.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/proc/web_app.py
@@ -360,6 +360,20 @@ async def lifespan(app: FastAPI):
         logger.warning("Failed to install Connection Hub authentication surface: %s", e)
 
     try:
+        from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.serving import (
+            install_delegated_serving_resolvers,
+        )
+
+        await install_delegated_serving_resolvers(
+            app,
+            redis=getattr(app.state, "redis_async", None),
+            tenant=settings.TENANT,
+            project=settings.PROJECT,
+        )
+    except Exception as e:
+        logger.warning("Failed to install delegated serving resolvers: %s", e)
+
+    try:
         from kdcube_ai_app.apps.middleware.economics_role import EconomicsRoleResolver
         _econ_role_resolver = EconomicsRoleResolver(
             pg_pool=app.state.pg_pool,

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/examples/bundles/connection-hub@1-0/config/bundles.template.yaml
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/examples/bundles/connection-hub@1-0/config/bundles.template.yaml
@@ -80,6 +80,22 @@ bundles:
             # Empty -> derived from the request host at runtime.
           public_base_url: "https://<PUBLIC_HOST>"
         delegated_credentials:
+            # Redis residency of the delegated-service catalog projections.
+            # These bound how long a cached document survives before a validated
+            # read-through; they never grant, extend, or revoke authority.
+          catalog:
+              # The ceiling every governed call intersects against. Expiry
+              # forces the read-through that repairs a corrupted entry.
+            active_cache_seconds: 300
+              # Immutable historical versions, read only to explain card drift.
+            version_cache_seconds: 3600
+            # Short fail-closed card markers.
+          cards:
+              # Must outlive a worst-case durable commit and stay short: a
+              # crashed mutation blocks that card until it expires.
+            updating_marker_seconds: 15
+              # Negative cache after revoke; revocation itself is durable.
+            revoked_tombstone_seconds: 60
           oauth:
             enabled: false
             brand: "KDCube"

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/examples/bundles/connection-hub@1-0/entrypoint.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/examples/bundles/connection-hub@1-0/entrypoint.py
@@ -203,6 +203,23 @@ def _payload(data: Optional[Mapping[str, Any]] = None, **kwargs: Any) -> Dict[st
     return merged
 
 
+def _expected_card_revision(payload: Mapping[str, Any]) -> Optional[int]:
+    """The revision the editor loaded. Absent means no precondition.
+
+    A malformed value raises rather than defaulting, so a bad request cannot
+    read as a stale-editor conflict.
+    """
+    if "expected_card_revision" not in payload:
+        return None
+    raw = payload.get("expected_card_revision")
+    if raw is None or raw == "":
+        return None
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        raise ValueError("expected_card_revision must be an integer")
+
+
 def _bool(value: Any, default: bool = False) -> bool:
     if value is None:
         return default
@@ -2038,6 +2055,11 @@ class ConnectionHubEntrypoint(BaseEntrypoint):
                     else None
                 ),
                 label=str(payload.get("label") or "").strip() or None,
+                expected_card_revision=_expected_card_revision(payload),
+                expected_catalog_version=str(
+                    payload.get("expected_catalog_version") or ""
+                ).strip()
+                or None,
             )
         except ValueError as exc:
             return {"ok": False, "error": "invalid_delegated_access_request", "message": str(exc)}

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/examples/bundles/connection-hub@1-0/entrypoint.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/examples/bundles/connection-hub@1-0/entrypoint.py
@@ -230,6 +230,21 @@ def _bool(value: Any, default: bool = False) -> bool:
     return str(value).strip().lower() in {"1", "true", "yes", "on", "enabled"}
 
 
+def _named_service_operations_for(payload: Mapping[str, Any], resource: str) -> Any:
+    """The card-level selection a per-resource grant payload carries.
+
+    The demand names one door, so its payload names namespaces under that door;
+    `"*"` is card-level and travels as the string. Absent stays absent — the
+    service decides what an omitted selection means per entrance.
+    """
+    raw = payload.get("named_service_operations")
+    if isinstance(raw, str):
+        return raw.strip() or None
+    if isinstance(raw, Mapping) and raw:
+        return {resource: dict(raw)}
+    return None
+
+
 def _safe_list(value: Any) -> list[str]:
     if value is None:
         return []
@@ -2114,6 +2129,7 @@ class ConnectionHubEntrypoint(BaseEntrypoint):
                 resource=resource,
                 claims=claims,
                 account_scope=account_scope,
+                named_service_operations=_named_service_operations_for(payload, resource),
                 replace=bool(payload.get("replace")),
                 # Optional rename: a DCR client registers one fixed name, so the
                 # user may label the card. Empty keeps the existing name.
@@ -2124,10 +2140,7 @@ class ConnectionHubEntrypoint(BaseEntrypoint):
         # Optional named-service narrowing for THIS resource (namespace -> exact
         # operations), same selector the manual create flow sends — so extending
         # an agent's access from the hub can include named-service resources.
-        raw_ns = payload.get("named_service_operations")
-        named_service_operations = (
-            {resource: dict(raw_ns)} if isinstance(raw_ns, Mapping) and raw_ns else None
-        )
+        named_service_operations = _named_service_operations_for(payload, resource)
         # Default = MERGE (a one-click grant accumulates). `replace: true` is
         # the EDIT semantics: the submitted claim set becomes the record exactly
         # (the user unchecked something). Removing everything is a revoke, not

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/examples/bundles/connection-hub@1-0/entrypoint.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/examples/bundles/connection-hub@1-0/entrypoint.py
@@ -71,6 +71,12 @@ from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.cac
 from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.catalog.publisher import (
     ensure_delegated_catalog,
 )
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.cards.persistence import (
+    DurableCardPersistence,
+)
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.cards.store import (
+    BundleStorageDelegatedCardStore,
+)
 from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.catalog.resolver import (
     DelegatedCatalogResolver,
 )
@@ -580,6 +586,15 @@ def _bind_delegated_client_request_config(entrypoint: Any, request: Any) -> Dict
             )
         except Exception:
             request.state.connections_delegated_config = None
+        # The delegated-access service is composed here because only the bundle
+        # knows its storage root and catalog. SDK request code receives the
+        # capability and never builds it. Lazy: most OAuth requests never touch
+        # it, and the frozen config keeps a later build consistent with what
+        # this request validated.
+        parsed = oauth_delegated_config(request)
+        request.state.automation_access_factory = (
+            lambda: _automation_access_service_for(entrypoint, parsed)
+        )
     return cfg
 
 
@@ -606,15 +621,45 @@ def _delegated_catalog_resolver(entrypoint: Any, redis: Any) -> Any:
     )
 
 
-def _automation_access_service(entrypoint: Any, request: Any) -> AutomationAccessService:
+def _delegated_card_persistence(entrypoint: Any, redis: Any) -> Any:
+    """Durable card persistence, or ``None`` when bundle storage is
+    unavailable — card operations then fail closed."""
+    storage_root = entrypoint.bundle_storage_root()
+    if storage_root is None:
+        return None
+    tenant, project = _runtime_tenant_project(entrypoint)
+    return DurableCardPersistence(
+        redis=redis,
+        tenant=tenant,
+        project=project,
+        card_store=BundleStorageDelegatedCardStore(storage_root),
+        settings=DelegatedCacheSettings.from_connections(_connections_config(entrypoint)),
+    )
+
+
+def _automation_access_service_for(entrypoint: Any, config: Any) -> AutomationAccessService:
+    """Build the service against an already-resolved delegated-client config.
+
+    The config is the request's authorization input, so it is frozen by the
+    caller rather than re-read here: bundle props are runtime-mutable, and a
+    later rebuild could otherwise act under a config the handler never
+    validated.
+    """
     tenant, project = _runtime_tenant_project(entrypoint)
     redis = getattr(entrypoint, "redis", None) or get_async_redis_client(get_settings().REDIS_URL)
     return AutomationAccessService(
         redis=redis,
         tenant=tenant,
         project=project,
-        config=_delegated_oauth_config_from_entrypoint(entrypoint, request),
+        config=config,
         catalog_resolver=_delegated_catalog_resolver(entrypoint, redis),
+        card_persistence=_delegated_card_persistence(entrypoint, redis),
+    )
+
+
+def _automation_access_service(entrypoint: Any, request: Any) -> AutomationAccessService:
+    return _automation_access_service_for(
+        entrypoint, _delegated_oauth_config_from_entrypoint(entrypoint, request)
     )
 
 

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/examples/bundles/connection-hub@1-0/entrypoint.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/examples/bundles/connection-hub@1-0/entrypoint.py
@@ -65,6 +65,24 @@ from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.acc
 from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.automation_access import (
     AutomationAccessService,
 )
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.cache_settings import (
+    DelegatedCacheSettings,
+)
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.catalog.publisher import (
+    ensure_delegated_catalog,
+)
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.catalog.resolver import (
+    DelegatedCatalogResolver,
+)
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.catalog.runtime_cache import (
+    DelegatedCatalogRuntimeCache,
+)
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.catalog.source import (
+    connections_from_props,
+)
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.catalog.store import (
+    BundleStorageDelegatedCatalogStore,
+)
 from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_to_kdcube import (
     RedisOAuthStateStore,
     DelegatedToKdcubeStore,
@@ -573,6 +591,21 @@ def _delegated_oauth_config_from_entrypoint(entrypoint: Any, request: Any) -> An
     return oauth_delegated_config(SimpleNamespace(state=state))
 
 
+def _delegated_catalog_resolver(entrypoint: Any, redis: Any) -> Any:
+    """Resolver over this bundle's registered catalog, or ``None`` when its
+    storage root is unavailable — card writes then fail closed."""
+    storage_root = entrypoint.bundle_storage_root()
+    if storage_root is None:
+        return None
+    tenant, project = _runtime_tenant_project(entrypoint)
+    connections = _connections_config(entrypoint)
+    return DelegatedCatalogResolver(
+        cache=DelegatedCatalogRuntimeCache(redis, tenant=tenant, project=project),
+        store=BundleStorageDelegatedCatalogStore(storage_root),
+        settings=DelegatedCacheSettings.from_connections(connections),
+    )
+
+
 def _automation_access_service(entrypoint: Any, request: Any) -> AutomationAccessService:
     tenant, project = _runtime_tenant_project(entrypoint)
     redis = getattr(entrypoint, "redis", None) or get_async_redis_client(get_settings().REDIS_URL)
@@ -581,6 +614,7 @@ def _automation_access_service(entrypoint: Any, request: Any) -> AutomationAcces
         tenant=tenant,
         project=project,
         config=_delegated_oauth_config_from_entrypoint(entrypoint, request),
+        catalog_resolver=_delegated_catalog_resolver(entrypoint, redis),
     )
 
 
@@ -1316,6 +1350,45 @@ class ConnectionHubEntrypoint(BaseEntrypoint):
             self._named_service_registry = registry
         return self._named_service_registry
 
+    async def on_app_deploy(self, **kwargs: Any) -> None:
+        """Publish the delegated-service catalog for this app generation.
+
+        The generation is ready only after the immutable version and the
+        complete active document are committed durably and in Redis. Request
+        paths never publish; they may only restore an expired projection.
+        """
+        await super().on_app_deploy(**kwargs)
+        props = kwargs.get("props")
+        if props is None:
+            props = getattr(self, "bundle_props", None)
+        storage_root = kwargs.get("storage_root") or self.bundle_storage_root()
+        if storage_root is None:
+            raise RuntimeError(
+                "[connection-hub] on_app_deploy: bundle storage is unavailable; "
+                "the delegated catalog cannot be published"
+            )
+        redis = kwargs.get("redis") or getattr(self, "redis", None)
+        if redis is None:
+            redis = get_async_redis_client(get_settings().REDIS_URL)
+        tenant = str(kwargs.get("tenant") or "").strip()
+        project = str(kwargs.get("project") or "").strip()
+        if not (tenant and project):
+            tenant, project = _runtime_tenant_project(self)
+
+        connections = connections_from_props(props)
+        result = await ensure_delegated_catalog(
+            connections=connections,
+            store=BundleStorageDelegatedCatalogStore(storage_root),
+            cache=DelegatedCatalogRuntimeCache(redis, tenant=tenant, project=project),
+            settings=DelegatedCacheSettings.from_connections(connections),
+            reason=str(kwargs.get("reason") or "app_deploy"),
+        )
+        LOGGER.info(
+            "[connection-hub] on_app_deploy: delegated catalog version=%s created=%s",
+            result.version,
+            result.created,
+        )
+
     async def on_bundle_load(self, **kwargs: Any) -> None:
         # BaseEntrypoint.on_bundle_load (via super) publishes named-service
         # discovery from _named_service_providers().
@@ -1863,11 +1936,11 @@ class ConnectionHubEntrypoint(BaseEntrypoint):
                 label=str(payload.get("label") or "").strip(),
                 resource_grants=dict(payload.get("resource_grants") or {}),
                 operations=_safe_list(payload.get("operations")),
-                # Both preserve absent vs empty: None leaves the dimension
-                # unrestricted, an empty mapping restricts to nothing.
-                # broker.py keys on `is not None`.
+                # Both preserve absent vs empty. An omitted selection keeps the
+                # record's own state; "*" is the full policy of the saved
+                # catalog, and {} allows no named-service operation.
                 named_service_operations=(
-                    dict(payload.get("named_service_operations") or {})
+                    payload.get("named_service_operations")
                     if "named_service_operations" in payload
                     else None
                 ),
@@ -1910,7 +1983,7 @@ class ConnectionHubEntrypoint(BaseEntrypoint):
                 access_id=str(payload.get("access_id") or "").strip(),
                 resource_grants=dict(payload.get("resource_grants") or {}),
                 named_service_operations=(
-                    dict(payload.get("named_service_operations") or {})
+                    payload.get("named_service_operations")
                     if "named_service_operations" in payload
                     else None
                 ),

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/examples/bundles/connection-hub@1-0/tests/test_delegated_access_create.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/examples/bundles/connection-hub@1-0/tests/test_delegated_access_create.py
@@ -124,3 +124,70 @@ async def test_named_service_operations_keep_their_absent_semantics(entrypoint):
         data={"label": "x", "resource_grants": {"res": ["named_services:use"]}},
     )
     assert entrypoint.service.calls[-1]["named_service_operations"] is None
+
+
+# -- save preconditions ---------------------------------------------------------
+
+
+def test_service_still_accepts_the_save_preconditions():
+    parameters = inspect.signature(AutomationAccessService.update_access).parameters
+    assert "expected_card_revision" in parameters
+    assert "expected_catalog_version" in parameters
+
+
+@pytest.mark.asyncio
+async def test_update_forwards_the_editor_preconditions(entrypoint):
+    await entrypoint.module.ConnectionHubEntrypoint.delegated_access_update(
+        entrypoint.instance,
+        data={
+            "access_id": "aut_1",
+            "resource_grants": {"res": ["named_services:use"]},
+            "expected_card_revision": 8,
+            "expected_catalog_version": "delegated_catalog_2026-08-14-10-00-00-000_abcdef012345",
+        },
+    )
+    call = entrypoint.service.calls[-1]
+    assert call["expected_card_revision"] == 8
+    assert call["expected_catalog_version"] == (
+        "delegated_catalog_2026-08-14-10-00-00-000_abcdef012345"
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_revision_sent_as_a_string_is_accepted(entrypoint):
+    await entrypoint.module.ConnectionHubEntrypoint.delegated_access_update(
+        entrypoint.instance,
+        data={
+            "access_id": "aut_1",
+            "resource_grants": {"res": ["named_services:use"]},
+            "expected_card_revision": "8",
+        },
+    )
+    assert entrypoint.service.calls[-1]["expected_card_revision"] == 8
+
+
+@pytest.mark.asyncio
+async def test_absent_preconditions_stay_none(entrypoint):
+    await entrypoint.module.ConnectionHubEntrypoint.delegated_access_update(
+        entrypoint.instance,
+        data={"access_id": "aut_1", "resource_grants": {"res": ["named_services:use"]}},
+    )
+    call = entrypoint.service.calls[-1]
+    assert call["expected_card_revision"] is None
+    assert call["expected_catalog_version"] is None
+
+
+@pytest.mark.asyncio
+async def test_a_malformed_revision_is_a_bad_request_not_a_conflict(entrypoint):
+    """A conflict means the editor is stale; a broken field is neither."""
+    result = await entrypoint.module.ConnectionHubEntrypoint.delegated_access_update(
+        entrypoint.instance,
+        data={
+            "access_id": "aut_1",
+            "resource_grants": {"res": ["named_services:use"]},
+            "expected_card_revision": "not-a-number",
+        },
+    )
+    assert result["ok"] is False
+    assert result["error"] == "invalid_delegated_access_request"
+    assert entrypoint.service.calls == []

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/examples/bundles/connection-hub@1-0/ui/widgets/connections/src/App.tsx
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/examples/bundles/connection-hub@1-0/ui/widgets/connections/src/App.tsx
@@ -228,7 +228,7 @@ export default function App() {
         // offer its one-click grant pane; the nonce remounts it to re-read.
         try {
           const url = new URL(window.location.href);
-          (['pending_agent_grant', 'agent_client_id', 'manual_access_id', 'resource', 'claims', 'account_id', 'account_claim'] as const).forEach((key) => {
+          (['pending_agent_grant', 'agent_client_id', 'manual_access_id', 'resource', 'claims', 'namespace', 'operation', 'account_id', 'account_claim'] as const).forEach((key) => {
             const value = (params[key] || '').trim();
             if (value) url.searchParams.set(key, value);
             else url.searchParams.delete(key);

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/examples/bundles/connection-hub@1-0/ui/widgets/connections/src/api/types.ts
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/examples/bundles/connection-hub@1-0/ui/widgets/connections/src/api/types.ts
@@ -117,6 +117,11 @@ export interface DelegatedAccessResourceOption {
 
 export type DelegatedAccessNamedServiceOperations = Record<string, Record<string, string[]>>;
 
+/** The stored selection as the server returns it, verbatim. `"*"` means every
+ *  operation the acknowledged catalog offers; a map is an exact choice; an
+ *  empty map is an explicit "nothing". Agent grants carry the wildcard. */
+export type DelegatedAccessStoredNamedServices = '*' | DelegatedAccessNamedServiceOperations;
+
 export interface DelegatedAccessRecord {
   access_id: string;
   label?: string;
@@ -124,7 +129,7 @@ export interface DelegatedAccessRecord {
   delegate_subject?: string;
   operations?: string[];
   resource_grants?: Record<string, string[]>;
-  named_service_operations?: DelegatedAccessNamedServiceOperations;
+  named_service_operations?: DelegatedAccessStoredNamedServices;
   /** Per-account claim binding: {provider_id: {account_id: [claims]}}. For a
    *  provider, which connected account(s) this client may use AND, per account,
    *  the claims it may use there. account "*" = any account; claim "*" = any. */

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/examples/bundles/connection-hub@1-0/ui/widgets/connections/src/api/types.ts
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/examples/bundles/connection-hub@1-0/ui/widgets/connections/src/api/types.ts
@@ -130,6 +130,11 @@ export interface DelegatedAccessRecord {
   operations?: string[];
   resource_grants?: Record<string, string[]>;
   named_service_operations?: DelegatedAccessStoredNamedServices;
+  /** Derived, never authority: the selection above expanded under the catalog
+   *  version the card was saved against. `"*"` and a pre-encoding record name
+   *  no operations of their own, so this is the only way a surface can draw
+   *  what such a card actually covers. */
+  effective_named_service_operations?: DelegatedAccessNamedServiceOperations;
   /** Per-account claim binding: {provider_id: {account_id: [claims]}}. For a
    *  provider, which connected account(s) this client may use AND, per account,
    *  the claims it may use there. account "*" = any account; claim "*" = any. */

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/examples/bundles/connection-hub@1-0/ui/widgets/connections/src/api/types.ts
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/examples/bundles/connection-hub@1-0/ui/widgets/connections/src/api/types.ts
@@ -135,6 +135,10 @@ export interface DelegatedAccessRecord {
    *  no operations of their own, so this is the only way a surface can draw
    *  what such a card actually covers. */
   effective_named_service_operations?: DelegatedAccessNamedServiceOperations;
+  /** Card resource -> the catalog row that governs it. A card key is the row's
+   *  own pattern (hub-created) or a concrete URL (OAuth `resource`), so a
+   *  surface may not find its row by string equality. */
+  catalog_row_by_resource?: Record<string, string>;
   /** Per-account claim binding: {provider_id: {account_id: [claims]}}. For a
    *  provider, which connected account(s) this client may use AND, per account,
    *  the claims it may use there. account "*" = any account; claim "*" = any. */

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/examples/bundles/connection-hub@1-0/ui/widgets/connections/src/api/types.ts
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/examples/bundles/connection-hub@1-0/ui/widgets/connections/src/api/types.ts
@@ -134,6 +134,53 @@ export interface DelegatedAccessRecord {
   expires_at?: number;
   last_four?: string;
   source?: 'manual' | 'oauth' | string;
+  /** Monotonic revision; sent back on save so a stale editor is refused. */
+  card_revision?: number;
+  /** The catalog generation this card was last saved against. */
+  catalog_version?: string;
+  /** Backend-computed comparison with the active catalog. */
+  catalog_drift?: DelegatedCatalogDrift;
+}
+
+/** A capability the card selected that the active catalog no longer offers.
+ *  Already ineffective; save removes it. */
+export interface DelegatedDriftRemoval {
+  resource: string;
+  claim?: string;
+  operation?: string;
+  namespace?: string;
+  was_selected?: boolean;
+  effect?: 'denied_immediately' | string;
+}
+
+/** A capability the catalog gained since the card was saved. Never selected. */
+export interface DelegatedDriftAddition {
+  resource: string;
+  claim?: string;
+  operation?: string;
+  namespace?: string;
+  selected?: boolean;
+}
+
+export interface DelegatedCatalogDrift {
+  status: 'current' | 'changed' | 'no_relevant_change' | 'baseline_missing' | 'unavailable';
+  saved_version?: string;
+  current_version?: string;
+  /** Set when the card's baseline could not be read; additions are unknown. */
+  baseline_confirmed_absent?: boolean;
+  /** Set on `unavailable`: editing authority is disabled. */
+  reason?: string;
+  removed?: {
+    resources?: DelegatedDriftRemoval[];
+    claims?: DelegatedDriftRemoval[];
+    outer_operations?: DelegatedDriftRemoval[];
+    named_service_operations?: DelegatedDriftRemoval[];
+  };
+  added?: {
+    claims?: DelegatedDriftAddition[];
+    outer_operations?: DelegatedDriftAddition[];
+    named_service_operations?: DelegatedDriftAddition[];
+  };
 }
 
 export interface DelegatedAccessListResult {
@@ -153,6 +200,20 @@ export interface DelegatedAccessCreateResult {
   authorization_header?: string;
   error?: string;
   message?: string;
+  /** Set by save when reconciliation dropped withdrawn selections. */
+  pruned?: {
+    resources?: string[];
+    claims?: Array<{ resource: string; claim: string }>;
+    named_service_operations?: Array<{ resource: string; namespace: string; operation: string }>;
+  };
+  /** Set when reconciliation left no authority and the card was revoked. */
+  revoked?: boolean;
+  /** Set on a 409: which precondition did not hold. */
+  status?: number;
+  mismatched?: {
+    card_revision?: { expected: number; actual: number };
+    catalog_version?: { expected: string; actual: string };
+  };
 }
 
 export interface DelegatedAccessRevokeResult {

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/examples/bundles/connection-hub@1-0/ui/widgets/connections/src/features/delegatedAccess/DelegatedAccessPanel.tsx
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/examples/bundles/connection-hub@1-0/ui/widgets/connections/src/features/delegatedAccess/DelegatedAccessPanel.tsx
@@ -8,6 +8,7 @@ import type {
   DelegatedAccessNamedServiceOperations,
   DelegatedAccessRecord,
   DelegatedAccessResourceOption,
+  DelegatedCatalogDrift,
   DelegatedToKdcubeAccount,
 } from '../../api/types';
 import {
@@ -415,6 +416,81 @@ function CountFold({ entries, noun }: { entries: string[]; noun: string }) {
       </button>
       {open ? <ChipRow entries={entries} /> : null}
     </span>
+  );
+}
+
+function driftLabel(row: { resource: string; namespace?: string; claim?: string; operation?: string }): string {
+  const parts = [doorAlias(row.resource) || row.resource];
+  if (row.namespace) parts.push(row.namespace);
+  parts.push(row.claim || row.operation || '');
+  return parts.filter(Boolean).join(' · ');
+}
+
+/** Backend-computed drift. The panel renders what the server decided; it never
+ *  compares catalogs itself. */
+function CatalogDriftNotice({ drift }: { drift?: DelegatedCatalogDrift }) {
+  if (!drift) return null;
+  if (drift.status === 'current' || drift.status === 'no_relevant_change') return null;
+
+  if (drift.status === 'unavailable') {
+    return (
+      <div className="notice" style={{ marginTop: 10, marginBottom: 10 }}>
+        <strong>Service access cannot be checked right now</strong>
+        <div>Editing is unavailable until the service catalog can be read again.</div>
+      </div>
+    );
+  }
+
+  const removed = [
+    ...(drift.removed?.resources || []),
+    ...(drift.removed?.claims || []),
+    ...(drift.removed?.outer_operations || []),
+    ...(drift.removed?.named_service_operations || []),
+  ];
+  const added = [
+    ...(drift.added?.claims || []),
+    ...(drift.added?.outer_operations || []),
+    ...(drift.added?.named_service_operations || []),
+  ];
+  if (!removed.length && !added.length && drift.status !== 'baseline_missing') return null;
+
+  return (
+    <div className="notice" style={{ marginTop: 10, marginBottom: 10 }}>
+      <strong>Service access changed since this grant was last saved</strong>
+      <details>
+        <summary>What changed</summary>
+        {removed.length ? (
+          <div>
+            <div className="card-field-label">No longer available</div>
+            <ul>
+              {removed.map((row) => (
+                <li key={`removed-${driftLabel(row)}`}>
+                  <code>{driftLabel(row)}</code> — already ineffective, removed when you save
+                </li>
+              ))}
+            </ul>
+          </div>
+        ) : null}
+        {added.length ? (
+          <div>
+            <div className="card-field-label">Newly available</div>
+            <ul>
+              {added.map((row) => (
+                <li key={`added-${driftLabel(row)}`}>
+                  <code>{driftLabel(row)}</code> — not granted; select it to allow
+                </li>
+              ))}
+            </ul>
+          </div>
+        ) : null}
+        {drift.status === 'baseline_missing' ? (
+          <div>
+            This grant predates the recorded service catalog, so newly available options
+            cannot be listed.
+          </div>
+        ) : null}
+      </details>
+    </div>
   );
 }
 
@@ -963,6 +1039,15 @@ export function DelegatedAccessPanel({ openParams }: { openParams?: Record<strin
     ]));
   };
 
+  /** Claims this card holds that the active catalog no longer offers, per the
+   *  backend's comparison. */
+  const withdrawnClaims = (item: DelegatedAccessRecord, resource: string): Set<string> => {
+    const rows = item.catalog_drift?.removed?.claims || [];
+    return new Set(
+      rows.filter((row) => row.resource === resource && row.claim).map((row) => row.claim as string),
+    );
+  };
+
   const saveEdit = async (item: DelegatedAccessRecord) => {
     const kept: Record<string, string[]> = {};
     Object.keys(item.resource_grants || {}).forEach((resource) => {
@@ -1001,6 +1086,10 @@ export function DelegatedAccessPanel({ openParams }: { openParams?: Record<strin
           ? keptNamedServiceOperations
           : undefined,
         accountScope: editAccountScope,
+        // What this editor was opened on. The server refuses the save when
+        // either moved.
+        expectedCardRevision: item.card_revision,
+        expectedCatalogVersion: item.catalog_drift?.current_version || item.catalog_version,
       })).unwrap().catch(() => undefined);
       clearEditState();
       void dispatch(loadDelegatedAccess());
@@ -1500,6 +1589,7 @@ export function DelegatedAccessPanel({ openParams }: { openParams?: Record<strin
                       ) : null}
                     </div>
                   ) : null}
+                  <CatalogDriftNotice drift={item.catalog_drift} />
                   {editing ? (
                     <label className="rename-row">
                       <span className="card-field-label">Name</span>
@@ -1522,16 +1612,29 @@ export function DelegatedAccessPanel({ openParams }: { openParams?: Record<strin
                             <div className="account-title">{resource === '*' ? 'all resources' : (doorAlias(resource) || resourceLabelFor(resource) || resource)}</div>
                             {resource !== '*' ? <DoorRef value={resource} /> : null}
                             <div className="resource-grants">
-                              {editableClaimsFor(item, resource).map((claim) => (
-                                <label className="grant-chip" key={`${resource}:${claim}`} title={grantOptionByName.get(claim)?.label || undefined}>
-                                  <input
-                                    type="checkbox"
-                                    checked={editPicks[`${resource}:${claim}`] === true}
-                                    onChange={(event) => toggleEditClaim(resource, claim, event.target.checked)}
-                                  />
-                                  <span>{claim}</span>
-                                </label>
-                              ))}
+                              {editableClaimsFor(item, resource).map((claim) => {
+                                const stale = withdrawnClaims(item, resource).has(claim);
+                                return (
+                                  <label
+                                    className={stale ? 'grant-chip grant-chip-stale' : 'grant-chip'}
+                                    key={`${resource}:${claim}`}
+                                    title={
+                                      stale
+                                        ? 'No longer offered by the service catalog — already ineffective, removed when you save'
+                                        : grantOptionByName.get(claim)?.label || undefined
+                                    }
+                                  >
+                                    <input
+                                      type="checkbox"
+                                      checked={editPicks[`${resource}:${claim}`] === true}
+                                      disabled={stale}
+                                      onChange={(event) => toggleEditClaim(resource, claim, event.target.checked)}
+                                    />
+                                    <span>{claim}</span>
+                                    {stale ? <span className="badge badge-warn">withdrawn</span> : null}
+                                  </label>
+                                );
+                              })}
                             </div>
                             {/* Namespace operations are stored per card and derived
                                 per request only for manual automations; the OAuth

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/examples/bundles/connection-hub@1-0/ui/widgets/connections/src/features/delegatedAccess/DelegatedAccessPanel.tsx
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/examples/bundles/connection-hub@1-0/ui/widgets/connections/src/features/delegatedAccess/DelegatedAccessPanel.tsx
@@ -67,6 +67,10 @@ type PendingAgentGrant = {
   // The user still ticks the checkbox explicitly; the picker is default-closed.
   accountId?: string;
   accountClaim?: string;
+  // The inner capability the refused call wanted. Approval grants this one
+  // operation, not everything its claims allow.
+  namespace?: string;
+  operation?: string;
 };
 
 function pendingAgentGrantFromParams(get: (key: string) => string): PendingAgentGrant | null {
@@ -77,7 +81,17 @@ function pendingAgentGrantFromParams(get: (key: string) => string): PendingAgent
   const claims = get('claims').split(',').map((item) => item.trim()).filter(Boolean);
   const accountId = get('account_id').trim();
   const accountClaim = get('account_claim').trim();
-  return { clientId, resource, claims, accountId: accountId || undefined, accountClaim: accountClaim || undefined };
+  const namespace = get('namespace').trim();
+  const operation = get('operation').trim();
+  return {
+    clientId,
+    resource,
+    claims,
+    accountId: accountId || undefined,
+    accountClaim: accountClaim || undefined,
+    namespace: namespace || undefined,
+    operation: operation || undefined,
+  };
 }
 
 /** The pending per-agent grant a chat consent card carries here — as the
@@ -445,10 +459,43 @@ function cardNamedServiceOperations(
   return selection as DelegatedAccessNamedServiceOperations;
 }
 
+/** Whether this card's doors configure named services at all.
+ *
+ *  Separates "covers nothing" from "there is nothing to cover". Only the first
+ *  is worth a row: a card that selected no operation reaches none of them, and
+ *  drawing nothing reads as if the question did not apply. */
+function cardOffersNamedServices(
+  item: DelegatedAccessRecord,
+  resources: DelegatedAccessResourceOption[],
+): boolean {
+  const offered = offeredNamedServiceOperations(
+    resources,
+    Object.keys(item.resource_grants || {}),
+    (key) => (item.catalog_row_by_resource || {})[key] || key,
+  );
+  return Object.keys(offered).length > 0;
+}
+
+/** One row per namespace the card covers.
+ *
+ *  Rows are merged across doors. A wildcard and a pre-encoding card store ONE
+ *  materialized tree for the whole card, and the projection attributes that
+ *  same tree to every door the card holds — printing it once per door states a
+ *  per-door fact the card does not carry. */
 function namedServiceRows(item: DelegatedAccessRecord): string[] {
-  return Object.values(cardNamedServiceOperations(item))
-    .flatMap((namespaces) => Object.entries(namespaces || {}))
-    .map(([namespace, operations]) => `${namespace} (${(operations || []).join(', ')})`);
+  const merged = new Map<string, Set<string>>();
+  Object.values(cardNamedServiceOperations(item)).forEach((namespaces) => {
+    Object.entries(namespaces || {}).forEach(([namespace, operations]) => {
+      const held = merged.get(namespace) || new Set<string>();
+      (operations || []).forEach((operation) => held.add(operation));
+      merged.set(namespace, held);
+    });
+  });
+  return Array.from(merged.entries())
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([namespace, operations]) => (
+      `${namespace} (${Array.from(operations).sort().join(', ')})`
+    ));
 }
 
 /** Every named-service operation the ACTIVE catalog offers for these resources.
@@ -458,19 +505,38 @@ function namedServiceRows(item: DelegatedAccessRecord): string[] {
 function offeredNamedServiceOperations(
   resources: DelegatedAccessResourceOption[],
   forResources: string[],
+  // The create form picks resources FROM the options, so its keys are already
+  // catalog keys; a stored card's may not be.
+  rowFor: (resource: string) => string = (resource) => resource,
 ): DelegatedAccessNamedServiceOperations {
-  const wanted = new Set(forResources);
   const out: DelegatedAccessNamedServiceOperations = {};
-  resources.forEach((option) => {
-    if (!wanted.has(option.resource)) return;
+  forResources.forEach((resource) => {
+    const option = catalogRowFor(resources, resource, rowFor);
+    if (!option) return;
     const namespaces: Record<string, string[]> = {};
     (option.named_services || []).forEach((namespace) => {
       const operations = operationRows(namespace).map((row) => row.operation);
       if (operations.length) namespaces[namespace.namespace] = operations;
     });
-    if (Object.keys(namespaces).length) out[option.resource] = namespaces;
+    // Keyed by the CARD's resource, so the selection and this map align.
+    if (Object.keys(namespaces).length) out[resource] = namespaces;
   });
   return out;
+}
+
+/** The catalog row a card resource resolves to.
+ *
+ *  A card key is the row's own pattern (hub-created) or a concrete URL (an
+ *  OAuth client's `resource`). The server resolves the two through one matcher
+ *  and ships the answer as `catalog_row_by_resource`; string equality is the
+ *  fallback for a record that predates the field. */
+function catalogRowFor(
+  resources: DelegatedAccessResourceOption[],
+  resource: string,
+  rowFor: (resource: string) => string,
+): DelegatedAccessResourceOption | undefined {
+  const key = rowFor(resource) || resource;
+  return resources.find((option) => option.resource === key);
 }
 
 /** The card-level selection as the server stores it.
@@ -601,7 +667,14 @@ export function DelegatedAccessPanel({ openParams }: { openParams?: Record<strin
   const { providers, accounts } = useAppSelector((s) => s.delegatedToKdcube);
   const [label, setLabel] = useState('Automation access');
   const [resourceGrants, setResourceGrants] = useState<Record<string, string[]>>({});
-  const [namedServiceOperations, setNamedServiceOperations] = useState<DelegatedAccessNamedServiceOperations>({});
+  const [namedServiceOperations, setNamedServiceOperations] = useState<DelegatedAccessNamedServiceOperations>(
+    // The demand names the operation it was refused; approval grants that one.
+    () => {
+      const asked = pendingAgentGrantRequest(openParams);
+      if (!asked?.namespace || !asked.operation || !asked.resource) return {};
+      return { [asked.resource]: { [asked.namespace]: [asked.operation] } };
+    },
+  );
   const [ttlSeconds, setTtlSeconds] = useState(ttlOptions[0].value);
   const [pendingGrant, setPendingGrant] = useState(() => pendingAgentGrantRequest(openParams));
   const manualFocus = useMemo(() => manualAccessFocusRequest(openParams), [openParams]);
@@ -636,6 +709,12 @@ export function DelegatedAccessPanel({ openParams }: { openParams?: Record<strin
   // Namespace narrowing being edited: {resource: {namespace: [operation]}}.
   const [editNamedServiceOperations, setEditNamedServiceOperations] =
     useState<DelegatedAccessNamedServiceOperations>({});
+  // Card resource -> catalog row, for the record being edited.
+  const [editCatalogRows, setEditCatalogRows] = useState<Record<string, string>>({});
+  const editRowFor = useCallback(
+    (resource: string) => editCatalogRows[resource] || resource,
+    [editCatalogRows],
+  );
   // Per-account claim binding being edited: {provider_id: {account_id: [claims]}}.
   // Default-closed: a provider with nothing ticked grants NO account to this
   // client; only the ticked accounts+claims are allowed.
@@ -828,9 +907,12 @@ export function DelegatedAccessPanel({ openParams }: { openParams?: Record<strin
     });
     // A per-account-only change (the deep link from a binding miss: the door
     // claim is already granted, the user only ticked a per-account permission)
-    // has no new door claim to send. Still emit the resource carrying its
-    // EXISTING claims so the account binding persists rather than being dropped.
-    if (Object.keys(pendingAccountScope).length && !merged[pendingGrant.resource]) {
+    // has no new door claim to send. An operation-only ask — the card holds
+    // every claim the operation declares and only its boundary excludes it —
+    // has none either. Still emit the resource carrying its EXISTING claims so
+    // the binding and the operation reach the record.
+    const operationOnlyAsk = Boolean(pendingGrant.namespace && pendingGrant.operation);
+    if ((Object.keys(pendingAccountScope).length || operationOnlyAsk) && !merged[pendingGrant.resource]) {
       const existing = items.find((record) => (record.client_id || '') === pendingGrant.clientId);
       merged[pendingGrant.resource] = [...((existing?.resource_grants || {})[pendingGrant.resource] || [])];
     }
@@ -911,6 +993,7 @@ export function DelegatedAccessPanel({ openParams }: { openParams?: Record<strin
     });
     setEditingAccessId(item.access_id);
     setEditPicks(picks);
+    setEditCatalogRows({ ...(item.catalog_row_by_resource || {}) });
     // Seeded from what the card COVERS, not from what it names: a wildcard
     // names nothing, and an empty picker is indistinguishable from an explicit
     // {} — the operator would then narrow the card with the first box they tick
@@ -918,7 +1001,11 @@ export function DelegatedAccessPanel({ openParams }: { openParams?: Record<strin
     setEditNamedServiceOperations(
       seedNamedServiceOperations(
         item,
-        offeredNamedServiceOperations(resources, Object.keys(item.resource_grants || {})),
+        offeredNamedServiceOperations(
+          resources,
+          Object.keys(item.resource_grants || {}),
+          (resource) => (item.catalog_row_by_resource || {})[resource] || resource,
+        ),
       ),
     );
     setEditAccountScope(seedAccountScopeFromRecord(item));
@@ -1074,7 +1161,7 @@ export function DelegatedAccessPanel({ openParams }: { openParams?: Record<strin
   const toggleEditClaim = (resource: string, claim: string, checked: boolean) => {
     setEditPicks((current) => ({ ...current, [`${resource}:${claim}`]: checked }));
     if (checked) return;
-    const resourceOption = resources.find((item) => item.resource === resource);
+    const resourceOption = catalogRowFor(resources, resource, editRowFor);
     if (!resourceOption) return;
     setEditNamedServiceOperations((current) => {
       const existingNamespaces = current[resource];
@@ -1103,7 +1190,7 @@ export function DelegatedAccessPanel({ openParams }: { openParams?: Record<strin
     checked: boolean,
   ) => {
     if (checked) {
-      const resourceOption = resources.find((item) => item.resource === resource);
+      const resourceOption = catalogRowFor(resources, resource, editRowFor);
       const required = [
         ...grants,
         ...(resourceOption ? commonOperationGrants(resourceOption) : []),
@@ -1138,7 +1225,9 @@ export function DelegatedAccessPanel({ openParams }: { openParams?: Record<strin
   // The catalog's claims (so one can be added) union the record's own (so a
   // claim the catalog dropped is still shown and removable).
   const editableClaimsFor = (item: DelegatedAccessRecord, resource: string): string[] => {
-    const option = resources.find((candidate) => candidate.resource === resource);
+    const option = catalogRowFor(
+      resources, resource, (key) => (item.catalog_row_by_resource || {})[key] || key,
+    );
     return Array.from(new Set([
       ...((item.resource_grants || {})[resource] || []),
       ...(option ? grantsForResource(option) : []),
@@ -1168,64 +1257,38 @@ export function DelegatedAccessPanel({ openParams }: { openParams?: Record<strin
       void dispatch(loadDelegatedAccess());
       return;
     }
-    // A manual automation has no live client identity the guard narrows; its
-    // CARD is the authority, keyed by access_id. Editing rewrites that card in
-    // place — the token the operator already copied stays valid, only the scope
-    // (and label) changes — so it saves through the automation-update op, not
-    // the agent-grant path.
-    if (item.source === 'manual') {
-      const prunedKept = Object.fromEntries(
-        Object.entries(kept).filter(([, claims]) => claims.length > 0),
-      );
-      // The edited selection, minus resources fully unchecked above. Left
-      // undefined when the card carries no narrowing and none was picked, so a
-      // rename preserves it instead of narrowing every resource to nothing.
-      const keptNamedServiceOperations = Object.fromEntries(
-        Object.entries(editNamedServiceOperations)
-          .filter(([resource]) => prunedKept[resource]),
-      );
-      // Nothing offered anywhere means there is nothing to say about the inner
-      // boundary; omitting preserves the card's own policy. Otherwise the save
-      // is explicit — `"*"` when every offered box is ticked, the exact map
-      // otherwise, {} when the operator cleared them all.
-      const offered = offeredNamedServiceOperations(resources, Object.keys(prunedKept));
-      await dispatch(updateDelegatedAccess({
-        accessId: item.access_id,
-        label: editLabel.trim() || item.label || 'Automation access',
-        resourceGrants: prunedKept,
-        namedServiceOperations: Object.keys(offered).length
-          ? encodeNamedServiceSelection(keptNamedServiceOperations, offered)
-          : undefined,
-        accountScope: editAccountScope,
-        // What this editor was opened on. The server refuses the save when
-        // either moved.
-        expectedCardRevision: item.card_revision,
-        expectedCatalogVersion: item.catalog_drift?.current_version || item.catalog_version,
-      })).unwrap().catch(() => undefined);
-      clearEditState();
-      void dispatch(loadDelegatedAccess());
-      return;
-    }
-    if (!item.client_id) return;
-    {
-      // The account binding is a per-client (not per-resource) edit, so send it
-      // once with the first resource; `replace` makes the submitted scope
-      // authoritative (an unchecked provider clears its binding -> nothing
-      // granted there; the runtime is default-closed for delegated callers).
-      const accountScope = editAccountScope;
-      let first = true;
-      for (const [resource, claims] of Object.entries(kept)) {
-        if (!claims.length) continue;
-        await dispatch(grantAgentAccess({
-          clientId: item.client_id,
-          resource,
-          claims,
-          replace: true,
-          ...(first ? { accountScope, label: editLabel.trim() } : {}),
-        })).unwrap().catch(() => undefined);
-        first = false;
-      }
-    }
+    // One save for every family: the card is the authority, keyed by access_id,
+    // and the edit replaces the authority the operator reviewed. The credential
+    // is untouched — a copied manual token, an agent's reusable bearer and an
+    // OAuth client's handles all keep working, on their very next call.
+    const prunedKept = Object.fromEntries(
+      Object.entries(kept).filter(([, claims]) => claims.length > 0),
+    );
+    // The edited selection, minus resources fully unchecked above.
+    const keptNamedServiceOperations = Object.fromEntries(
+      Object.entries(editNamedServiceOperations)
+        .filter(([resource]) => prunedKept[resource]),
+    );
+    // Nothing offered anywhere means there is nothing to say about the inner
+    // boundary; omitting preserves the card's own policy. Otherwise the save
+    // is explicit — `"*"` when every offered box is ticked, the exact map
+    // otherwise, {} when the operator cleared them all.
+    const offered = offeredNamedServiceOperations(
+      resources, Object.keys(prunedKept), editRowFor,
+    );
+    await dispatch(updateDelegatedAccess({
+      accessId: item.access_id,
+      label: editLabel.trim() || item.label || 'Automation access',
+      resourceGrants: prunedKept,
+      namedServiceOperations: Object.keys(offered).length
+        ? encodeNamedServiceSelection(keptNamedServiceOperations, offered)
+        : undefined,
+      accountScope: editAccountScope,
+      // What this editor was opened on. The server refuses the save when
+      // either moved.
+      expectedCardRevision: item.card_revision,
+      expectedCatalogVersion: item.catalog_drift?.current_version || item.catalog_version,
+    })).unwrap().catch(() => undefined);
     clearEditState();
     void dispatch(loadDelegatedAccess());
   };
@@ -1237,6 +1300,16 @@ export function DelegatedAccessPanel({ openParams }: { openParams?: Record<strin
   // grant checked earlier stays selected while the user searches on.
   const visibleResources = resources.filter((item) => resourceMatchesQuery(item, resourceQuery, grantOptionByName));
   const searching = Boolean(resourceQuery.trim());
+  // The identity the card in progress has already committed to, or '' while
+  // nothing is selected and every door is still reachable.
+  const committedIdentityScope = (() => {
+    const scopes = new Set(
+      resources
+        .filter((item) => (resourceGrants[item.resource] || []).length)
+        .map((item) => item.identity_scope || 'grantor'),
+    );
+    return scopes.size === 1 ? Array.from(scopes)[0] : '';
+  })();
   const renderResourceList = () => (
     <div className="resource-list">
       <input
@@ -1254,6 +1327,11 @@ export function DelegatedAccessPanel({ openParams }: { openParams?: Record<strin
         const grants = grantsForResource(item);
         const selectedCount = (resourceGrants[item.resource] || []).length;
         const isOpen = openResources[item.resource] ?? (searching || selectedCount > 0);
+        // One card issues ONE credential, so every door on it must run under
+        // the same identity. The server refuses a mixture; offering it is what
+        // makes that refusal a surprise.
+        const scope = item.identity_scope || 'grantor';
+        const scopeBlocked = Boolean(committedIdentityScope) && scope !== committedIdentityScope;
         return (
           <div className="resource-option resource-option-stack" key={item.resource}>
             <button
@@ -1280,13 +1358,27 @@ export function DelegatedAccessPanel({ openParams }: { openParams?: Record<strin
             </button>
             {isOpen ? (
               <>
+                {scopeBlocked ? (
+                  <p className="resource-boundaries-empty">
+                    This endpoint runs under <code>{scope}</code>, and this card is
+                    already committed to <code>{committedIdentityScope}</code>. One
+                    card carries one identity - grant it on a separate card.
+                  </p>
+                ) : null}
                 <div className="resource-grants">
                   {grants.map((grant) => {
                     const option = grantOptionByName.get(grant);
                     return (
-                      <label className="grant-chip" key={`${item.resource}:${grant}`} title={option?.label || undefined}>
+                      <label
+                        className={`grant-chip${scopeBlocked ? ' grant-chip-blocked' : ''}`}
+                        key={`${item.resource}:${grant}`}
+                        title={scopeBlocked
+                          ? `Runs under ${scope}; this card is already committed to ${committedIdentityScope}`
+                          : (option?.label || undefined)}
+                      >
                         <input
                           type="checkbox"
+                          disabled={scopeBlocked}
                           checked={(resourceGrants[item.resource] || []).includes(grant)}
                           onChange={(event) => toggleResourceGrant(item.resource, grant, event.target.checked)}
                         />
@@ -1523,7 +1615,14 @@ export function DelegatedAccessPanel({ openParams }: { openParams?: Record<strin
                           {/* Edit mode keeps the per-claim checkboxes; the
                               read-only view is the same labelled-row card the
                               connected-app grants use. */}
-                          {editing ? Object.entries(item.resource_grants || {}).map(([resource, grants]) => (
+                          {editing ? Object.entries(item.resource_grants || {}).map(([resource, grants]) => {
+                            const resourceOption = catalogRowFor(
+                              resources, resource, (key) => (item.catalog_row_by_resource || {})[key] || key,
+                            );
+                            const editedGrants = grants.filter(
+                              (claim) => editPicks[`${resource}:${claim}`] !== false,
+                            );
+                            return (
                             <div key={resource}>
                               <div className="account-title">{doorAlias(resource) || resourceLabelFor(resource) || resource}</div>
                               {resource !== '*' ? <DoorRef value={resource} /> : null}
@@ -1541,8 +1640,23 @@ export function DelegatedAccessPanel({ openParams }: { openParams?: Record<strin
                                   </label>
                                 ))}
                               </div>
+                              {resourceOption ? (
+                                <DelegatedResourceCatalog
+                                  resource={resourceOption}
+                                  selectedGrants={editedGrants}
+                                  selectedOperations={editNamedServiceOperations[resource] || {}}
+                                  onOperationChange={(namespace, operation, operationGrants, checked) => (
+                                    toggleEditNamedServiceOperation(
+                                      resource, namespace, operation, operationGrants, checked,
+                                    )
+                                  )}
+                                  providers={providers}
+                                  accounts={accounts}
+                                />
+                              ) : null}
                             </div>
-                          )) : (
+                            );
+                          }) : (
                             <div className="card-fields">
                               {/* Door and Access are paired per door, so which claims
                                   belong to which door survives on a multi-door grant.
@@ -1571,6 +1685,16 @@ export function DelegatedAccessPanel({ openParams }: { openParams?: Record<strin
                                       last saved. Operations added since are not included.
                                     </small>
                                   ) : null}
+                                </Field>
+                              ) : cardOffersNamedServices(item, resources) ? (
+                                // The door offers named services and none were
+                                // selected: an empty selection reaches nothing,
+                                // so this may not read as "not narrowed".
+                                <Field label="Services">
+                                  <small>
+                                    None selected - this card reaches no named-service
+                                    operation on this door.
+                                  </small>
                                 </Field>
                               ) : (
                                 <Field label="Operations">
@@ -1716,7 +1840,9 @@ export function DelegatedAccessPanel({ openParams }: { openParams?: Record<strin
                   {item.resource_grants && Object.keys(item.resource_grants).length ? (
                     editing ? (
                       Object.keys(item.resource_grants).map((resource) => {
-                        const resourceOption = resources.find((candidate) => candidate.resource === resource);
+                        const resourceOption = catalogRowFor(
+                          resources, resource, (key) => (item.catalog_row_by_resource || {})[key] || key,
+                        );
                         const editedGrants = editableClaimsFor(item, resource)
                           .filter((claim) => editPicks[`${resource}:${claim}`] === true);
                         return (
@@ -1748,10 +1874,10 @@ export function DelegatedAccessPanel({ openParams }: { openParams?: Record<strin
                                 );
                               })}
                             </div>
-                            {/* Namespace operations are stored per card and derived
-                                per request only for manual automations; the OAuth
-                                edit op does not accept them. */}
-                            {item.source === 'manual' && resourceOption ? (
+                            {/* Every family: the card type decides how the
+                                credential is managed, not whether its grantor
+                                may change authority. */}
+                            {resourceOption ? (
                               <DelegatedResourceCatalog
                                 resource={resourceOption}
                                 selectedGrants={editedGrants}
@@ -1797,12 +1923,19 @@ export function DelegatedAccessPanel({ openParams }: { openParams?: Record<strin
                         <Field label="Operations"><CountFold entries={item.operations} noun="operation" /></Field>
                       ) : null}
                       {(() => {
-                        // A grant can carry an EMPTY namespace map; render the
-                        // row only when the card actually covers services.
                         const services = namedServiceRows(item);
-                        return services.length ? (
-                          <Field label="Services"><CountFold entries={services} noun="service" /></Field>
-                        ) : null;
+                        if (services.length) {
+                          return <Field label="Services"><CountFold entries={services} noun="service" /></Field>;
+                        }
+                        if (!cardOffersNamedServices(item, resources)) return null;
+                        return (
+                          <Field label="Services">
+                            <small>
+                              None selected — this card reaches no named-service
+                              operation on this door.
+                            </small>
+                          </Field>
+                        );
                       })()}
                       {Object.keys(item.account_scope || {}).length ? (
                         <Field label="Accounts">

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/examples/bundles/connection-hub@1-0/ui/widgets/connections/src/features/delegatedAccess/DelegatedAccessPanel.tsx
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/examples/bundles/connection-hub@1-0/ui/widgets/connections/src/features/delegatedAccess/DelegatedAccessPanel.tsx
@@ -419,6 +419,24 @@ function CountFold({ entries, noun }: { entries: string[]; noun: string }) {
   );
 }
 
+/** The stored selection has three forms and only one of them is a map. A
+ *  wildcard names no operations to list — it means whatever the acknowledged
+ *  catalog offers — so it yields no rows here and the caller says so in words. */
+function isWildcardNamedServices(
+  selection: DelegatedAccessRecord['named_service_operations'],
+): boolean {
+  return typeof selection === 'string';
+}
+
+function namedServiceRows(
+  selection: DelegatedAccessRecord['named_service_operations'],
+): string[] {
+  if (!selection || isWildcardNamedServices(selection)) return [];
+  return Object.values(selection as DelegatedAccessNamedServiceOperations)
+    .flatMap((namespaces) => Object.entries(namespaces || {}))
+    .map(([namespace, operations]) => `${namespace} (${(operations || []).join(', ')})`);
+}
+
 function driftLabel(row: { resource: string; namespace?: string; claim?: string; operation?: string }): string {
   const parts = [doorAlias(row.resource) || row.resource];
   if (row.namespace) parts.push(row.namespace);
@@ -804,16 +822,23 @@ export function DelegatedAccessPanel({ openParams }: { openParams?: Record<strin
     });
     setEditingAccessId(item.access_id);
     setEditPicks(picks);
+    // A wildcard names no operations to seed. Leaving the editor empty makes
+    // the save omit the field, which preserves the stored policy instead of
+    // narrowing the card to nothing.
     setEditNamedServiceOperations(
-      Object.fromEntries(
-        Object.entries(item.named_service_operations || {})
-          .map(([resource, namespaces]) => [
-            resource,
-            Object.fromEntries(
-              Object.entries(namespaces || {}).map(([ns, ops]) => [ns, [...(ops || [])]]),
-            ),
-          ]),
-      ),
+      isWildcardNamedServices(item.named_service_operations)
+        ? {}
+        : Object.fromEntries(
+          Object.entries(
+            (item.named_service_operations || {}) as DelegatedAccessNamedServiceOperations,
+          )
+            .map(([resource, namespaces]) => [
+              resource,
+              Object.fromEntries(
+                Object.entries(namespaces || {}).map(([ns, ops]) => [ns, [...(ops || [])]]),
+              ),
+            ]),
+        ),
     );
     setEditAccountScope(seedAccountScopeFromRecord(item));
     setEditLabel(item.label || '');
@@ -1451,12 +1476,10 @@ export function DelegatedAccessPanel({ openParams }: { openParams?: Record<strin
                                   </Field>
                                 </Fragment>
                               ))}
-                              {item.named_service_operations && Object.keys(item.named_service_operations).length ? (
+                              {namedServiceRows(item.named_service_operations).length ? (
                                 <Field label="Services">
                                   <CountFold
-                                    entries={Object.values(item.named_service_operations)
-                                      .flatMap((namespaces) => Object.entries(namespaces))
-                                      .map(([namespace, operations]) => `${namespace} (${operations.join(', ')})`)}
+                                    entries={namedServiceRows(item.named_service_operations)}
                                     noun="service"
                                   />
                                 </Field>
@@ -1685,11 +1708,10 @@ export function DelegatedAccessPanel({ openParams }: { openParams?: Record<strin
                         <Field label="Operations"><CountFold entries={item.operations} noun="operation" /></Field>
                       ) : null}
                       {(() => {
-                        // A grant can carry an EMPTY namespace map; render the
-                        // row only when it actually names services.
-                        const services = Object.values(item.named_service_operations || {})
-                          .flatMap((namespaces) => Object.entries(namespaces))
-                          .map(([namespace, operations]) => `${namespace} (${operations.join(', ')})`);
+                        // A grant can carry an EMPTY namespace map, or a
+                        // wildcard that names none; render the row only when it
+                        // actually names services.
+                        const services = namedServiceRows(item.named_service_operations);
                         return services.length ? (
                           <Field label="Services"><CountFold entries={services} noun="service" /></Field>
                         ) : null;

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/examples/bundles/connection-hub@1-0/ui/widgets/connections/src/features/delegatedAccess/DelegatedAccessPanel.tsx
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/examples/bundles/connection-hub@1-0/ui/widgets/connections/src/features/delegatedAccess/DelegatedAccessPanel.tsx
@@ -8,6 +8,7 @@ import type {
   DelegatedAccessNamedServiceOperations,
   DelegatedAccessRecord,
   DelegatedAccessResourceOption,
+  DelegatedAccessStoredNamedServices,
   DelegatedCatalogDrift,
   DelegatedToKdcubeAccount,
 } from '../../api/types';
@@ -428,13 +429,95 @@ function isWildcardNamedServices(
   return typeof selection === 'string';
 }
 
-function namedServiceRows(
-  selection: DelegatedAccessRecord['named_service_operations'],
-): string[] {
-  if (!selection || isWildcardNamedServices(selection)) return [];
-  return Object.values(selection as DelegatedAccessNamedServiceOperations)
+/** What the card covers, for display and for seeding the editor.
+ *
+ *  The stored selection answers this only when it is an exact map. A wildcard
+ *  and a pre-encoding record name no operations of their own, so the server
+ *  ships the expansion it saved them against; without it both draw exactly like
+ *  an explicit {}. */
+function cardNamedServiceOperations(
+  item: DelegatedAccessRecord,
+): DelegatedAccessNamedServiceOperations {
+  const effective = item.effective_named_service_operations;
+  if (effective && Object.keys(effective).length) return effective;
+  const selection = item.named_service_operations;
+  if (!selection || isWildcardNamedServices(selection)) return {};
+  return selection as DelegatedAccessNamedServiceOperations;
+}
+
+function namedServiceRows(item: DelegatedAccessRecord): string[] {
+  return Object.values(cardNamedServiceOperations(item))
     .flatMap((namespaces) => Object.entries(namespaces || {}))
     .map(([namespace, operations]) => `${namespace} (${(operations || []).join(', ')})`);
+}
+
+/** Every named-service operation the ACTIVE catalog offers for these resources.
+ *
+ *  The same rows the picker draws, so "all of them are ticked" is a question
+ *  the panel can answer without guessing. */
+function offeredNamedServiceOperations(
+  resources: DelegatedAccessResourceOption[],
+  forResources: string[],
+): DelegatedAccessNamedServiceOperations {
+  const wanted = new Set(forResources);
+  const out: DelegatedAccessNamedServiceOperations = {};
+  resources.forEach((option) => {
+    if (!wanted.has(option.resource)) return;
+    const namespaces: Record<string, string[]> = {};
+    (option.named_services || []).forEach((namespace) => {
+      const operations = operationRows(namespace).map((row) => row.operation);
+      if (operations.length) namespaces[namespace.namespace] = operations;
+    });
+    if (Object.keys(namespaces).length) out[option.resource] = namespaces;
+  });
+  return out;
+}
+
+/** The card-level selection as the server stores it.
+ *
+ *  `"*"` is not a separate mode in the design: an explicitly submitted wildcard
+ *  "means the operator selected all operations shown from the current catalog",
+ *  which is the one case Save may keep as `"*"` against the new catalog
+ *  version. So ticking every offered box encodes as `"*"`, anything less as the
+ *  exact map, and nothing as an explicit {}. */
+function encodeNamedServiceSelection(
+  selected: DelegatedAccessNamedServiceOperations,
+  offered: DelegatedAccessNamedServiceOperations,
+): DelegatedAccessStoredNamedServices {
+  const entries = Object.entries(offered);
+  if (!entries.length) return selected;
+  const everythingTicked = entries.every(([resource, namespaces]) => (
+    Object.entries(namespaces).every(([namespace, operations]) => {
+      const held = new Set(selected[resource]?.[namespace] || []);
+      return operations.every((operation) => held.has(operation));
+    })
+  ));
+  return everythingTicked ? '*' : selected;
+}
+
+/** The card's coverage, kept to what the picker can actually draw.
+ *
+ *  Operations the active catalog no longer offers have no checkbox, so seeding
+ *  them would resubmit choices the operator cannot see or untick — the design
+ *  is explicit that the frontend never sends a hidden stale operation back
+ *  merely to reconstruct the old card. */
+function seedNamedServiceOperations(
+  item: DelegatedAccessRecord,
+  offered: DelegatedAccessNamedServiceOperations,
+): DelegatedAccessNamedServiceOperations {
+  const covered = cardNamedServiceOperations(item);
+  const out: DelegatedAccessNamedServiceOperations = {};
+  Object.entries(offered).forEach(([resource, namespaces]) => {
+    const held = covered[resource] || {};
+    const kept: Record<string, string[]> = {};
+    Object.entries(namespaces).forEach(([namespace, operations]) => {
+      const selected = new Set(held[namespace] || []);
+      const surviving = operations.filter((operation) => selected.has(operation));
+      if (surviving.length) kept[namespace] = surviving;
+    });
+    if (Object.keys(kept).length) out[resource] = kept;
+  });
+  return out;
 }
 
 function driftLabel(row: { resource: string; namespace?: string; claim?: string; operation?: string }): string {
@@ -675,7 +758,13 @@ export function DelegatedAccessPanel({ openParams }: { openParams?: Record<strin
     await dispatch(createDelegatedAccess({
       label: label.trim() || 'Automation access',
       resourceGrants,
-      namedServiceOperations: selectedNamedServiceOperations,
+      namedServiceOperations: encodeNamedServiceSelection(
+        selectedNamedServiceOperations,
+        offeredNamedServiceOperations(
+          resources,
+          selectedResourceEntries.map(([resource]) => resource),
+        ),
+      ),
       accountScope: createAccountScope,
       ttlSeconds,
     })).unwrap().catch(() => undefined);
@@ -822,27 +911,19 @@ export function DelegatedAccessPanel({ openParams }: { openParams?: Record<strin
     });
     setEditingAccessId(item.access_id);
     setEditPicks(picks);
-    // A wildcard names no operations to seed. Leaving the editor empty makes
-    // the save omit the field, which preserves the stored policy instead of
-    // narrowing the card to nothing.
+    // Seeded from what the card COVERS, not from what it names: a wildcard
+    // names nothing, and an empty picker is indistinguishable from an explicit
+    // {} — the operator would then narrow the card with the first box they tick
+    // believing they widen it.
     setEditNamedServiceOperations(
-      isWildcardNamedServices(item.named_service_operations)
-        ? {}
-        : Object.fromEntries(
-          Object.entries(
-            (item.named_service_operations || {}) as DelegatedAccessNamedServiceOperations,
-          )
-            .map(([resource, namespaces]) => [
-              resource,
-              Object.fromEntries(
-                Object.entries(namespaces || {}).map(([ns, ops]) => [ns, [...(ops || [])]]),
-              ),
-            ]),
-        ),
+      seedNamedServiceOperations(
+        item,
+        offeredNamedServiceOperations(resources, Object.keys(item.resource_grants || {})),
+      ),
     );
     setEditAccountScope(seedAccountScopeFromRecord(item));
     setEditLabel(item.label || '');
-  }, [seedAccountScopeFromRecord]);
+  }, [resources, seedAccountScopeFromRecord]);
   // Human label for one connected account (falls back to the id).
   const accountLabelById = useMemo(() => {
     const map = new Map<string, string>();
@@ -1103,12 +1184,17 @@ export function DelegatedAccessPanel({ openParams }: { openParams?: Record<strin
         Object.entries(editNamedServiceOperations)
           .filter(([resource]) => prunedKept[resource]),
       );
+      // Nothing offered anywhere means there is nothing to say about the inner
+      // boundary; omitting preserves the card's own policy. Otherwise the save
+      // is explicit — `"*"` when every offered box is ticked, the exact map
+      // otherwise, {} when the operator cleared them all.
+      const offered = offeredNamedServiceOperations(resources, Object.keys(prunedKept));
       await dispatch(updateDelegatedAccess({
         accessId: item.access_id,
         label: editLabel.trim() || item.label || 'Automation access',
         resourceGrants: prunedKept,
-        namedServiceOperations: Object.keys(keptNamedServiceOperations).length
-          ? keptNamedServiceOperations
+        namedServiceOperations: Object.keys(offered).length
+          ? encodeNamedServiceSelection(keptNamedServiceOperations, offered)
           : undefined,
         accountScope: editAccountScope,
         // What this editor was opened on. The server refuses the save when
@@ -1476,12 +1562,15 @@ export function DelegatedAccessPanel({ openParams }: { openParams?: Record<strin
                                   </Field>
                                 </Fragment>
                               ))}
-                              {namedServiceRows(item.named_service_operations).length ? (
+                              {namedServiceRows(item).length ? (
                                 <Field label="Services">
-                                  <CountFold
-                                    entries={namedServiceRows(item.named_service_operations)}
-                                    noun="service"
-                                  />
+                                  <CountFold entries={namedServiceRows(item)} noun="service" />
+                                  {isWildcardNamedServices(item.named_service_operations) ? (
+                                    <small>
+                                      Every operation these services offered when this card was
+                                      last saved. Operations added since are not included.
+                                    </small>
+                                  ) : null}
                                 </Field>
                               ) : (
                                 <Field label="Operations">
@@ -1708,10 +1797,9 @@ export function DelegatedAccessPanel({ openParams }: { openParams?: Record<strin
                         <Field label="Operations"><CountFold entries={item.operations} noun="operation" /></Field>
                       ) : null}
                       {(() => {
-                        // A grant can carry an EMPTY namespace map, or a
-                        // wildcard that names none; render the row only when it
-                        // actually names services.
-                        const services = namedServiceRows(item.named_service_operations);
+                        // A grant can carry an EMPTY namespace map; render the
+                        // row only when the card actually covers services.
+                        const services = namedServiceRows(item);
                         return services.length ? (
                           <Field label="Services"><CountFold entries={services} noun="service" /></Field>
                         ) : null;

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/examples/bundles/connection-hub@1-0/ui/widgets/connections/src/features/delegatedAccess/DelegatedResourceCatalog.tsx
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/examples/bundles/connection-hub@1-0/ui/widgets/connections/src/features/delegatedAccess/DelegatedResourceCatalog.tsx
@@ -185,12 +185,51 @@ export function DelegatedResourceCatalog({
   const namespaces = resource.named_services || [];
   if (!namespaces.length) return null;
 
+  /* Every offered row, so "all of them" is a question this component can both
+   * ask and answer. Ticking all of them is what the save encodes as `"*"`. */
+  const offeredRows = namespaces.flatMap((namespace) => (
+    operationRows(namespace).map((row) => ({ namespace: namespace.namespace, row }))
+  ));
+  const selectedCount = namespaces.reduce((total, namespace) => (
+    total + (selectedOperations[namespace.namespace] || []).length
+  ), 0);
+
+  const setEveryOperation = (checked: boolean) => {
+    offeredRows.forEach(({ namespace, row }) => {
+      const held = new Set(selectedOperations[namespace] || []);
+      if (held.has(row.operation) === checked) return;
+      onOperationChange(namespace, row.operation, row.grants, checked);
+    });
+  };
+
   return (
     <div className="resource-boundaries">
       <div className="resource-boundaries-head">
         <strong>Named-service access</strong>
+        <span className="resource-boundaries-bulk">
+          <button
+            type="button"
+            onClick={() => setEveryOperation(true)}
+            disabled={selectedCount >= offeredRows.length}
+          >
+            Select all currently available
+          </button>
+          <button
+            type="button"
+            onClick={() => setEveryOperation(false)}
+            disabled={!selectedCount}
+          >
+            Clear
+          </button>
+        </span>
         <span className="badge">{namespaces.length} namespaces</span>
       </div>
+      {offeredRows.length && !selectedCount ? (
+        <p className="resource-boundaries-empty">
+          No operations selected - this card will reach no named-service
+          operation on this door.
+        </p>
+      ) : null}
       {namespaces.map((namespace) => {
         const rows = operationRows(namespace);
         const selected = new Set(selectedOperations[namespace.namespace] || []);

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/examples/bundles/connection-hub@1-0/ui/widgets/connections/src/features/delegatedAccess/delegatedAccessSlice.ts
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/examples/bundles/connection-hub@1-0/ui/widgets/connections/src/features/delegatedAccess/delegatedAccessSlice.ts
@@ -4,10 +4,10 @@ import type {
   DelegatedAccessCreateResult,
   DelegatedAccessGrantOption,
   DelegatedAccessListResult,
-  DelegatedAccessNamedServiceOperations,
   DelegatedAccessRecord,
   DelegatedAccessResourceOption,
   DelegatedAccessRevokeResult,
+  DelegatedAccessStoredNamedServices,
 } from '../../api/types';
 
 export interface DelegatedAccessState {
@@ -60,7 +60,9 @@ export interface CreateDelegatedAccessArgs {
   label: string;
   resourceGrants: Record<string, string[]>;
   operations?: string[];
-  namedServiceOperations: DelegatedAccessNamedServiceOperations;
+  /** `"*"` when every operation the current catalog offers for the selected
+   *  resources is ticked, an exact map otherwise, {} for nothing. */
+  namedServiceOperations: DelegatedAccessStoredNamedServices;
   /** Per-account binding {provider:{account_id:[claims]}}. Undefined preserves
    *  an existing binding; {} explicitly restricts the caller to no accounts. */
   accountScope?: Record<string, Record<string, string[]>>;
@@ -149,9 +151,10 @@ export interface UpdateDelegatedAccessArgs {
   label: string;
   resourceGrants: Record<string, string[]>;
   operations?: string[];
-  /** Namespace narrowing {resource:{namespace:[operation]}}. Undefined preserves
-   *  the record's; {} narrows every resource to nothing. */
-  namedServiceOperations?: DelegatedAccessNamedServiceOperations;
+  /** Namespace narrowing {resource:{namespace:[operation]}}, or `"*"` when the
+   *  operator ticked every operation the current catalog offers. Undefined
+   *  preserves the record's; {} narrows every resource to nothing. */
+  namedServiceOperations?: DelegatedAccessStoredNamedServices;
   /** Per-account binding {provider:{account_id:[claims]}}. Undefined preserves
    *  an existing binding; {} explicitly restricts the caller to no accounts. */
   accountScope?: Record<string, Record<string, string[]>>;

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/examples/bundles/connection-hub@1-0/ui/widgets/connections/src/features/delegatedAccess/delegatedAccessSlice.ts
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/examples/bundles/connection-hub@1-0/ui/widgets/connections/src/features/delegatedAccess/delegatedAccessSlice.ts
@@ -155,6 +155,11 @@ export interface UpdateDelegatedAccessArgs {
   /** Per-account binding {provider:{account_id:[claims]}}. Undefined preserves
    *  an existing binding; {} explicitly restricts the caller to no accounts. */
   accountScope?: Record<string, Record<string, string[]>>;
+  /** What the editor loaded. The server refuses the save with 409 when either
+   *  moved, so choices made against an obsolete view cannot acknowledge a
+   *  newer catalog. */
+  expectedCardRevision?: number;
+  expectedCatalogVersion?: string;
 }
 
 /** Edit a manual automation IN PLACE — the card keeps its access_id/client_id,
@@ -167,7 +172,19 @@ export const updateDelegatedAccess = createAsyncThunk<
   { rejectValue: string }
 >(
   'delegatedAccess/update',
-  async ({ accessId, label, resourceGrants, operations, namedServiceOperations, accountScope }, { rejectWithValue }) => {
+  async (
+    {
+      accessId,
+      label,
+      resourceGrants,
+      operations,
+      namedServiceOperations,
+      accountScope,
+      expectedCardRevision,
+      expectedCatalogVersion,
+    },
+    { rejectWithValue },
+  ) => {
     try {
       const res = await postOp<DelegatedAccessCreateResult>('delegated_access_update', {
         access_id: accessId,
@@ -180,7 +197,16 @@ export const updateDelegatedAccess = createAsyncThunk<
         ...(accountScope !== undefined
           ? { account_scope: accountScope }
           : {}),
+        ...(expectedCardRevision !== undefined
+          ? { expected_card_revision: expectedCardRevision }
+          : {}),
+        ...(expectedCatalogVersion
+          ? { expected_catalog_version: expectedCatalogVersion }
+          : {}),
       });
+      // A precondition failure is not an error to show and forget: it carries
+      // the refreshed card the editor must reload.
+      if (res?.ok === false && res?.status === 409) return res;
       if (res?.ok === false) return rejectWithValue(resultError(res, 'Failed to update delegated access'));
       return res || {};
     } catch (e) {
@@ -272,8 +298,27 @@ const delegatedAccessSlice = createSlice({
         state.busy = true;
         state.error = '';
       })
-      .addCase(updateDelegatedAccess.fulfilled, (state, action: PayloadAction<DelegatedAccessCreateResult>) => {
+      .addCase(updateDelegatedAccess.fulfilled, (state, action) => {
         state.busy = false;
+        const accessId = action.meta.arg.accessId;
+        if (action.payload.revoked) {
+          state.items = state.items.filter((item) => item.access_id !== accessId);
+          if (state.issuedAccess?.access_id === accessId) {
+            state.issuedToken = '';
+            state.issuedHeader = '';
+            state.issuedAccess = undefined;
+          }
+          state.error =
+            action.payload.message ||
+            'Every selection on this card was withdrawn from the service catalog, so it was revoked.';
+          return;
+        }
+        if (action.payload.status === 409) {
+          // The card the server returned is the current one; the editor reopens
+          // on it instead of retrying against the view it had.
+          state.error =
+            'This access changed while you were editing it. The latest version is shown; review and save again.';
+        }
         if (action.payload.access) {
           const updated = action.payload.access;
           state.items = state.items.map((item) => (item.access_id === updated.access_id ? updated : item));

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/examples/bundles/connection-hub@1-0/ui/widgets/connections/src/styles.css
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/examples/bundles/connection-hub@1-0/ui/widgets/connections/src/styles.css
@@ -1332,6 +1332,42 @@ code {
   font-size: 12px;
 }
 
+.resource-boundaries-bulk {
+  display: flex;
+  gap: 8px;
+  margin-left: auto;
+}
+
+.resource-boundaries-bulk button {
+  background: none;
+  border: none;
+  padding: 0;
+  color: var(--accent, #2f6fd0);
+  font: inherit;
+  cursor: pointer;
+  text-decoration: underline;
+}
+
+.resource-boundaries-bulk button:disabled {
+  color: var(--text-3, #9aa4b2);
+  cursor: default;
+  text-decoration: none;
+}
+
+.grant-chip-blocked {
+  opacity: 0.5;
+}
+
+.grant-chip-blocked input {
+  cursor: not-allowed;
+}
+
+.resource-boundaries-empty {
+  margin: 0 0 8px;
+  color: var(--text-2);
+  font-size: 12px;
+}
+
 .namespace-boundary {
   border-top: 1px solid var(--line-soft);
 }

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/examples/bundles/connection-hub@1-0/ui/widgets/connections/src/styles.css
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/examples/bundles/connection-hub@1-0/ui/widgets/connections/src/styles.css
@@ -1291,6 +1291,22 @@ code {
   accent-color: var(--kind);
 }
 
+/* Selected here, no longer offered by the service catalog: visible so the
+   operator can see what changed, inert because saving removes it. */
+.grant-chip-stale {
+  opacity: 0.7;
+  border-style: dashed;
+}
+
+.grant-chip-stale span:first-of-type {
+  text-decoration: line-through;
+}
+
+.grant-chip-stale:hover {
+  border-color: var(--line);
+  background: transparent;
+}
+
 .grant-chip span {
   min-width: 0;
   overflow-wrap: anywhere;

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/examples/bundles/kdcube-services@1-0/services/named_services/bridge.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/examples/bundles/kdcube-services@1-0/services/named_services/bridge.py
@@ -13,6 +13,7 @@ from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.cat
     CapabilityRequest,
     CardProvenance,
     authorize_current_capability,
+    card_boundary_denial,
     catalog_unavailable_denial,
 )
 from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.catalog.resolver import (
@@ -380,6 +381,28 @@ class NamedServicesMcpBridge:
                 "operation": operation,
             }
         if not policy.operation_configured(tool_name=tool_name, operation=operation):
+            # For a delegated caller the boundary IS the card, and the active
+            # catalog was already consulted above — so reaching here means the
+            # deployment offers this and only the card does not cover it. That
+            # has a remedy its grantor owns, and the denial has to say so:
+            # the mirror of the removal denial, not an anonymous "not allowed".
+            view = delegated_credential_view(self._request)
+            if view.present:
+                return card_boundary_denial(
+                    provenance=CardProvenance(
+                        access_id=view.registry_access_id,
+                        card_revision=view.card_revision,
+                        catalog_version=view.catalog_version,
+                    ),
+                    request=CapabilityRequest(
+                        kind=CAPABILITY_NAMED_SERVICE_OPERATION,
+                        resource=view.resource,
+                        surface="named_service",
+                        outer_operation=tool_name,
+                        namespace=policy.namespace,
+                        operation=operation,
+                    ),
+                )
             return {
                 "ok": False,
                 "error": "named_service_operation_not_configured",

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/examples/bundles/kdcube-services@1-0/services/named_services/bridge.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/examples/bundles/kdcube-services@1-0/services/named_services/bridge.py
@@ -7,6 +7,20 @@ from typing import Any, Iterable, Mapping, Sequence
 from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.credential_view import (
     delegated_credential_view,
 )
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.catalog.authorization import (
+    CAPABILITY_NAMED_SERVICE_OPERATION,
+    ActiveCatalogCapabilities,
+    CapabilityRequest,
+    CardProvenance,
+    authorize_current_capability,
+    catalog_unavailable_denial,
+)
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.catalog.resolver import (
+    CatalogUnavailable,
+)
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.serving import (
+    delegated_serving_resolvers,
+)
 from kdcube_ai_app.apps.chat.sdk.runtime.comm_ctx import (
     get_current_request_context,
     get_current_user_identity,
@@ -120,6 +134,14 @@ def _credential_grants_from_request(request: Any, *, required: Iterable[str] = (
     return available
 
 
+def _denial_code(denial: Mapping[str, Any]) -> str:
+    """Denials carry either a flat error string or a structured error object."""
+    error = denial.get("error")
+    if isinstance(error, Mapping):
+        return str(error.get("code") or "")
+    return str(error or "")
+
+
 def _delegated_grant_record(request: Any) -> dict[str, Any]:
     delegated = getattr(getattr(request, "state", None), "delegated_credential", None)
     if not isinstance(delegated, Mapping):
@@ -216,7 +238,15 @@ class NamedServicesMcpBridge:
             sorted(view.grants),
             _account_scope_summary(view.account_scope),
         )
-        catalog_config = _named_service_catalog_config_from_request(request) or self._config
+        # A card that carries a materialized tree is bounded by it, and an empty
+        # tree is that card's own boundary — falling back to the full descriptor
+        # there would widen what consent narrowed. A request with no delegated
+        # credential, or a card written before the field, runs on the descriptor.
+        catalog_config = (
+            _named_service_catalog_config_from_request(request)
+            if view.named_services_present
+            else self._config
+        )
         # The guarded service decides which connector app serves each provider
         # in auth scenarios (never a user pick): bind its declaration so realm
         # integrations and consent composers resolve it for this request.
@@ -292,6 +322,49 @@ class NamedServicesMcpBridge:
                 project=self._project,
             )
         return endpoint
+
+    async def _current_catalog_denial(
+        self, *, namespace: str, operation: str, tool_name: str
+    ) -> dict[str, Any] | None:
+        """Intersect the requested namespace operation with the active catalog.
+
+        The card's materialized tree proves the operation was selected under
+        the catalog generation the card was saved against; it does not prove
+        the deployment still offers it. Runs on the parsed request, never on a
+        tool name.
+        """
+        view = delegated_credential_view(self._request)
+        if not view.present:
+            # Not a delegated caller: the descriptor is the only boundary.
+            return None
+        resolvers = delegated_serving_resolvers(self._request)
+        if resolvers is None:
+            return catalog_unavailable_denial("delegated_serving_resolvers_absent")
+        try:
+            document = await resolvers.catalog.resolve_active()
+        except CatalogUnavailable as exc:
+            return catalog_unavailable_denial(exc.reason)
+        except Exception:
+            LOGGER.warning(
+                "[kdcube-services.named_services_mcp] active catalog unreadable", exc_info=True
+            )
+            return catalog_unavailable_denial("catalog_unavailable")
+        return authorize_current_capability(
+            catalog=ActiveCatalogCapabilities(document),
+            provenance=CardProvenance(
+                access_id=view.registry_access_id,
+                card_revision=view.card_revision,
+                catalog_version=view.catalog_version,
+            ),
+            request=CapabilityRequest(
+                kind=CAPABILITY_NAMED_SERVICE_OPERATION,
+                resource=view.resource,
+                surface="named_service",
+                outer_operation=tool_name,
+                namespace=namespace,
+                operation=operation,
+            ),
+        )
 
     async def _authorize(self, policy: NamespaceBoundaryPolicy, operation: str, tool_name: str) -> dict[str, Any] | None:
         if not policy.tool_configured(tool_name):
@@ -479,16 +552,20 @@ class NamedServicesMcpBridge:
             if op == OBJECT_ACTION and action_name
             else op
         )
-        denial = await self._authorize(
-            policy, authorization_operation, tool_name=tool_name
+        denial = await self._current_catalog_denial(
+            namespace=ns, operation=authorization_operation, tool_name=tool_name
         )
+        if denial is None:
+            denial = await self._authorize(
+                policy, authorization_operation, tool_name=tool_name
+            )
         if denial is not None:
             LOGGER.warning(
                 "[kdcube-services.named_services_mcp] denied tool=%s operation=%s namespace=%s error=%s missing_grants=%s available_grants=%s delegate=%s grantor=%s",
                 tool_name,
                 op,
                 ns,
-                denial.get("error") or "",
+                _denial_code(denial),
                 denial.get("missing_grants") or [],
                 denial.get("available_grants") or [],
                 trace.get("delegate_identity") or "",

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/examples/bundles/kdcube-services@1-0/services/named_services/bridge.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/examples/bundles/kdcube-services@1-0/services/named_services/bridge.py
@@ -19,6 +19,10 @@ from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.cat
 from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.catalog.resolver import (
     CatalogUnavailable,
 )
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.named_service_policy import (
+    boundary_permits_operation,
+    configured_named_service_operations,
+)
 from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.serving import (
     delegated_serving_resolvers,
 )
@@ -211,6 +215,39 @@ def _runtime_trace_context() -> dict[str, Any]:
     }
 
 
+def _narrow_public_services(
+    services: list[dict[str, Any]], offered: Mapping[str, set[str]]
+) -> list[dict[str, Any]]:
+    """Drop operations the active catalog no longer offers, then the tools and
+    namespaces left with nothing."""
+    kept: list[dict[str, Any]] = []
+    for namespace in services:
+        name = str(namespace.get("namespace") or "")
+        allowed = set(offered.get(name) or ())
+        if not allowed:
+            continue
+        tools: dict[str, Any] = {}
+        for tool_name, raw in dict(namespace.get("tools") or {}).items():
+            tool = dict(raw) if isinstance(raw, Mapping) else {}
+            nested = tool.get("operations")
+            if isinstance(nested, Mapping) and nested:
+                surviving = {
+                    op: policy for op, policy in nested.items() if str(op) in allowed
+                }
+                if not surviving:
+                    continue
+                tool["operations"] = surviving
+            elif str(tool.get("operation") or tool_name) not in allowed:
+                continue
+            tools[str(tool_name)] = tool
+        if not tools:
+            continue
+        narrowed = dict(namespace)
+        narrowed["tools"] = tools
+        kept.append(narrowed)
+    return kept
+
+
 class NamedServicesMcpBridge:
     """MCP-facing adapter for configured KDCube named-service namespaces."""
 
@@ -260,6 +297,11 @@ class NamedServicesMcpBridge:
             if isinstance(catalog_config, Mapping) else None
         )
         self._catalog = NamedServiceBoundaryCatalog(catalog_config)
+        # The card's materialized tree, raw: the shared predicate reads it.
+        # None for a caller with no card.
+        self._card_named_services = (
+            catalog_config if view.named_services_present else None
+        )
 
     def _bind_delegated_request_scope(self):
         # Bind the calling agent's per-provider account scope so the shared
@@ -288,11 +330,58 @@ class NamedServicesMcpBridge:
         )
         return view
 
-    def list_services(self) -> dict[str, Any]:
+    async def _delegated_catalog_operations(
+        self,
+    ) -> tuple[dict[str, set[str]] | None, dict[str, Any] | None]:
+        """``(namespace -> operations the active catalog offers, denial)``.
+
+        Both ``None`` for a caller with no delegated credential: the descriptor
+        is that caller's only boundary. Resolved for the door the request
+        arrived at, because a card may hold several.
+        """
+        view = delegated_credential_view(self._request)
+        if not view.present:
+            return None, None
+        resolvers = delegated_serving_resolvers(self._request)
+        if resolvers is None:
+            return None, catalog_unavailable_denial("delegated_serving_resolvers_absent")
+        try:
+            document = await resolvers.catalog.resolve_active()
+        except CatalogUnavailable as exc:
+            return None, catalog_unavailable_denial(exc.reason)
+        except Exception:
+            LOGGER.warning(
+                "[kdcube-services.named_services_mcp] active catalog unreadable", exc_info=True
+            )
+            return None, catalog_unavailable_denial("catalog_unavailable")
+        resource_cfg = ActiveCatalogCapabilities(document).resource_config(
+            CapabilityRequest(
+                kind=CAPABILITY_NAMED_SERVICE_OPERATION,
+                resource=view.resource,
+                surface="named_service",
+            )
+        )
+        named_services = getattr(resource_cfg, "named_services", None)
+        if not isinstance(named_services, Mapping) or not named_services:
+            return {}, None
+        return configured_named_service_operations(named_services), None
+
+    async def list_services(self) -> dict[str, Any]:
         self._bind_delegated_request_scope()
+        # The listing is bounded by the card's materialized tree, which is what
+        # the catalog offered when the card was saved. Execution intersects that
+        # with the catalog as it is now, so without the same intersection here a
+        # withdrawn operation stays advertised - and the removal denial's own
+        # recovery, "refresh discovery", confirms the wrong answer.
+        offered, denial = await self._delegated_catalog_operations()
+        if denial is not None:
+            return denial
+        services = self._catalog.list_public()
+        if offered is not None:
+            services = _narrow_public_services(services, offered)
         return {
             "ok": True,
-            "services": self._catalog.list_public(),
+            "services": services,
             "note": (
                 "This MCP surface exposes configured named-service namespaces. "
                 "Each namespace operation may require additional delegated grants."
@@ -367,8 +456,51 @@ class NamedServicesMcpBridge:
             ),
         )
 
+    def _card_boundary_denial(
+        self, *, namespace: str, operation: str, tool_name: str
+    ) -> dict[str, Any] | None:
+        """The card-side refusal, or ``None`` for a caller with no card.
+
+        The active catalog was consulted before this, so reaching here means the
+        deployment offers the capability and only the card does not cover it —
+        a remedy its grantor owns. Both the missing-tool and missing-operation
+        branches are that same condition.
+        """
+        view = delegated_credential_view(self._request)
+        if not view.present:
+            return None
+        return card_boundary_denial(
+            provenance=CardProvenance(
+                access_id=view.registry_access_id,
+                card_revision=view.card_revision,
+                catalog_version=view.catalog_version,
+            ),
+            request=CapabilityRequest(
+                kind=CAPABILITY_NAMED_SERVICE_OPERATION,
+                resource=view.resource,
+                surface="named_service",
+                outer_operation=tool_name,
+                namespace=namespace,
+                operation=operation,
+            ),
+        )
+
     async def _authorize(self, policy: NamespaceBoundaryPolicy, operation: str, tool_name: str) -> dict[str, Any] | None:
-        if not policy.tool_configured(tool_name):
+        if self._card_named_services is not None:
+            # The card-side question, answered by the predicate the native
+            # agent gate uses. The tool name is this surface's routing; the
+            # card grants operations.
+            if not boundary_permits_operation(
+                self._card_named_services,
+                namespace=policy.namespace,
+                operation=operation,
+            ):
+                denial = self._card_boundary_denial(
+                    namespace=policy.namespace, operation=operation, tool_name=tool_name
+                )
+                if denial is not None:
+                    return denial
+        elif not policy.tool_configured(tool_name):
             return {
                 "ok": False,
                 "error": "named_service_tool_not_configured",
@@ -380,29 +512,7 @@ class NamedServicesMcpBridge:
                 "tool": tool_name,
                 "operation": operation,
             }
-        if not policy.operation_configured(tool_name=tool_name, operation=operation):
-            # For a delegated caller the boundary IS the card, and the active
-            # catalog was already consulted above — so reaching here means the
-            # deployment offers this and only the card does not cover it. That
-            # has a remedy its grantor owns, and the denial has to say so:
-            # the mirror of the removal denial, not an anonymous "not allowed".
-            view = delegated_credential_view(self._request)
-            if view.present:
-                return card_boundary_denial(
-                    provenance=CardProvenance(
-                        access_id=view.registry_access_id,
-                        card_revision=view.card_revision,
-                        catalog_version=view.catalog_version,
-                    ),
-                    request=CapabilityRequest(
-                        kind=CAPABILITY_NAMED_SERVICE_OPERATION,
-                        resource=view.resource,
-                        surface="named_service",
-                        outer_operation=tool_name,
-                        namespace=policy.namespace,
-                        operation=operation,
-                    ),
-                )
+        elif not policy.operation_configured(tool_name=tool_name, operation=operation):
             return {
                 "ok": False,
                 "error": "named_service_operation_not_configured",

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/examples/bundles/kdcube-services@1-0/surfaces/mcp/named_services.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/examples/bundles/kdcube-services@1-0/surfaces/mcp/named_services.py
@@ -114,7 +114,7 @@ def build_named_services_mcp_app(
         structured_output=False,
     )
     async def _named_services_list() -> dict[str, Any]:
-        return _bridge().list_services()
+        return await _bridge().list_services()
 
     @mcp.tool(
         name="named_services_about",

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/examples/bundles/kdcube-services@1-0/tests/test_bridge_consent_denial.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/examples/bundles/kdcube-services@1-0/tests/test_bridge_consent_denial.py
@@ -43,21 +43,57 @@ class _Policy:
         return ""
 
 
-def _request(client_id: str, grants=None, account_scope=None):
+RESOURCE_PATTERN = (
+    "*/api/integrations/bundles/*/*/kdcube-services@1-0/public/mcp/named_services*"
+)
+
+
+def _bind_catalog(state, namespaces):
+    """A delegated call resolves the active catalog, so a test that reaches
+    dispatch states the generation it runs under."""
+    from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.oauth.tests.helpers import (
+        bind_delegated_catalog,
+    )
+
+    bind_delegated_catalog(
+        SimpleNamespace(state=state),
+        {
+            "delegated_credentials": {
+                "oauth": {
+                    "enabled": True,
+                    "resources": [
+                        {
+                            "resource": RESOURCE_PATTERN,
+                            "grants": ["named_services:use"],
+                            "named_services": {"namespaces": namespaces},
+                        },
+                    ],
+                },
+            },
+        },
+    )
+
+
+def _request(
+    client_id: str,
+    grants=None,
+    account_scope=None,
+    *,
+    catalog_namespaces=None,
+):
     grants = list(grants or ["named_services:use", "slack:read"])
-    return SimpleNamespace(state=SimpleNamespace(delegated_credential={
+    request = SimpleNamespace(state=SimpleNamespace(delegated_credential={
         "credential": {"attrs": {"grants": grants}},
         "grant_record": {
             "client_id": client_id,
             "grants": [],
-            "resource_grants": {
-                "*/api/integrations/bundles/*/*/kdcube-services@1-0/public/mcp/named_services*": [
-                    *grants,
-                ],
-            },
+            "resource_grants": {RESOURCE_PATTERN: [*grants]},
             "account_scope": dict(account_scope or {}),
         },
     }))
+    if catalog_namespaces is not None:
+        _bind_catalog(request.state, catalog_namespaces)
+    return request
 
 
 def _bridge(m, request):
@@ -227,7 +263,11 @@ async def test_bounded_action_authorizes_the_exact_action_key(monkeypatch) -> No
         config=config,
         tenant="t",
         project="p",
-        request=_request("claude", ["named_services:use", "slack:post"]),
+        request=_request(
+            "claude",
+            ["named_services:use", "slack:post"],
+            catalog_namespaces=config["namespaces"],
+        ),
     )
     captured = {}
 
@@ -287,6 +327,7 @@ async def test_tool_call_rebinds_agent_account_scope_before_provider_call(monkey
             "kdcube-agent:ported-langgraph-agents@2026-07-13:lg-react",
             ["named_services:use"],
             account_scope={"slack": {"slack-1": ["slack:files:write"]}},
+            catalog_namespaces=config["namespaces"],
         ),
     )
 
@@ -344,6 +385,7 @@ async def test_account_scope_claim_satisfies_provider_backed_bridge_gate(monkeyp
             "kdcube-agent:ported-langgraph-agents@2026-07-13:lg-react",
             ["named_services:use"],
             account_scope={"slack": {"slack-1": ["slack:channels"]}},
+            catalog_namespaces=config["namespaces"],
         ),
     )
     captured = {}

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/examples/bundles/kdcube-services@1-0/tests/test_bridge_consent_denial.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/examples/bundles/kdcube-services@1-0/tests/test_bridge_consent_denial.py
@@ -404,3 +404,44 @@ async def test_account_scope_claim_satisfies_provider_backed_bridge_gate(monkeyp
 
     assert result["ok"] is True
     assert captured["request"].operation == "object.list"
+
+
+async def test_a_tool_the_card_does_not_carry_denies_like_a_missing_operation():
+    """Narrowing a card can drop a whole tool, not only an operation.
+
+    Narrowing a card drops whole tools as readily as single operations, and
+    both are the same condition: the catalog offers it, the card does not. One
+    predicate over the card's tree answers both, so neither can report a
+    deployment misconfiguration and send the caller to wait for a fix nobody is
+    going to make.
+    """
+    m = _bridge_module()
+    request = _request("dcr-claude")
+    # A card whose tree covers nothing in this namespace.
+    request.state.delegated_credential["grant_record"]["named_services"] = {
+        "namespaces": {"mail": {"tools": {}}}
+    }
+
+    bridge = _bridge(m, request)
+    denial = await bridge._authorize(_Policy(), "object.search", tool_name="search")
+
+    assert denial is not None
+    assert (denial.get("error") or {}).get("code") == "delegated_capability_not_granted", denial
+    recovery = (denial.get("ret") or {}).get("recovery") or {}
+    assert recovery.get("request_user_consent") is True, denial
+    assert recovery.get("action") == "grant_capability_in_delegated_access", denial
+
+
+async def test_a_caller_with_no_card_still_reads_it_as_a_configuration_gap():
+    """Without a card the boundary IS the descriptor, so the old wording holds."""
+    m = _bridge_module()
+
+    class _NoTool(_Policy):
+        def tool_configured(self, tool_name):
+            return False
+
+    bridge = _bridge(m, SimpleNamespace(state=SimpleNamespace()))
+    denial = await bridge._authorize(_NoTool(), "object.search", tool_name="search")
+
+    assert denial is not None
+    assert denial.get("error") == "named_service_tool_not_configured", denial

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/examples/bundles/kdcube-services@1-0/tests/test_bridge_current_catalog.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/examples/bundles/kdcube-services@1-0/tests/test_bridge_current_catalog.py
@@ -1,0 +1,245 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Elena Viter
+
+"""The named-services door intersects the card with the active catalog.
+
+A card's materialized boundary proves an operation was selected under the
+catalog generation the card was saved against. It does not prove the deployment
+still offers it, so the door checks the parsed namespace and operation against
+the active catalog before a provider is selected.
+"""
+
+from __future__ import annotations
+
+import copy
+from pathlib import Path
+from types import SimpleNamespace
+
+from kdcube_ai_app.apps.chat.sdk.runtime.dynamic_module_loader import load_dynamic_module_for_path
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.oauth.tests.helpers import (
+    bind_delegated_catalog,
+)
+
+BUNDLE_ROOT = Path(__file__).resolve().parents[1]
+
+RESOURCE = "*/api/integrations/bundles/*/*/kdcube-services@1-0/public/mcp/named_services*"
+CARD_VERSION = "delegated_catalog_2026-08-09-09-00-00-000_a1b2c3d4e5f6"
+
+NAMED_SERVICES = {
+    "namespaces": {
+        "mail": {
+            "tools": {
+                "search": {"operation": "object.search", "grants": ["named_services:use"]},
+                "schema": {"operation": "object.schema", "grants": ["named_services:use"]},
+            },
+        },
+    },
+}
+
+CONNECTIONS = {
+    "delegated_credentials": {
+        "oauth": {
+            "enabled": True,
+            "resources": [
+                {
+                    "resource": RESOURCE,
+                    "grants": ["named_services:use"],
+                    "tools": {"named_services_search": {"grants": ["named_services:use"]}},
+                    "named_services": copy.deepcopy(NAMED_SERVICES),
+                },
+            ],
+        },
+    },
+}
+
+
+def _bridge_module():
+    _name, module = load_dynamic_module_for_path(
+        BUNDLE_ROOT / "services" / "named_services" / "bridge.py"
+    )
+    return module
+
+
+class _Policy:
+    namespace = "mail"
+
+    def tool_configured(self, tool_name):
+        return True
+
+    def operation_configured(self, *, tool_name, operation):
+        return True
+
+    def grants_for(self, *, tool_name, operation):
+        return []
+
+    def authority_for(self, *, tool_name, operation):
+        return ""
+
+
+def _request(*, delegated=True, connections=CONNECTIONS, unavailable="", resolvers=True):
+    state = SimpleNamespace()
+    if delegated:
+        state.delegated_credential = {
+            "credential": {"attrs": {"grants": ["named_services:use"]}},
+            "grant_record": {
+                "client_id": "claude",
+                "registry_access_id": "oauth-5aa44826664a0bdd",
+                "card_revision": 8,
+                "catalog_version": CARD_VERSION,
+                "resource_grants": {RESOURCE: ["named_services:use"]},
+                "named_services": copy.deepcopy(NAMED_SERVICES),
+            },
+        }
+    if resolvers:
+        bind_delegated_catalog(
+            SimpleNamespace(state=state), connections, unavailable=unavailable
+        )
+    return SimpleNamespace(state=state)
+
+
+def _bridge(module, request, *, config=None):
+    return module.NamedServicesMcpBridge(
+        config=config or {}, tenant="t", project="p", request=request
+    )
+
+
+def _without(namespace: str = "", operation_tool: str = "") -> dict:
+    trimmed = copy.deepcopy(CONNECTIONS)
+    namespaces = trimmed["delegated_credentials"]["oauth"]["resources"][0]["named_services"]["namespaces"]
+    if namespace:
+        namespaces.pop(namespace, None)
+    if operation_tool:
+        namespaces["mail"]["tools"].pop(operation_tool, None)
+    return trimmed
+
+
+async def test_an_operation_the_catalog_still_offers_is_admitted():
+    module = _bridge_module()
+    bridge = _bridge(module, _request())
+
+    denial = await bridge._current_catalog_denial(
+        namespace="mail", operation="object.search", tool_name="named_services_search"
+    )
+
+    assert denial is None
+
+
+async def test_a_namespace_removed_from_the_catalog_denies_with_its_whole_path():
+    module = _bridge_module()
+    bridge = _bridge(module, _request(connections=_without(namespace="mail")))
+
+    denial = await bridge._current_catalog_denial(
+        namespace="mail", operation="object.search", tool_name="named_services_search"
+    )
+
+    assert denial is not None
+    assert denial["error"]["code"] == "delegated_capability_no_longer_available"
+    assert denial["error"]["retryable"] is False
+    ret = denial["ret"]
+    assert ret["access_id"] == "oauth-5aa44826664a0bdd"
+    assert ret["card_revision"] == 8
+    assert ret["card_catalog_version"] == CARD_VERSION
+    assert ret["active_catalog_version"] != CARD_VERSION
+    assert ret["requested_capability"] == {
+        "kind": "named_service_operation",
+        "resource": RESOURCE,
+        "surface": "named_service",
+        "outer_operation": "named_services_search",
+        "namespace": "mail",
+        "operation": "object.search",
+    }
+
+
+async def test_a_removed_operation_denies_while_its_namespace_survives():
+    module = _bridge_module()
+    bridge = _bridge(module, _request(connections=_without(operation_tool="schema")))
+
+    removed = await bridge._current_catalog_denial(
+        namespace="mail", operation="object.schema", tool_name="named_services_schema"
+    )
+    surviving = await bridge._current_catalog_denial(
+        namespace="mail", operation="object.search", tool_name="named_services_search"
+    )
+
+    assert removed is not None
+    assert removed["ret"]["requested_capability"]["operation"] == "object.schema"
+    assert surviving is None
+
+
+async def test_a_caller_without_a_delegated_credential_is_not_narrowed():
+    module = _bridge_module()
+    bridge = _bridge(module, _request(delegated=False))
+
+    denial = await bridge._current_catalog_denial(
+        namespace="mail", operation="object.search", tool_name="named_services_search"
+    )
+
+    assert denial is None
+
+
+async def test_an_unreadable_catalog_is_retryable_unavailability():
+    module = _bridge_module()
+    bridge = _bridge(module, _request(unavailable="durable_active_unreadable"))
+
+    denial = await bridge._current_catalog_denial(
+        namespace="mail", operation="object.search", tool_name="named_services_search"
+    )
+
+    assert denial is not None
+    assert denial["error"]["code"] == "temporarily_unavailable"
+    assert denial["error"]["retryable"] is True
+    assert denial["ret"]["reason"] == "durable_active_unreadable"
+
+
+async def test_uninstalled_serving_resolvers_fail_closed():
+    """Absent readers are a composition failure, never "no requirement"."""
+    module = _bridge_module()
+    bridge = _bridge(module, _request(resolvers=False))
+
+    denial = await bridge._current_catalog_denial(
+        namespace="mail", operation="object.search", tool_name="named_services_search"
+    )
+
+    assert denial is not None
+    assert denial["error"]["code"] == "temporarily_unavailable"
+    assert denial["ret"]["reason"] == "delegated_serving_resolvers_absent"
+
+
+async def test_the_door_refuses_before_a_provider_is_selected(monkeypatch):
+    module = _bridge_module()
+    bridge = _bridge(module, _request(connections=_without(namespace="mail")))
+
+    async def _never(*_args, **_kwargs):
+        raise AssertionError("provider must not be reached")
+
+    monkeypatch.setattr(module, "call_named_service_endpoint", _never)
+
+    payload = await bridge.call(
+        tool_name="named_services_search", operation="object.search", namespace="mail",
+    )
+
+    assert payload["error"]["code"] == "delegated_capability_no_longer_available"
+
+
+async def test_a_delegated_card_with_an_empty_boundary_reaches_no_namespace():
+    """The card's empty tree is its boundary; the descriptor does not refill it."""
+    module = _bridge_module()
+    request = _request()
+    request.state.delegated_credential["grant_record"]["named_services"] = {"namespaces": {}}
+    bridge = _bridge(module, request, config=copy.deepcopy(NAMED_SERVICES))
+
+    payload = await bridge.call(
+        tool_name="named_services_search", operation="object.search", namespace="mail",
+    )
+
+    assert payload["error"] == "namespace_not_configured"
+
+
+async def test_a_card_written_before_the_boundary_field_keeps_the_descriptor():
+    """Absence of the field is a pre-encoding card, not an empty boundary."""
+    module = _bridge_module()
+    request = _request()
+    request.state.delegated_credential["grant_record"].pop("named_services")
+    bridge = _bridge(module, request, config=copy.deepcopy(NAMED_SERVICES))
+
+    assert set(bridge._catalog.namespace_names()) == {"mail"}

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/examples/bundles/kdcube-services@1-0/tests/test_bridge_current_catalog.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/examples/bundles/kdcube-services@1-0/tests/test_bridge_current_catalog.py
@@ -243,3 +243,60 @@ async def test_a_card_written_before_the_boundary_field_keeps_the_descriptor():
     bridge = _bridge(module, request, config=copy.deepcopy(NAMED_SERVICES))
 
     assert set(bridge._catalog.namespace_names()) == {"mail"}
+
+
+class _NarrowedPolicy(_Policy):
+    """The card's boundary: the tool is configured, this operation is not."""
+
+    def operation_configured(self, *, tool_name, operation):
+        return operation != "object.search"
+
+
+async def test_an_operation_the_card_does_not_cover_names_its_remedy():
+    """The mirror of the removal denial.
+
+    The catalog still offers this, so the answer is not "gone" — the card's
+    grantor can add it. Without saying so the door returned an anonymous
+    `named_service_operation_not_configured`, and the caller had nothing to act
+    on in the one case where a remedy exists.
+    """
+    module = _bridge_module()
+    bridge = _bridge(module, _request())
+
+    denial = await bridge._authorize(
+        _NarrowedPolicy(), "object.search", tool_name="named_services_search"
+    )
+
+    assert denial is not None
+    assert denial["error"]["code"] == "delegated_capability_not_granted"
+    assert denial["error"]["retryable"] is False
+    ret = denial["ret"]
+    assert ret["access_id"] == "oauth-5aa44826664a0bdd"
+    assert ret["card_revision"] == 8
+    assert ret["card_catalog_version"] == CARD_VERSION
+    assert ret["recovery"] == {
+        "action": "grant_capability_in_delegated_access",
+        "retry_same_request": False,
+        "request_user_consent": True,
+    }
+    assert ret["requested_capability"] == {
+        "kind": "named_service_operation",
+        "resource": RESOURCE,
+        "surface": "named_service",
+        "outer_operation": "named_services_search",
+        "namespace": "mail",
+        "operation": "object.search",
+    }
+
+
+async def test_a_non_delegated_caller_still_gets_the_descriptor_answer():
+    """Nothing to grant and no card to point at: the boundary is the descriptor
+    itself, so the flat configuration error stays."""
+    module = _bridge_module()
+    bridge = _bridge(module, _request(delegated=False))
+
+    denial = await bridge._authorize(
+        _NarrowedPolicy(), "object.search", tool_name="named_services_search"
+    )
+
+    assert denial["error"] == "named_service_operation_not_configured"

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/examples/bundles/kdcube-services@1-0/tests/test_bridge_current_catalog.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/examples/bundles/kdcube-services@1-0/tests/test_bridge_current_catalog.py
@@ -261,10 +261,16 @@ async def test_an_operation_the_card_does_not_cover_names_its_remedy():
     on in the one case where a remedy exists.
     """
     module = _bridge_module()
-    bridge = _bridge(module, _request())
+    # The card's own tree is the boundary, so narrowing it is how this happens.
+    request = _request()
+    tools = request.state.delegated_credential["grant_record"]["named_services"]
+    tools["namespaces"]["mail"]["tools"].pop("search")
+    bridge = _bridge(module, request)
 
     denial = await bridge._authorize(
-        _NarrowedPolicy(), "object.search", tool_name="named_services_search"
+        bridge._catalog.policy_for("mail"),
+        "object.search",
+        tool_name="named_services_search",
     )
 
     assert denial is not None
@@ -300,3 +306,56 @@ async def test_a_non_delegated_caller_still_gets_the_descriptor_answer():
     )
 
     assert denial["error"] == "named_service_operation_not_configured"
+
+
+async def test_the_listing_hides_an_operation_the_catalog_withdrew():
+    """Discovery is bounded by the card's tree; execution intersects it with the
+    catalog as it is now. Without the same intersection here a withdrawn
+    operation stays advertised, and the removal denial's own recovery -
+    "refresh discovery" - confirms the wrong answer."""
+    module = _bridge_module()
+
+    listed = await _bridge(module, _request()).list_services()
+    mail = next(ns for ns in listed["services"] if ns["namespace"] == "mail")
+    assert "search" in mail["tools"]
+
+    # The card keeps its materialized tree; only the catalog loses the tool.
+    withdrawn = await _bridge(
+        module, _request(connections=_without(operation_tool="search"))
+    ).list_services()
+    mail = next(ns for ns in withdrawn["services"] if ns["namespace"] == "mail")
+    assert "search" not in mail["tools"], mail["tools"]
+    assert "schema" in mail["tools"]
+
+    # And execution agrees with the listing.
+    denial = await _bridge(
+        module, _request(connections=_without(operation_tool="search"))
+    )._current_catalog_denial(
+        namespace="mail", operation="object.search", tool_name="named_services_search"
+    )
+    assert denial is not None
+
+
+async def test_a_namespace_the_catalog_dropped_leaves_the_listing():
+    module = _bridge_module()
+    listed = await _bridge(
+        module, _request(connections=_without(namespace="mail"))
+    ).list_services()
+    assert [ns["namespace"] for ns in listed["services"]] == []
+
+
+async def test_the_listing_fails_closed_when_the_catalog_is_unavailable():
+    """Falling back to the card's tree here would reopen the gap on every cache
+    miss."""
+    module = _bridge_module()
+    listed = await _bridge(module, _request(unavailable="catalog_unavailable")).list_services()
+    assert listed.get("ok") is False
+
+
+async def test_a_caller_with_no_delegated_credential_lists_the_descriptor():
+    module = _bridge_module()
+    bridge = _bridge(
+        module, _request(delegated=False), config=copy.deepcopy(NAMED_SERVICES)
+    )
+    listed = await bridge.list_services()
+    assert [ns["namespace"] for ns in listed["services"]] == ["mail"]

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/examples/bundles/workspace@2026-03-31-13-36/services/platform_session_issuer.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/examples/bundles/workspace@2026-03-31-13-36/services/platform_session_issuer.py
@@ -123,8 +123,17 @@ def delegated_consent_page(
     signout_action = _str(data.get("signout_action")) or "/oauth/logout"
     return_to = _str(data.get("return_to"))
 
+    contract_version = _str(
+        (data.get("consent_contract") or {}).get("version")
+        if isinstance(data.get("consent_contract"), Mapping)
+        else ""
+    )
     hidden = render_consent_authorize_hidden_inputs(oauth_fields)
     hidden += "\n" + _hidden_input("csrf_token", csrf_token)
+    hidden += "\n" + _hidden_input("consent_contract_version", contract_version)
+    hidden += "\n" + _hidden_input(
+        "expected_catalog_version", _str(data.get("catalog_version"))
+    )
 
     grants = data.get("platform_grants") if isinstance(data.get("platform_grants"), list) else []
     grant_rows = "\n".join(
@@ -151,6 +160,39 @@ def delegated_consent_page(
         for item in tools
         if isinstance(item, Mapping) and _str(item.get("name"))
     ) or '<p class="empty">No individual tools requested.</p>'
+
+    operations = (
+        data.get("named_service_operations")
+        if isinstance(data.get("named_service_operations"), list)
+        else []
+    )
+    operation_rows = "\n".join(
+        _checkbox_row(
+            name="named_service_operations",
+            value=f"{_str(item.get('namespace'))}:{_str(item.get('operation'))}",
+            title=f"{_str(item.get('namespace_label'))} · {_str(item.get('label'))}",
+            description=_str(item.get("description")),
+            detail=", ".join(_str(grant) for grant in (item.get("grants") or []) if _str(grant)),
+        )
+        for item in operations
+        if isinstance(item, Mapping) and _str(item.get("namespace")) and _str(item.get("operation"))
+    )
+    operations_html = ""
+    if operation_rows:
+        operations_html = f"""
+          <h2>Named-service operations</h2>
+          <p class="hint">Nothing is selected by default. Selecting none connects
+          this client without named-service access; it can be widened later in
+          Connection Hub.</p>
+          {_checkbox_row(
+              name="named_service_operations_all",
+              value="1",
+              title="Every operation offered right now",
+              description="Bound to the current service catalog; operations added later are not included.",
+              detail="",
+          )}
+{operation_rows}
+"""
 
     account_html = ""
     if grantor_label or grantor_subject:
@@ -233,6 +275,7 @@ def delegated_consent_page(
           <h2>Tool access</h2>
           <p class="hint">Select the concrete tools this client may call.</p>
 {tool_rows}
+{operations_html}
           <div class="actions">
             <button class="primary" type="submit" name="decision" value="approve">Approve</button>
             <button class="secondary" type="submit" name="decision" value="deny">Deny</button>
@@ -262,7 +305,7 @@ def delegated_consent_page(
   </script>
 </body>
 </html>"""
-    return {"html": html_body}
+    return {"html": html_body, "consent_contract_version": contract_version}
 
 
 async def google_login_page(

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/authentication_surface.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/authentication_surface.py
@@ -86,6 +86,12 @@ def connection_hub_auth_enabled() -> bool:
     return _bool(_authenticator_config().get("enabled"), default=False)
 
 
+def connection_hub_app_id() -> str:
+    """The descriptor-named Connection Hub app for this deployment."""
+    cfg = _authenticator_config()
+    return _str(cfg.get("app_id") or cfg.get("bundle_id")) or DEFAULT_CONNECTION_HUB_BUNDLE_ID
+
+
 def _first(*values: Any) -> str:
     for value in values:
         text = _str(value)
@@ -214,7 +220,7 @@ class ConnectionHubAuthenticationSurface:
             pg_pool=pg_pool,
             tenant=tenant,
             project=project,
-            bundle_id=_str(cfg.get("app_id") or cfg.get("bundle_id") or DEFAULT_CONNECTION_HUB_BUNDLE_ID),
+            bundle_id=connection_hub_app_id(),
             operation=_str(cfg.get("operation") or DEFAULT_CONNECTION_HUB_AUTH_OPERATION),
         )
 

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/automation_access.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/automation_access.py
@@ -95,6 +95,10 @@ from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.cat
 from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.catalog.reconcile import (
     reconcile_selection,
 )
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.cards.migration import (
+    MIGRATION_CONFIRMATION_REQUIRED,
+    pre_migration_ambiguity,
+)
 from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.catalog.authorization import (
     CAPABILITY_NAMED_SERVICE_OPERATION,
     ActiveCatalogCapabilities,
@@ -283,8 +287,73 @@ def _subject_from_user(user: Mapping[str, Any]) -> str:
     return ""
 
 
+def _delegate_mutation_refusal(user: Mapping[str, Any]) -> dict[str, Any] | None:
+    """Card authority is changed by the grantor, never by the delegate.
+
+    A delegated caller authenticates as ``integration:<client>:<grantor>``. It
+    would find no card under a grantor-keyed index anyway; this states the rule
+    instead of relying on that.
+    """
+    subject = _subject_from_user(user)
+    if subject.startswith("integration:"):
+        return {
+            "ok": False,
+            "error": "delegated_access_requires_grantor",
+            "message": (
+                "A delegated credential cannot change the authority of the card that "
+                "issued it. Sign in as the granting user in Connection Hub."
+            ),
+        }
+    return None
+
+
+def _grants_delegable(grants: Iterable[str], delegable: set[str]) -> bool:
+    """An entry is offered only when EVERY claim it costs is delegable: ticking
+    it makes the panel demand all of them."""
+    return all(str(grant) in delegable for grant in (grants or ()))
+
+
+def _delegable_named_service_options(
+    namespaces: list[dict[str, Any]], delegable: set[str]
+) -> list[dict[str, Any]]:
+    """Drop operations whose claims this grantor cannot delegate, then tools and
+    namespaces left with nothing."""
+    kept: list[dict[str, Any]] = []
+    for namespace in namespaces:
+        tools = namespace.get("tools")
+        if not isinstance(tools, Mapping):
+            kept.append(namespace)
+            continue
+        kept_tools: dict[str, Any] = {}
+        for tool_name, raw in tools.items():
+            tool = dict(raw) if isinstance(raw, Mapping) else {}
+            operations = tool.get("operations")
+            if isinstance(operations, Mapping) and operations:
+                kept_ops = {
+                    op: policy
+                    for op, policy in operations.items()
+                    if _grants_delegable(
+                        (policy or {}).get("grants") if isinstance(policy, Mapping) else (),
+                        delegable,
+                    )
+                }
+                if not kept_ops:
+                    continue
+                tool["operations"] = kept_ops
+            elif not _grants_delegable(tool.get("grants") or (), delegable):
+                continue
+            kept_tools[tool_name] = tool
+        if not kept_tools:
+            continue
+        narrowed = dict(namespace)
+        narrowed["tools"] = kept_tools
+        kept.append(narrowed)
+    return kept
+
+
 def automation_record_key(tenant: str, project: str, access_id: str) -> str:
-    """The registry card's Redis key — the guard resolves live against it."""
+    """The pre-durable card key format. Nothing reads or writes it; cards live
+    in durable storage and are cached under ``…:delegated-access:card:<id>``."""
     return f"{tenant}:{project}:kdcube:delegated-access:automation:{access_id}"
 
 
@@ -401,18 +470,39 @@ def _selection_policy_argument(
     """The narrowing argument ``named_service_policy_for_resource`` expects.
 
     ``None`` keeps the full descriptor policy, an empty map narrows every
-    resource to nothing, and an exact map narrows to its entries. A legacy
-    record without an explicit selection keeps its prior full-policy meaning
-    until its next successful save writes one.
+    resource to nothing, and an exact map narrows to its entries. Only an
+    explicit ``"*"`` keeps the full policy; a pre-encoding selection reaching
+    here unresolved narrows to nothing rather than widening.
     """
-    if selection.is_all or selection.is_unknown:
+    if selection.is_all:
         return None
-    if selection.is_none:
+    if selection.is_none or selection.is_unknown:
         return {}
     return {
         resource: {namespace: list(values) for namespace, values in namespaces.items()}
         for resource, namespaces in selection.operations.items()
     }
+
+
+@dataclass(frozen=True)
+class ResolvedCardAuthority:
+    """What a save writes, or why it cannot.
+
+    ``revoke`` is the reconciliation outcome where nothing survived the active
+    catalog: an empty card is revoked, never persisted.
+    """
+
+    resource_grants: dict[str, list[str]] = field(default_factory=dict)
+    operations: list[str] = field(default_factory=list)
+    named_service_operations: NamedServiceSelection = field(
+        default_factory=NamedServiceSelection.none
+    )
+    named_services: dict[str, Any] = field(default_factory=dict)
+    account_scope: dict[str, dict[str, list[str]]] = field(default_factory=dict)
+    identity_scope: str = "grantor"
+    reconciled: Any = None
+    revoke: bool = False
+    error: dict[str, Any] | None = None
 
 
 def _inherited_selection(
@@ -427,11 +517,14 @@ def _inherited_selection(
     by construction, so freezing needs no historical catalog document and works
     even when the referenced version is gone.
 
+    A pre-encoding record names no operations either, and the design resolves
+    it the same way: "derive the prior exact set from stored named_services".
+
     An explicitly submitted ``"*"`` does not come through here — that one is
     consent to everything the current catalog shows.
     """
     selection = existing.named_service_operations
-    if not selection.is_all:
+    if not (selection.is_all or selection.is_unknown):
         return selection
     # Filtered by the claims THIS save persists, not the ones the record used to
     # hold: a wildcard boundary is the descriptor tree unfiltered, an exact
@@ -752,6 +845,14 @@ class AutomationAccessService:
         authority, handles = loaded
         return record_from_card(authority, handles)
 
+    async def _committed_revision(self, access_id: str, *, grantor_subject: str) -> int:
+        """The write precondition for this id. A revoked or expired card is not
+        live authority but still owns the counter, so this is not derived from
+        the loaded record."""
+        return await self._cards().current_revision(
+            access_id, subject_hash=_subject_key(grantor_subject)
+        )
+
     async def _persist_record(
         self, record: AutomationAccessRecord, *, expected_revision: int
     ) -> None:
@@ -911,15 +1012,6 @@ class AutomationAccessService:
             raise CatalogUnavailable("active_catalog_version_missing")
         return version
 
-    def _key(self, suffix: str) -> str:
-        return f"{self._tenant}:{self._project}:kdcube:delegated-access:{suffix}"
-
-    def _record_key(self, access_id: str) -> str:
-        return self._key(f"automation:{access_id}")
-
-    def _index_key(self, grantor_subject: str) -> str:
-        return self._key(f"automation-by-grantor:{_subject_key(grantor_subject)}")
-
     async def _available_inventory(
         self,
         user: Mapping[str, Any],
@@ -1003,7 +1095,14 @@ class AutomationAccessService:
         return namespaces
 
     async def resource_options(self, user: Mapping[str, Any]) -> list[dict[str, Any]]:
+        """The catalog projected through what THIS grantor may delegate.
+
+        A card can never carry more than its grantor holds, so a claim outside
+        their delegable set is not offered — the same rule the admin-only row
+        above already applies to whole resources.
+        """
         platform_admin = _is_platform_admin(user)
+        delegable = set((await self._available_inventory(user)).grant_names())
         out: list[dict[str, Any]] = []
         for resource in self._config.resources:
             if resource.admin_only and not platform_admin:
@@ -1012,7 +1111,9 @@ class AutomationAccessService:
                 "resource": resource.resource,
                 "label": resource.label or resource.resource,
                 "identity_scope": resource.identity_scope,
-                "grants": list(resource.grants),
+                "grants": [
+                    grant for grant in resource.grants if grant in delegable
+                ],
                 "admin_only": bool(resource.admin_only),
                 "operations": [
                     {
@@ -1022,37 +1123,47 @@ class AutomationAccessService:
                         "grants": list(tool.grants),
                     }
                     for tool in resource.tools
+                    if _grants_delegable(tool.grants, delegable)
                 ],
             }
             if isinstance(resource.named_services, Mapping):
-                named_services = await self._named_service_options(resource.named_services)
+                named_services = _delegable_named_service_options(
+                    await self._named_service_options(resource.named_services),
+                    delegable,
+                )
                 if named_services:
                     option["named_services"] = named_services
             out.append(option)
         return out
 
     def _configured_resource(self, resource: str) -> Any | None:
-        text = _clean(resource).rstrip("/")
+        """The catalog row governing a card resource. Matched, not compared:
+        a card key is the row's pattern or a concrete URL."""
+        text = _clean(resource)
         if not text:
             return None
-        for item in self._config.resources:
-            if str(item.resource or "").strip().rstrip("/") == text:
-                return item
-        return None
+        return self._config.card_selector_config(text)
 
-    def _configured_resources(self, resources: Iterable[str]) -> tuple[Any, ...]:
+    def _configured_resource_pairs(
+        self, resources: Iterable[str]
+    ) -> tuple[tuple[str, Any], ...]:
+        """``(card resource, governing row)``. Grants and the selection are
+        keyed by the card resource, the descriptor subtree by the row."""
         selected = _as_list(list(resources))
-        configs: list[Any] = []
+        pairs: list[tuple[str, Any]] = []
         missing: list[str] = []
         for resource in selected:
             cfg = self._configured_resource(resource)
             if cfg is None:
                 missing.append(resource)
             else:
-                configs.append(cfg)
+                pairs.append((resource, cfg))
         if missing:
             raise ValueError("unknown delegated resource(s): " + ", ".join(missing))
-        return tuple(configs)
+        return tuple(pairs)
+
+    def _configured_resources(self, resources: Iterable[str]) -> tuple[Any, ...]:
+        return tuple(cfg for _, cfg in self._configured_resource_pairs(resources))
 
     def _resource_grants(self, resource_grants: Mapping[str, Any]) -> dict[str, list[str]]:
         out: dict[str, list[str]] = {}
@@ -1127,10 +1238,42 @@ class AutomationAccessService:
                 "status": 503,
             }
         drift_by_card = await self._catalog_drift(records_found)
+        try:
+            active = await self._active_catalog()
+        except CatalogUnavailable:
+            active = None
         records = []
         for record in records_found:
             item = record.to_public_dict()
             item["catalog_drift"] = drift_by_card[record.access_id]
+            # Reported, never applied: listing does not rewrite a record.
+            ambiguity = pre_migration_ambiguity(
+                record,
+                named_service_resources=[
+                    resource
+                    for resource in record.resource_grants
+                    if isinstance(
+                        getattr(self._configured_resource(resource), "named_services", None),
+                        Mapping,
+                    )
+                ],
+                offered=(
+                    self._catalog_named_service_operations(active, record.resource_grants)
+                    if active is not None
+                    else None
+                ),
+            )
+            if ambiguity is not None:
+                item["migration"] = ambiguity
+            # Card resource -> the catalog row it resolves to. A surface must
+            # not re-derive this: the match is the resolver's, not a comparison.
+            rows = {}
+            for resource in record.resource_grants:
+                cfg = self._configured_resource(resource)
+                if cfg is not None:
+                    rows[resource] = str(getattr(cfg, "resource", "") or "")
+            if rows:
+                item["catalog_row_by_resource"] = rows
             records.append(item)
 
         records.sort(key=lambda item: str(item.get("created_at") or ""), reverse=True)
@@ -1183,6 +1326,9 @@ class AutomationAccessService:
         grantor_subject = _subject_from_user(user)
         if not grantor_subject:
             return {"ok": False, "error": "delegated_access_requires_authenticated_user"}
+        refusal = _delegate_mutation_refusal(user)
+        if refusal is not None:
+            return refusal
 
         selected_resource_grants = self._resource_grants(resource_grants)
         try:
@@ -1214,7 +1360,10 @@ class AutomationAccessService:
         # states what its surface can delegate, this deployment decides how much
         # of that may be asked for here, and until it says so the answer is no.
         try:
-            resource_configs = self._configured_resources(selected_resources) if self._config.resources else ()
+            resource_pairs = (
+                self._configured_resource_pairs(selected_resources)
+                if self._config.resources else ()
+            )
         except ValueError:
             return {
                 "ok": False,
@@ -1226,6 +1375,7 @@ class AutomationAccessService:
                     "with the tools it may grant, before access to it can be asked for."
                 ),
             }
+        resource_configs = tuple(cfg for _, cfg in resource_pairs)
 
         inventory = await self._available_inventory(user, requested_grants=selected_grants)
         available = set(inventory.grant_names())
@@ -1236,9 +1386,11 @@ class AutomationAccessService:
                 "error": "delegated_access_grants_not_delegable",
                 "grants": denied,
                 "message": (
-                    "These permissions are not among the ones this deployment allows for "
-                    "the endpoint. They are configured in connection-hub@1-0 "
-                    "`connections.delegated_credentials.oauth.resources`, per tool."
+                    "These permissions are not yours to delegate. A card never carries "
+                    "more than its grantor holds. Who may delegate each permission is "
+                    "declared in connection-hub@1-0 "
+                    "`connections.delegated_credentials.oauth.capabilities`, as "
+                    "`delegable_roles` and `delegable_permissions`."
                 ),
             }
         admin_required = [cfg.resource for cfg in resource_configs if cfg.admin_only]
@@ -1248,7 +1400,7 @@ class AutomationAccessService:
                 "error": "delegated_access_resource_requires_admin",
                 "resources": admin_required,
             }
-        cfg_by_resource = {cfg.resource: cfg for cfg in resource_configs}
+        cfg_by_resource = dict(resource_pairs)
         if selected_named_service_operations is not None and selected_named_service_operations.is_exact:
             unknown_selection_resources = sorted(
                 set(selected_named_service_operations.operations) - set(selected_resources)
@@ -1281,6 +1433,14 @@ class AutomationAccessService:
                 "ok": False,
                 "error": "delegated_access_resources_have_conflicting_identity_scopes",
                 "resources": selected_resources,
+                "identity_scopes": sorted(identity_scopes),
+                "message": (
+                    "A card issues one credential, so every endpoint on it must run "
+                    "under the same identity. These do not: " + ", ".join(sorted(identity_scopes))
+                    + ". The value is `identity_scope` in connection-hub@1-0 "
+                    "`connections.delegated_credentials.oauth.resources`. Grant "
+                    "endpoints that differ on separate cards."
+                ),
             }
         identity_scope = next(iter(identity_scopes), "grantor")
 
@@ -1376,14 +1536,17 @@ class AutomationAccessService:
             access_id = "aut_" + secrets.token_urlsafe(10)
             client_id = f"{AUTOMATION_CLIENT_PREFIX}:{access_id}"
 
-        # A create call that names no selection grants the full policy of the
-        # catalog it is saved against, and a legacy card resolves to the same
-        # explicit state on its next save.
-        if (
-            selected_named_service_operations is None
-            or selected_named_service_operations.is_unknown
-        ):
-            selected_named_service_operations = NamedServiceSelection.all()
+        # A create call that names no selection selects nothing. `"*"` is stored
+        # only when the user chose every operation the current catalog offers;
+        # claims do not select operations on their own.
+        if selected_named_service_operations is None:
+            selected_named_service_operations = NamedServiceSelection.none()
+        elif selected_named_service_operations.is_unknown:
+            selected_named_service_operations = (
+                _inherited_selection(existing, selected_resource_grants)
+                if existing is not None
+                else NamedServiceSelection.none()
+            )
         try:
             catalog_version = await self._active_catalog_version()
         except CatalogUnavailable as exc:
@@ -1395,15 +1558,28 @@ class AutomationAccessService:
                 "status": 503,
             }
 
+        try:
+            committed_revision = await self._committed_revision(
+                access_id, grantor_subject=grantor_subject
+            )
+        except CardUnavailable as exc:
+            return {
+                "ok": False,
+                "error": "delegated_cards_unavailable",
+                "reason": exc.reason,
+                "retryable": True,
+                "status": 503,
+            }
+
         named_services: dict[str, Any] = {}
-        for cfg in resource_configs:
+        for resource_value, cfg in resource_pairs:
             if isinstance(cfg.named_services, Mapping):
                 try:
                     selected_policy = named_service_policy_for_resource(
                         named_services=cfg.named_services,
-                        resource=cfg.resource,
+                        resource=resource_value,
                         selection=_selection_policy_argument(selected_named_service_operations),
-                        grants=selected_resource_grants.get(cfg.resource, []),
+                        grants=selected_resource_grants.get(resource_value, []),
                     )
                 except ValueError as exc:
                     return {
@@ -1491,7 +1667,7 @@ class AutomationAccessService:
             },
             identity_scope=identity_scope,
             catalog_version=catalog_version,
-            card_revision=(existing.card_revision + 1) if existing is not None else 1,
+            card_revision=committed_revision + 1,
             session_id=session_id,
             created_at=created_at,
             expires_at=expires_at,
@@ -1503,9 +1679,7 @@ class AutomationAccessService:
             access_token=access_token if access_source == ACCESS_SOURCE_AGENT else "",
         )
         try:
-            await self._persist_record(
-                record, expected_revision=existing.card_revision if existing is not None else 0
-            )
+            await self._persist_record(record, expected_revision=committed_revision)
         except (CardUnavailable, CardConflict, CardCommitFailed) as exc:
             return {
                 "ok": False,
@@ -1523,6 +1697,226 @@ class AutomationAccessService:
             "authorization_header": f"Bearer {access_token}" if access_token else "",
         }
 
+    async def _resolve_card_authority(
+        self,
+        *,
+        user: Mapping[str, Any],
+        existing: "AutomationAccessRecord",
+        active: Any,
+        resource_grants: Mapping[str, Any],
+        named_service_operations: Mapping[str, Any] | str | None,
+        account_scope: Mapping[str, Any] | None,
+    ) -> "ResolvedCardAuthority":
+        """The authority a save writes, resolved once for every entrance.
+
+        Owns the decisions, not the record: selection resolution, catalog
+        reconciliation, the delegability checks, the materialized boundary, and
+        the account binding. Callers own identity, preconditions, and the
+        credential fields their family carries.
+        """
+        selected_resource_grants = self._resource_grants(resource_grants)
+        try:
+            selected_named_service_operations = self._named_service_operation_selection(
+                named_service_operations
+            )
+        except ValueError as exc:
+            return ResolvedCardAuthority(error={
+                "ok": False,
+                "error": "invalid_named_service_operation_selection",
+                "message": str(exc),
+            })
+        if selected_named_service_operations is None:
+            ambiguity = pre_migration_ambiguity(
+                existing,
+                named_service_resources=[
+                    resource
+                    for resource in selected_resource_grants
+                    if isinstance(
+                        getattr(self._configured_resource(resource), "named_services", None),
+                        Mapping,
+                    )
+                ],
+                offered=self._catalog_named_service_operations(active, selected_resource_grants),
+            )
+            if ambiguity is not None:
+                return ResolvedCardAuthority(error={
+                    "ok": False,
+                    "error": MIGRATION_CONFIRMATION_REQUIRED,
+                    "message": (
+                        "This card predates the explicit named-service encoding and its "
+                        "stored evidence cannot be read without guessing. Review the "
+                        "operations and save an explicit selection."
+                    ),
+                    **ambiguity,
+                })
+        # Resolved before pruning: pruning acts on the selection about to be
+        # persisted. Omitted keeps the record's own state; a pre-encoding record
+        # resolves to what it materialized.
+        if (
+            selected_named_service_operations is None
+            or selected_named_service_operations.is_unknown
+        ):
+            selected_named_service_operations = _inherited_selection(
+                existing, selected_resource_grants
+            )
+
+        # Submitting nothing is a client error; pruning to nothing is a revoke.
+        if not any(selected_resource_grants.values()):
+            return ResolvedCardAuthority(error={
+                "ok": False, "error": "delegated_access_requires_resource_grants",
+            })
+
+        # Values absent from the active catalog are pruned, not rejected.
+        reconciled = reconcile_selection(
+            resource_grants=selected_resource_grants,
+            named_service_operations=selected_named_service_operations,
+            active=active,
+        )
+        if reconciled.empty:
+            return ResolvedCardAuthority(reconciled=reconciled, revoke=True)
+        selected_resource_grants = reconciled.resource_grants
+        selected_named_service_operations = reconciled.named_service_operations
+        selected_resources = list(selected_resource_grants)
+        if self._config.resources and not selected_resources:
+            return ResolvedCardAuthority(error={
+                "ok": False, "error": "delegated_access_requires_resource_grants",
+            })
+        selected_grants = _as_list([
+            grant
+            for grants_for_resource in selected_resource_grants.values()
+            for grant in grants_for_resource
+        ])
+        if not selected_grants:
+            # Removing everything is a revoke, not an edit.
+            return ResolvedCardAuthority(error={
+                "ok": False, "error": "delegated_access_requires_resource_grants",
+            })
+        # Same order as create_access: an endpoint this deployment never made
+        # delegable is a different answer from a permission it will not delegate.
+        try:
+            resource_pairs = (
+                self._configured_resource_pairs(selected_resources)
+                if self._config.resources else ()
+            )
+        except ValueError:
+            return ResolvedCardAuthority(error={
+                "ok": False,
+                "error": "delegated_access_unknown_resources",
+                "resources": selected_resources,
+                "message": (
+                    "This deployment has not made that endpoint delegable. Add it to "
+                    "connection-hub@1-0 `connections.delegated_credentials.oauth.resources`, "
+                    "with the tools it may grant, before access to it can be asked for."
+                ),
+            })
+        resource_configs = tuple(cfg for _, cfg in resource_pairs)
+        inventory = await self._available_inventory(user, requested_grants=selected_grants)
+        denied = [grant for grant in selected_grants if grant not in set(inventory.grant_names())]
+        if denied:
+            return ResolvedCardAuthority(error={
+                "ok": False,
+                "error": "delegated_access_grants_not_delegable",
+                "grants": denied,
+                "message": (
+                    "These permissions are not yours to delegate. A card never carries "
+                    "more than its grantor holds. Who may delegate each permission is "
+                    "declared in connection-hub@1-0 "
+                    "`connections.delegated_credentials.oauth.capabilities`, as "
+                    "`delegable_roles` and `delegable_permissions`."
+                ),
+            })
+        admin_required = [cfg.resource for cfg in resource_configs if cfg.admin_only]
+        if admin_required and not _is_platform_admin(user):
+            return ResolvedCardAuthority(error={
+                "ok": False,
+                "error": "delegated_access_resource_requires_admin",
+                "resources": admin_required,
+            })
+        cfg_by_resource = dict(resource_pairs)
+        if selected_named_service_operations is not None and selected_named_service_operations.is_exact:
+            unknown = sorted(
+                set(selected_named_service_operations.operations) - set(selected_resources)
+            )
+            if unknown:
+                return ResolvedCardAuthority(error={
+                    "ok": False,
+                    "error": "delegated_access_unknown_named_service_resources",
+                    "resources": unknown,
+                })
+        for resource_value, grants_for_resource in selected_resource_grants.items():
+            cfg = cfg_by_resource.get(resource_value)
+            if cfg is None:
+                continue
+            allowed_for_resource = set(self._config.supported_scopes(resource_value))
+            disallowed = [grant for grant in grants_for_resource if grant not in allowed_for_resource]
+            if disallowed:
+                return ResolvedCardAuthority(error={
+                    "ok": False,
+                    "error": "delegated_access_grants_not_allowed_for_resources",
+                    "grants": disallowed,
+                    "resource": resource_value,
+                })
+        identity_scopes = {
+            _clean(getattr(cfg, "identity_scope", "") or "grantor") for cfg in resource_configs
+        }
+        if len(identity_scopes) > 1:
+            return ResolvedCardAuthority(error={
+                "ok": False,
+                "error": "delegated_access_resources_have_conflicting_identity_scopes",
+                "resources": selected_resources,
+                "identity_scopes": sorted(identity_scopes),
+                "message": (
+                    "A card issues one credential, so every endpoint on it must run "
+                    "under the same identity. These do not: " + ", ".join(sorted(identity_scopes))
+                    + ". The value is `identity_scope` in connection-hub@1-0 "
+                    "`connections.delegated_credentials.oauth.resources`. Grant "
+                    "endpoints that differ on separate cards."
+                ),
+            })
+        # Recompute the boundary tree here: the descriptor is available in this
+        # process, the guard's is not.
+        named_services: dict[str, Any] = {}
+        for resource_value, cfg in resource_pairs:
+            if not isinstance(cfg.named_services, Mapping):
+                continue
+            try:
+                selected_policy = named_service_policy_for_resource(
+                    named_services=cfg.named_services,
+                    resource=resource_value,
+                    # Same value the record stores, so the tree and the
+                    # selection it was derived from cannot disagree.
+                    selection=_selection_policy_argument(selected_named_service_operations),
+                    grants=selected_resource_grants.get(resource_value, []),
+                )
+            except ValueError as exc:
+                return ResolvedCardAuthority(error={
+                    "ok": False,
+                    "error": "invalid_named_service_operation_selection",
+                    "message": str(exc),
+                })
+            named_services = self._merge_named_service_configs(named_services, selected_policy)
+        if account_scope is None:
+            selected_account_scope = {
+                provider: {account_id: list(claims) for account_id, claims in accounts.items()}
+                for provider, accounts in existing.account_scope.items()
+            }
+        else:
+            selected_account_scope = {
+                provider: {account_id: list(claims) for account_id, claims in accounts.items()}
+                for provider, accounts in normalize_account_scope(account_scope).items()
+            }
+        return ResolvedCardAuthority(
+            resource_grants=selected_resource_grants,
+            operations=self._resolve_operations(
+                grants=selected_grants, operations=(), resources=selected_resources,
+            ),
+            named_service_operations=selected_named_service_operations,
+            named_services=named_services,
+            account_scope=selected_account_scope,
+            identity_scope=next(iter(identity_scopes), existing.identity_scope or "grantor"),
+            reconciled=reconciled,
+        )
+
     async def update_access(
         self,
         user: Mapping[str, Any],
@@ -1535,15 +1929,19 @@ class AutomationAccessService:
         expected_card_revision: int | None = None,
         expected_catalog_version: str | None = None,
     ) -> dict[str, Any]:
-        """Edit a MANUAL automation access IN PLACE: replace its grants while
-        keeping the same access_id and token. The card is the guard's authority
-        (resolved live via resolve_live_grant_card), so the change applies to the
-        client's existing bearer on its very next call — no re-mint. A manual
-        token is client-side only, so it is never touched; only the card record
-        is rewritten. The submitted selection REPLACES the record exactly."""
+        """Edit a card's authority IN PLACE, whatever family issued it.
+
+        The card keeps its access_id and its credential material; the card is
+        the guard's authority (resolved live via resolve_live_grant_card), so
+        the change applies to the client's existing bearer on its very next call
+        — no re-mint, no re-authorization. The submitted selection REPLACES the
+        record exactly."""
         grantor_subject = _subject_from_user(user)
         if not grantor_subject:
             return {"ok": False, "error": "delegated_access_requires_authenticated_user"}
+        refusal = _delegate_mutation_refusal(user)
+        if refusal is not None:
+            return refusal
         access_id = _clean(access_id)
         if not access_id:
             return {"ok": False, "error": "delegated_access_requires_access_id"}
@@ -1561,10 +1959,8 @@ class AutomationAccessService:
             return {"ok": False, "error": "delegated_access_not_found"}
         if existing.grantor_subject != grantor_subject:
             return {"ok": False, "error": "delegated_access_not_owned"}
-        # Only a manual automation card is edited here. Agent/OAuth cards edit
-        # through their own consent flows (delegated_agent_grant_create).
-        if existing.source != ACCESS_SOURCE_MANUAL:
-            return {"ok": False, "error": "delegated_access_not_editable"}
+        # Every family edits here. The source records how the credential is
+        # managed; it does not decide whether the grantor may change authority.
 
         try:
             active = await self._active_catalog()
@@ -1594,34 +1990,18 @@ class AutomationAccessService:
         if conflict is not None:
             return conflict
 
-        # Validate the new grants with the SAME rules as create_access.
-        selected_resource_grants = self._resource_grants(resource_grants)
-        try:
-            selected_named_service_operations = self._named_service_operation_selection(
-                named_service_operations
-            )
-        except ValueError as exc:
-            return {"ok": False, "error": "invalid_named_service_operation_selection", "message": str(exc)}
-        # Resolved before pruning: pruning acts on the selection about to be
-        # persisted. Omitted keeps the record's own state; legacy becomes "*".
-        if selected_named_service_operations is None:
-            selected_named_service_operations = _inherited_selection(
-                existing, selected_resource_grants
-            )
-        if selected_named_service_operations.is_unknown:
-            selected_named_service_operations = NamedServiceSelection.all()
-
-        # Submitting nothing is a client error; pruning to nothing is a revoke.
-        if not any(selected_resource_grants.values()):
-            return {"ok": False, "error": "delegated_access_requires_resource_grants"}
-
-        # Values absent from the active catalog are pruned, not rejected.
-        reconciled = reconcile_selection(
-            resource_grants=selected_resource_grants,
-            named_service_operations=selected_named_service_operations,
+        resolved = await self._resolve_card_authority(
+            user=user,
+            existing=existing,
             active=active,
+            resource_grants=resource_grants,
+            named_service_operations=named_service_operations,
+            account_scope=account_scope,
         )
-        if reconciled.empty:
+        if resolved.error is not None:
+            return resolved.error
+        reconciled = resolved.reconciled
+        if resolved.revoke:
             # No authority survives: revoke rather than keep an empty card.
             revoked = await self.revoke_access(user, access_id=access_id)
             if not revoked.get("ok"):
@@ -1636,110 +2016,12 @@ class AutomationAccessService:
                     "catalog, so the card was revoked instead of saved."
                 ),
             }
-        selected_resource_grants = reconciled.resource_grants
-        selected_named_service_operations = reconciled.named_service_operations
-        selected_resources = list(selected_resource_grants)
-        if self._config.resources and not selected_resources:
-            return {"ok": False, "error": "delegated_access_requires_resource_grants"}
-        selected_grants = _as_list([
-            grant
-            for grants_for_resource in selected_resource_grants.values()
-            for grant in grants_for_resource
-        ])
-        if not selected_grants:
-            # Removing everything is a revoke, not an edit.
-            return {"ok": False, "error": "delegated_access_requires_resource_grants"}
-        # Same order as create_access: an endpoint this deployment never made
-        # delegable is a different answer from a permission it will not delegate.
-        try:
-            resource_configs = self._configured_resources(selected_resources) if self._config.resources else ()
-        except ValueError:
-            return {
-                "ok": False,
-                "error": "delegated_access_unknown_resources",
-                "resources": selected_resources,
-                "message": (
-                    "This deployment has not made that endpoint delegable. Add it to "
-                    "connection-hub@1-0 `connections.delegated_credentials.oauth.resources`, "
-                    "with the tools it may grant, before access to it can be asked for."
-                ),
-            }
-        inventory = await self._available_inventory(user, requested_grants=selected_grants)
-        denied = [grant for grant in selected_grants if grant not in set(inventory.grant_names())]
-        if denied:
-            return {
-                "ok": False,
-                "error": "delegated_access_grants_not_delegable",
-                "grants": denied,
-                "message": (
-                    "These permissions are not among the ones this deployment allows for "
-                    "the endpoint. They are configured in connection-hub@1-0 "
-                    "`connections.delegated_credentials.oauth.resources`, per tool."
-                ),
-            }
-        admin_required = [cfg.resource for cfg in resource_configs if cfg.admin_only]
-        if admin_required and not _is_platform_admin(user):
-            return {"ok": False, "error": "delegated_access_resource_requires_admin", "resources": admin_required}
-        cfg_by_resource = {cfg.resource: cfg for cfg in resource_configs}
-        if selected_named_service_operations is not None and selected_named_service_operations.is_exact:
-            unknown = sorted(
-                set(selected_named_service_operations.operations) - set(selected_resources)
-            )
-            if unknown:
-                return {"ok": False, "error": "delegated_access_unknown_named_service_resources", "resources": unknown}
-        for resource_value, grants_for_resource in selected_resource_grants.items():
-            cfg = cfg_by_resource.get(resource_value)
-            if cfg is None:
-                continue
-            allowed_for_resource = set(self._config.supported_scopes(resource_value))
-            disallowed = [grant for grant in grants_for_resource if grant not in allowed_for_resource]
-            if disallowed:
-                return {
-                    "ok": False,
-                    "error": "delegated_access_grants_not_allowed_for_resources",
-                    "grants": disallowed,
-                    "resource": resource_value,
-                }
-        identity_scopes = {
-            _clean(getattr(cfg, "identity_scope", "") or "grantor") for cfg in resource_configs
-        }
-        if len(identity_scopes) > 1:
-            return {
-                "ok": False,
-                "error": "delegated_access_resources_have_conflicting_identity_scopes",
-                "resources": selected_resources,
-            }
-        # Recompute the boundary tree here: the descriptor is available in this
-        # process, the guard's is not.
-        named_services: dict[str, Any] = {}
-        for cfg in resource_configs:
-            if not isinstance(cfg.named_services, Mapping):
-                continue
-            try:
-                selected_policy = named_service_policy_for_resource(
-                    named_services=cfg.named_services,
-                    resource=cfg.resource,
-                    # Same value the record stores below, so the tree and the
-                    # selection it was derived from cannot disagree.
-                    selection=_selection_policy_argument(selected_named_service_operations),
-                    grants=selected_resource_grants.get(cfg.resource, []),
-                )
-            except ValueError as exc:
-                return {"ok": False, "error": "invalid_named_service_operation_selection", "message": str(exc)}
-            named_services = self._merge_named_service_configs(named_services, selected_policy)
-        selected_operations = self._resolve_operations(
-            grants=selected_grants, operations=(), resources=selected_resources,
-        )
-        if account_scope is None:
-            selected_account_scope = {
-                provider: {account_id: list(claims) for account_id, claims in accounts.items()}
-                for provider, accounts in existing.account_scope.items()
-            }
-        else:
-            selected_account_scope = {
-                provider: {account_id: list(claims) for account_id, claims in accounts.items()}
-                for provider, accounts in normalize_account_scope(account_scope).items()
-            }
+        selected_resource_grants = resolved.resource_grants
+        selected_named_service_operations = resolved.named_service_operations
+        named_services = resolved.named_services
+        selected_operations = resolved.operations
+        selected_account_scope = resolved.account_scope
+
 
         now = int(time.time())
         if existing.expires_at <= now:
@@ -1759,7 +2041,7 @@ class AutomationAccessService:
                 provider: {account_id: tuple(claims) for account_id, claims in accounts.items()}
                 for provider, accounts in selected_account_scope.items()
             },
-            identity_scope=next(iter(identity_scopes), existing.identity_scope or "grantor"),
+            identity_scope=resolved.identity_scope,
             catalog_version=catalog_version,
             card_revision=existing.card_revision + 1,
             session_id=existing.session_id,
@@ -1767,8 +2049,13 @@ class AutomationAccessService:
             expires_at=existing.expires_at,
             last_four=existing.last_four,
             source=existing.source,
-            # Manual token stays client-side only; the record never holds it.
-            access_token="",
+            # Credential material is the card family's lifecycle, not its
+            # authority: an agent's reusable bearer and an OAuth client's token
+            # handles survive an authority edit untouched. A manual card holds
+            # none — its token is client-side only.
+            refresh_token=existing.refresh_token,
+            access_token=existing.access_token,
+            last_issued_at=existing.last_issued_at,
         )
         del remaining
         try:
@@ -2025,6 +2312,52 @@ class AutomationAccessService:
             )
         return None
 
+    @staticmethod
+    def _catalog_named_service_operations(
+        active: Any,
+        resource_grants: Mapping[str, Any],
+    ) -> dict[str, set[str]]:
+        """``namespace -> operations`` the active catalog offers for these resources."""
+        capabilities = ActiveCatalogCapabilities(active)
+        offered: dict[str, set[str]] = {}
+        for resource in resource_grants:
+            cfg = capabilities.resource_config(
+                CapabilityRequest(
+                    kind=CAPABILITY_NAMED_SERVICE_OPERATION,
+                    resource=_clean(resource),
+                    surface="named_service",
+                    namespace="-",
+                    operation="-",
+                )
+            )
+            block = getattr(cfg, "named_services", None) if cfg is not None else None
+            if not isinstance(block, Mapping):
+                continue
+            for namespace, operations in configured_named_service_operations(block).items():
+                offered.setdefault(namespace, set()).update(operations)
+        return offered
+
+    def _materialized_boundary_for(
+        self,
+        *,
+        selection: NamedServiceSelection,
+        resource: str,
+        grants: Iterable[str],
+    ) -> dict[str, Any]:
+        """The boundary tree a selection expands to for one resource."""
+        cfg = self._config.resource_config(resource) if resource else None
+        if cfg is None or not isinstance(getattr(cfg, "named_services", None), Mapping):
+            return {}
+        try:
+            return named_service_policy_for_resource(
+                named_services=cfg.named_services,
+                resource=cfg.resource,
+                selection=_selection_policy_argument(selection),
+                grants=list(grants),
+            )
+        except ValueError:
+            return {}
+
     async def record_oauth_grant(
         self,
         *,
@@ -2038,6 +2371,8 @@ class AutomationAccessService:
         access_token: str = "",
         refresh_token: str = "",
         account_scope: Mapping[str, Any] | None = None,
+        named_service_operations: Any = None,
+        catalog_version: str = "",
     ) -> AutomationAccessRecord | None:
         """Register (or update) an OAuth-flow delegated grant in the registry.
 
@@ -2075,7 +2410,12 @@ class AutomationAccessService:
         # Token rotation is not an authority change: the card keeps the catalog
         # generation it was last saved against and only advances its revision.
         existing_catalog_version = ""
-        existing_card_revision = 0
+        try:
+            existing_card_revision = await self._committed_revision(
+                access_id, grantor_subject=grantor
+            )
+        except CardUnavailable:
+            existing_card_revision = 0
         try:
             existing_card = await self._load_record(access_id, grantor_subject=grantor)
         except CardUnavailable:
@@ -2091,11 +2431,26 @@ class AutomationAccessService:
             }
             existing_selection = existing_card.named_service_operations
             existing_catalog_version = existing_card.catalog_version
-            existing_card_revision = existing_card.card_revision
             existing_named_services = copy.deepcopy(dict(existing_card.named_services or {}))
         # Initial consent (not a refresh rotation): absorb superseded sibling
         # cards BEFORE composing this card, so their binding carries over.
         is_initial_consent = existing_card is None
+        if is_initial_consent:
+            # Born from what the consent screen submitted, stamped with the
+            # catalog it was chosen against. An absent selection is `{}`.
+            try:
+                selection = self._named_service_operation_selection(
+                    named_service_operations
+                )
+            except ValueError:
+                selection = None
+            existing_selection = selection or NamedServiceSelection.none()
+            existing_catalog_version = _clean(catalog_version)
+            existing_named_services = self._materialized_boundary_for(
+                selection=existing_selection,
+                resource=resource_value,
+                grants=_as_list(list(scopes)),
+            )
         inherited_account_scope: dict[str, dict[str, list[str]]] = {}
         superseded: list[AutomationAccessRecord] = []
         if is_initial_consent:
@@ -2191,16 +2546,16 @@ class AutomationAccessService:
         if not grantor or not client:
             return {}
         seed: dict[str, dict[str, list[str]]] = {}
-        own_raw = await self._redis.get(
-            self._record_key(oauth_access_id(grantor, client, _clean(resource)))
-        )
         sources: list[Mapping[str, Mapping[str, Any]]] = []
-        if own_raw is not None:
-            try:
-                own = AutomationAccessRecord.from_mapping(json.loads(own_raw))
-                sources.append(own.account_scope)
-            except Exception:
-                pass
+        try:
+            own = await self._load_record(
+                oauth_access_id(grantor, client, _clean(resource)),
+                grantor_subject=grantor,
+            )
+        except CardUnavailable:
+            own = None
+        if own is not None:
+            sources.append(own.account_scope)
         try:
             donated, _retire = await self._collect_oauth_siblings(
                 grantor=grantor, client_id=client, resource=_clean(resource),
@@ -2361,6 +2716,7 @@ class AutomationAccessService:
         resource: str,
         claims: Iterable[str],
         account_scope: Mapping[str, Any] | None = None,
+        named_service_operations: Mapping[str, Any] | str | None = None,
         replace: bool = False,
         label: str | None = None,
     ) -> dict[str, Any]:
@@ -2378,6 +2734,9 @@ class AutomationAccessService:
         grantor_subject = _subject_from_user(user)
         if not grantor_subject:
             return {"ok": False, "error": "delegated_access_requires_authenticated_user"}
+        refusal = _delegate_mutation_refusal(user)
+        if refusal is not None:
+            return refusal
         client = _clean(client_id)
         resource_value = _clean(resource)
         claim_list = _as_list(list(claims))
@@ -2452,11 +2811,55 @@ class AutomationAccessService:
         # A DCR client registers one fixed name (every Claude connector arrives
         # as "Claude"), so the user may rename the card to tell connections
         # apart. Empty/absent label leaves the current one untouched.
+        try:
+            active = await self._active_catalog()
+        except CatalogUnavailable as exc:
+            return {
+                "ok": False,
+                "error": "delegated_catalog_unavailable",
+                "reason": exc.reason,
+                "retryable": True,
+                "status": 503,
+            }
+        resolved = await self._resolve_card_authority(
+            user=user,
+            existing=record,
+            active=active,
+            resource_grants={res: list(vals) for res, vals in resource_grants.items()},
+            named_service_operations=named_service_operations,
+            account_scope={
+                provider: {account_id: list(cl) for account_id, cl in accounts.items()}
+                for provider, accounts in account_scope_out.items()
+            },
+        )
+        if resolved.error is not None:
+            return resolved.error
+        if resolved.revoke:
+            revoked = await self.revoke_access(user, access_id=access_id)
+            if not revoked.get("ok"):
+                return revoked
+            return {
+                "ok": True,
+                "revoked": True,
+                "access_id": access_id,
+                "pruned": resolved.reconciled.to_public_dict(),
+            }
+        resource_grants = {
+            res: tuple(vals) for res, vals in resolved.resource_grants.items()
+        }
+        account_scope_out = {
+            provider: {account_id: tuple(cl) for account_id, cl in accounts.items()}
+            for provider, accounts in resolved.account_scope.items()
+        }
         new_label = _clean(label)
         updated = replace_fields(
             record,
             resource_grants=resource_grants,
             account_scope=account_scope_out,
+            named_service_operations=resolved.named_service_operations,
+            named_services=copy.deepcopy(resolved.named_services),
+            operations=tuple(resolved.operations),
+            catalog_version=_clean(getattr(active, "version", "")),
             label=new_label or record.label,
             card_revision=record.card_revision + 1,
         )
@@ -2488,6 +2891,9 @@ class AutomationAccessService:
         grantor_subject = _subject_from_user(user)
         if not grantor_subject:
             return {"ok": False, "error": "delegated_access_requires_authenticated_user"}
+        refusal = _delegate_mutation_refusal(user)
+        if refusal is not None:
+            return refusal
         access_id_value = _clean(access_id)
         if not access_id_value:
             return {"ok": False, "error": "delegated_access_id_required"}

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/automation_access.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/automation_access.py
@@ -55,7 +55,9 @@ from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.oau
 )
 from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.named_service_policy import (
     as_string_list,
+    boundary_permits_operation,
     clean_text,
+    configured_named_service_operations,
     merge_named_service_configs,
     named_service_policy_for_resource,
     narrow_named_service_config,
@@ -88,6 +90,7 @@ from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.cat
 from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.catalog.drift import (
     card_drift,
     drift_unavailable,
+    selected_named_service_operations,
 )
 from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.catalog.reconcile import (
     reconcile_selection,
@@ -99,6 +102,7 @@ from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.cat
     CardProvenance,
     authorize_current_capability,
     capability_denial,
+    card_boundary_denial,
 )
 from kdcube_ai_app.apps.chat.sdk.solutions.named_services_providers.boundary_policy import (
     NamedServiceBoundaryCatalog,
@@ -411,6 +415,46 @@ def _selection_policy_argument(
     }
 
 
+def _inherited_selection(
+    existing: "AutomationAccessRecord",
+    grants_by_resource: Mapping[str, Iterable[str]] | None = None,
+) -> NamedServiceSelection:
+    """The selection an edit that never mentioned it carries forward.
+
+    A wildcard is bound to the catalog version the card was saved against, so
+    an unrelated edit must not re-pin it to the current one: it is frozen into
+    the exact set it already means. The materialized boundary is that expansion
+    by construction, so freezing needs no historical catalog document and works
+    even when the referenced version is gone.
+
+    An explicitly submitted ``"*"`` does not come through here — that one is
+    consent to everything the current catalog shows.
+    """
+    selection = existing.named_service_operations
+    if not selection.is_all:
+        return selection
+    # Filtered by the claims THIS save persists, not the ones the record used to
+    # hold: a wildcard boundary is the descriptor tree unfiltered, an exact
+    # selection may only name what the card can actually invoke, and an edit
+    # that widens claims must not lose the namespaces those claims just opened.
+    held = dict(grants_by_resource) if grants_by_resource is not None else dict(existing.resource_grants)
+    frozen: dict[str, dict[str, list[str]]] = {}
+    for resource, grants in held.items():
+        offered = configured_named_service_operations(
+            existing.named_services, grants=list(grants or ())
+        )
+        per_namespace = {
+            namespace: sorted(operations)
+            for namespace, operations in offered.items()
+            if operations
+        }
+        if per_namespace:
+            frozen[resource] = per_namespace
+    if not frozen:
+        return NamedServiceSelection.none()
+    return NamedServiceSelection.exact(frozen)
+
+
 def _materialized_has_namespaces(named_services: Any) -> bool:
     if not isinstance(named_services, Mapping):
         return False
@@ -563,6 +607,21 @@ class AutomationAccessRecord:
         public = {key: value for key, value in payload.items() if value not in ("", [], {})}
         if selection is not None:
             public["named_service_operations"] = selection
+        # Derived, never authority: the selection expanded under the version the
+        # card was saved against. "*" and a pre-encoding record name no
+        # operations, so without this a surface can only render them as an empty
+        # picker — indistinguishable from an explicit {}.
+        effective = {
+            resource: {
+                namespace: sorted(operations)
+                for namespace, operations in namespaces.items()
+                if operations
+            }
+            for resource, namespaces in selected_named_service_operations(self).items()
+        }
+        effective = {resource: rows for resource, rows in effective.items() if rows}
+        if effective:
+            public["effective_named_service_operations"] = effective
         return public
 
 
@@ -1103,7 +1162,7 @@ class AutomationAccessService:
         label: str,
         resource_grants: Mapping[str, Any],
         operations: Iterable[str] = (),
-        named_service_operations: Mapping[str, Any] | None = None,
+        named_service_operations: Mapping[str, Any] | str | None = None,
         account_scope: Mapping[str, Any] | None = None,
         ttl_seconds: Any = None,
         client_id: str | None = None,
@@ -1272,7 +1331,9 @@ class AutomationAccessService:
                 if not merge_existing and selected_named_service_operations is None:
                     # Same rule for the namespace narrowing: omitting it keeps
                     # the record's own state, including an explicit empty one.
-                    selected_named_service_operations = existing.named_service_operations
+                    selected_named_service_operations = _inherited_selection(
+                        existing, selected_resource_grants
+                    )
             if existing is not None and merge_existing:
                 for resource_key, held in existing.resource_grants.items():
                     merged = list(selected_resource_grants.get(resource_key, []))
@@ -1285,13 +1346,19 @@ class AutomationAccessService:
                     for grants_for_resource in selected_resource_grants.values()
                     for grant in grants_for_resource
                 ])
-                if selected_named_service_operations is not None:
+                # The card's own side is frozen before it is merged into: a
+                # consent screen names a door and its claims, never the inner
+                # namespaces, so it is not the reviewed explicit "*" that may
+                # re-pin. Computed after the claim merge above, because the
+                # freeze is filtered by the claims THIS save persists.
+                inherited = _inherited_selection(existing, selected_resource_grants)
+                if selected_named_service_operations is None:
+                    selected_named_service_operations = inherited
+                else:
                     # A one-click extension accumulates: the merged boundary is
                     # the wider of what the card holds and what was submitted.
                     selected_named_service_operations = (
-                        selected_named_service_operations.union(
-                            existing.named_service_operations
-                        )
+                        selected_named_service_operations.union(inherited)
                     )
                 # Merge the account binding per provider AND per account: union
                 # the claim lists (a one-click grant accumulates; a REPLACE edit
@@ -1462,7 +1529,7 @@ class AutomationAccessService:
         *,
         access_id: str,
         resource_grants: Mapping[str, Any],
-        named_service_operations: Mapping[str, Any] | None = None,
+        named_service_operations: Mapping[str, Any] | str | None = None,
         account_scope: Mapping[str, Any] | None = None,
         label: str | None = None,
         expected_card_revision: int | None = None,
@@ -1538,7 +1605,9 @@ class AutomationAccessService:
         # Resolved before pruning: pruning acts on the selection about to be
         # persisted. Omitted keeps the record's own state; legacy becomes "*".
         if selected_named_service_operations is None:
-            selected_named_service_operations = existing.named_service_operations
+            selected_named_service_operations = _inherited_selection(
+                existing, selected_resource_grants
+            )
         if selected_named_service_operations.is_unknown:
             selected_named_service_operations = NamedServiceSelection.all()
 
@@ -1769,6 +1838,12 @@ class AutomationAccessService:
             {"removed": <structured denial>}   the card holds it, the catalog
                                                no longer offers it
             CatalogUnavailable                 current authority is unknown
+
+        A refusal says WHICH side refused: ``missing_claims`` when the card
+        lacks the claims, ``not_granted`` (a structured card-side denial) when
+        it holds them and only its own boundary excludes the operation. Without
+        that, a caller reads every refusal as "ask for consent" and loops on
+        claims the card already carries.
         """
         ns = _clean(namespace).lower().rstrip(":")
         op = _clean(operation)
@@ -1838,19 +1913,48 @@ class AutomationAccessService:
             if removed is not None:
                 return {"governed": True, "granted": False, "removed": removed}
             granted = False
+            missing_claims: list[str] = sorted(required)
+            not_granted: dict[str, Any] | None = None
             if record is not None:
                 held = set(record.resource_grants.get(cfg.resource, ()))
-                granted = required.issubset(held)
-                selection = record.named_service_operations
-                if granted and selection.is_none:
-                    granted = False
-                elif granted and selection.is_exact:
-                    narrowed = selection.operations.get(cfg.resource)
-                    if narrowed:
-                        granted = op in set(narrowed.get(ns, ()))
+                missing_claims = sorted(required - held)
+                granted = not missing_claims
+                if granted:
+                    # The materialized boundary is the card's answer, the same
+                    # tree the named-services door enforces. Reading the
+                    # selection instead loses the wildcard, whose meaning is
+                    # "everything the acknowledged catalog offered" — an
+                    # expansion that lives in the boundary, not in the intent.
+                    # A pre-encoding record carries no boundary and keeps its
+                    # claims-only compatibility answer.
+                    if not record.named_service_operations.is_unknown:
+                        granted = boundary_permits_operation(
+                            record.named_services, namespace=ns, operation=op
+                        )
+                        if not granted:
+                            # The claims are held and the catalog offers this;
+                            # only the card's own boundary excludes it. Saying
+                            # so is what keeps the caller out of a consent loop
+                            # for claims it already has.
+                            not_granted = card_boundary_denial(
+                                provenance=CardProvenance(
+                                    access_id=record.access_id,
+                                    card_revision=record.card_revision,
+                                    catalog_version=record.catalog_version,
+                                ),
+                                request=CapabilityRequest(
+                                    kind=CAPABILITY_NAMED_SERVICE_OPERATION,
+                                    resource=cfg.resource,
+                                    surface="named_service",
+                                    namespace=ns,
+                                    operation=op,
+                                ),
+                            )
             return {
                 "governed": True,
                 "granted": granted,
+                "not_granted": not_granted,
+                "missing_claims": missing_claims,
                 "resource": cfg.resource,
                 "claims": sorted(required),
                 "client_id": client_id,

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/automation_access.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/automation_access.py
@@ -25,6 +25,7 @@ import json
 import secrets
 import time
 from dataclasses import dataclass, field
+from dataclasses import replace as replace_fields
 from typing import Any, Iterable, Mapping
 from urllib.parse import urlsplit
 
@@ -60,9 +61,25 @@ from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.nam
     operation_grants as _named_service_operation_grants,
 )
 from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.cards.model import (
+    CARD_STATE_ACTIVE,
     NAMED_SERVICE_OPERATIONS_ALL,
+    CardAuthority,
+    CardCredentialHandles,
     CardRecordError,
     NamedServiceSelection,
+)
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.cards.cache import (
+    DelegatedCardRuntimeCache,
+)
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.cards.store import (
+    subject_hash_for,
+)
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.cards.resolver import (
+    CardUnavailable,
+)
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.cards.service import (
+    CardCommitFailed,
+    CardConflict,
 )
 from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.catalog.resolver import (
     CatalogUnavailable,
@@ -261,7 +278,7 @@ def oauth_access_id(grantor_subject: str, client_id: str, resource: str = "") ->
 
 
 def _subject_key(subject: str) -> str:
-    return hashlib.sha256(subject.encode("utf-8")).hexdigest()
+    return subject_hash_for(subject)
 
 
 def _is_platform_admin(user: Mapping[str, Any]) -> bool:
@@ -342,14 +359,15 @@ async def read_agent_grant_record(
     if not grantor or not client:
         return None
     access_id = agent_grant_access_id(grantor, client, resources)
-    key = f"{_clean(tenant)}:{_clean(project)}:kdcube:delegated-access:automation:{access_id}"
-    raw = await redis.get(key)
-    if raw is None:
-        return None
+    cache = DelegatedCardRuntimeCache(redis, tenant=_clean(tenant), project=_clean(project))
     try:
-        record = AutomationAccessRecord.from_mapping(json.loads(raw))
+        entry = await cache.read(access_id)
     except Exception:
+        # A probe enriches a picker; it never denies on its own.
         return None
+    if entry is None or not entry.is_card or entry.authority is None:
+        return None
+    record = record_from_card(entry.authority)
     if record.source != ACCESS_SOURCE_AGENT:
         return None
     if record.expires_at and record.expires_at <= int(time.time()):
@@ -532,6 +550,78 @@ class AutomationAccessRecord:
         return public
 
 
+def card_authority_from_record(record: AutomationAccessRecord) -> CardAuthority:
+    """The record's non-secret authorization decision."""
+    return CardAuthority(
+        access_id=record.access_id,
+        client_id=record.client_id,
+        grantor_subject=record.grantor_subject,
+        delegate_subject=record.delegate_subject,
+        source=record.source,
+        label=record.label,
+        card_revision=record.card_revision,
+        catalog_version=record.catalog_version,
+        state=CARD_STATE_ACTIVE,
+        operations=tuple(record.operations),
+        resource_grants={key: tuple(value) for key, value in record.resource_grants.items()},
+        named_service_operations=record.named_service_operations,
+        named_services=copy.deepcopy(dict(record.named_services or {})),
+        account_scope={
+            provider: {account_id: tuple(claims) for account_id, claims in accounts.items()}
+            for provider, accounts in record.account_scope.items()
+        },
+        identity_scope=record.identity_scope,
+        created_at=record.created_at,
+        expires_at=record.expires_at,
+        last_issued_at=record.last_issued_at,
+        last_four=record.last_four,
+    )
+
+
+def card_handles_from_record(record: AutomationAccessRecord) -> CardCredentialHandles:
+    """The record's live, reusable credential material."""
+    return CardCredentialHandles(
+        access_id=record.access_id,
+        access_token=record.access_token,
+        refresh_token=record.refresh_token,
+        session_id=record.session_id,
+    )
+
+
+def record_from_card(
+    authority: CardAuthority,
+    handles: CardCredentialHandles | None = None,
+) -> AutomationAccessRecord:
+    """Recombine authority and handles into the record shape callers render."""
+    held = handles or CardCredentialHandles(access_id=authority.access_id)
+    return AutomationAccessRecord(
+        access_id=authority.access_id,
+        label=authority.label,
+        client_id=authority.client_id,
+        grantor_subject=authority.grantor_subject,
+        delegate_subject=authority.delegate_subject,
+        operations=tuple(authority.operations),
+        resource_grants={key: tuple(value) for key, value in authority.resource_grants.items()},
+        named_service_operations=authority.named_service_operations,
+        named_services=copy.deepcopy(dict(authority.named_services or {})),
+        account_scope={
+            provider: {account_id: tuple(claims) for account_id, claims in accounts.items()}
+            for provider, accounts in authority.account_scope.items()
+        },
+        identity_scope=authority.identity_scope,
+        catalog_version=authority.catalog_version,
+        card_revision=authority.card_revision,
+        session_id=held.session_id,
+        created_at=authority.created_at,
+        expires_at=authority.expires_at,
+        last_four=authority.last_four,
+        source=authority.source,
+        refresh_token=held.refresh_token,
+        access_token=held.access_token,
+        last_issued_at=authority.last_issued_at,
+    )
+
+
 class AutomationAccessService:
     """Create/list/revoke user-created delegated automation credentials."""
 
@@ -545,6 +635,7 @@ class AutomationAccessService:
         grant_store: GrantStore | None = None,
         authority: Any | None = None,
         catalog_resolver: Any | None = None,
+        card_persistence: Any | None = None,
         minter: Any | None = None,
         named_service_discovery: Any | None = None,
     ) -> None:
@@ -559,6 +650,56 @@ class AutomationAccessService:
         # Required by the operations that stamp a card. Read-only and
         # credential-lifecycle operations do not need it.
         self._catalog_resolver = catalog_resolver
+        # Policy depends on the persistence contract, not on how a card is
+        # stored. Composition of the durable implementation belongs to the
+        # caller that owns storage.
+        self._persistence = card_persistence
+
+    # -- card persistence -----------------------------------------------------
+    #
+    # Durable revisions are the source of truth; Redis holds the live
+    # projection and the bounded credential handles. Every raw record access
+    # goes through these three operations.
+
+    def _cards(self) -> Any:
+        if self._persistence is None:
+            raise CardUnavailable("card_persistence_not_configured")
+        return self._persistence
+
+    async def _load_record(
+        self, access_id: str, *, grantor_subject: str
+    ) -> AutomationAccessRecord | None:
+        loaded = await self._cards().load(
+            access_id, subject_hash=_subject_key(grantor_subject)
+        )
+        if loaded is None:
+            return None
+        authority, handles = loaded
+        return record_from_card(authority, handles)
+
+    async def _persist_record(
+        self, record: AutomationAccessRecord, *, expected_revision: int
+    ) -> None:
+        await self._cards().persist(
+            card_authority_from_record(record),
+            card_handles_from_record(record),
+            subject_hash=_subject_key(record.grantor_subject),
+            expected_revision=expected_revision,
+        )
+
+    async def _forget_record(self, record: AutomationAccessRecord) -> None:
+        await self._cards().forget(
+            card_authority_from_record(record),
+            subject_hash=_subject_key(record.grantor_subject),
+        )
+
+    async def _list_active_records(
+        self, grantor_subject: str, *, now: int | None = None
+    ) -> list[AutomationAccessRecord]:
+        authorities = await self._cards().list_active(
+            subject_hash=_subject_key(grantor_subject), now=now
+        )
+        return [record_from_card(authority) for authority in authorities]
 
     async def _active_catalog_version(self) -> str:
         """The generation a save is stamped with.
@@ -780,30 +921,17 @@ class AutomationAccessService:
             return {"ok": False, "error": "delegated_access_requires_authenticated_user"}
 
         now = int(time.time())
-        raw_ids = await self._redis.smembers(self._index_key(grantor_subject))
-        access_ids = [
-            item.decode("utf-8") if isinstance(item, (bytes, bytearray)) else str(item)
-            for item in (raw_ids or [])
-        ]
-        records: list[dict[str, Any]] = []
-        stale: list[str] = []
-        for access_id in access_ids:
-            raw = await self._redis.get(self._record_key(access_id))
-            if raw is None:
-                stale.append(access_id)
-                continue
-            try:
-                payload = json.loads(raw)
-            except Exception:
-                stale.append(access_id)
-                continue
-            record = AutomationAccessRecord.from_mapping(payload)
-            if record.expires_at and record.expires_at < now:
-                stale.append(access_id)
-                continue
-            records.append(record.to_public_dict())
-        if stale and hasattr(self._redis, "srem"):
-            await self._redis.srem(self._index_key(grantor_subject), *stale)
+        try:
+            records_found = await self._list_active_records(grantor_subject, now=now)
+        except CardUnavailable as exc:
+            return {
+                "ok": False,
+                "error": "delegated_cards_unavailable",
+                "reason": exc.reason,
+                "retryable": True,
+                "status": 503,
+            }
+        records = [record.to_public_dict() for record in records_found]
 
         records.sort(key=lambda item: str(item.get("created_at") or ""), reverse=True)
         return {
@@ -975,12 +1103,18 @@ class AutomationAccessService:
             client_id = requested_client_id
             access_id = agent_grant_access_id(grantor_subject, client_id, selected_resources)
             access_source = ACCESS_SOURCE_AGENT
-            existing_raw = await self._redis.get(self._record_key(access_id))
-            if existing_raw is not None:
-                try:
-                    existing = AutomationAccessRecord.from_mapping(json.loads(existing_raw))
-                except Exception:
-                    existing = None
+            try:
+                existing = await self._load_record(
+                    access_id, grantor_subject=grantor_subject
+                )
+            except CardUnavailable as exc:
+                return {
+                    "ok": False,
+                    "error": "delegated_cards_unavailable",
+                    "reason": exc.reason,
+                    "retryable": True,
+                    "status": 503,
+                }
             if existing is not None:
                 created_at_override = existing.created_at or None
                 if not merge_existing and not account_scope_provided:
@@ -1160,9 +1294,18 @@ class AutomationAccessService:
             # unbound one; a manual automation keeps the token client-side only.
             access_token=access_token if access_source == ACCESS_SOURCE_AGENT else "",
         )
-        await self._redis.setex(self._record_key(access_id), expires_in, json.dumps(record.to_dict()))
-        await self._redis.sadd(self._index_key(grantor_subject), access_id)
-        await self._redis.expire(self._index_key(grantor_subject), BUNDLE_SESSION_MAX_TTL_SECONDS)
+        try:
+            await self._persist_record(
+                record, expected_revision=existing.card_revision if existing is not None else 0
+            )
+        except (CardUnavailable, CardConflict, CardCommitFailed) as exc:
+            return {
+                "ok": False,
+                "error": "delegated_card_not_committed",
+                "reason": getattr(exc, "reason", ""),
+                "retryable": True,
+                "status": 503,
+            }
         await self.notify_change(grantor_subject, action="created", access=record.to_public_dict())
 
         return {
@@ -1194,13 +1337,18 @@ class AutomationAccessService:
         access_id = _clean(access_id)
         if not access_id:
             return {"ok": False, "error": "delegated_access_requires_access_id"}
-        raw = await self._redis.get(self._record_key(access_id))
-        if raw is None:
-            return {"ok": False, "error": "delegated_access_not_found"}
         try:
-            existing = AutomationAccessRecord.from_mapping(json.loads(raw))
-        except Exception:
-            return {"ok": False, "error": "delegated_access_record_invalid"}
+            existing = await self._load_record(access_id, grantor_subject=grantor_subject)
+        except CardUnavailable as exc:
+            return {
+                "ok": False,
+                "error": "delegated_cards_unavailable",
+                "reason": exc.reason,
+                "retryable": True,
+                "status": 503,
+            }
+        if existing is None:
+            return {"ok": False, "error": "delegated_access_not_found"}
         if existing.grantor_subject != grantor_subject:
             return {"ok": False, "error": "delegated_access_not_owned"}
         # Only a manual automation card is edited here. Agent/OAuth cards edit
@@ -1366,7 +1514,17 @@ class AutomationAccessService:
             # Manual token stays client-side only; the record never holds it.
             access_token="",
         )
-        await self._redis.setex(self._record_key(access_id), remaining, json.dumps(updated.to_dict()))
+        del remaining
+        try:
+            await self._persist_record(updated, expected_revision=existing.card_revision)
+        except (CardUnavailable, CardConflict, CardCommitFailed) as exc:
+            return {
+                "ok": False,
+                "error": "delegated_card_not_committed",
+                "reason": getattr(exc, "reason", ""),
+                "retryable": True,
+                "status": 503,
+            }
         await self.notify_change(grantor_subject, action="updated", access=updated.to_public_dict())
         return {"ok": True, "access": updated.to_public_dict()}
 
@@ -1382,15 +1540,13 @@ class AutomationAccessService:
         the grant has expired. Keyed by the SAME deterministic access_id
         `create_access(client_id=…)` writes, so the per-turn resolver reuses the
         stored, already-bound token instead of minting an unbound one."""
-        record = await read_agent_grant_record(
-            self._redis,
-            tenant=self._tenant,
-            project=self._project,
+        record = await self._load_record(
+            agent_grant_access_id(grantor_subject, client_id, resources),
             grantor_subject=grantor_subject,
-            client_id=client_id,
-            resources=resources,
         )
-        if record is None or not record.access_token:
+        if record is None or record.source != ACCESS_SOURCE_AGENT:
+            return None
+        if not record.access_token:
             return None
         return {
             "access_token": record.access_token,
@@ -1455,14 +1611,14 @@ class AutomationAccessService:
                     continue
                 if _clean(tool_policy.get("operation") or "") == op:
                     required |= self._operation_grants({}, dict(tool_policy))
-            record = await read_agent_grant_record(
-                self._redis,
-                tenant=self._tenant,
-                project=self._project,
+            # A service method reads through its own persistence port; the
+            # standalone probe exists for callers that have no service.
+            record = await self._load_record(
+                agent_grant_access_id(grantor_subject, client_id, [cfg.resource]),
                 grantor_subject=grantor_subject,
-                client_id=client_id,
-                resources=[cfg.resource],
             )
+            if record is not None and record.source != ACCESS_SOURCE_AGENT:
+                record = None
             granted = False
             if record is not None:
                 held = set(record.resource_grants.get(cfg.resource, ()))
@@ -1541,30 +1697,26 @@ class AutomationAccessService:
         # generation it was last saved against and only advances its revision.
         existing_catalog_version = ""
         existing_card_revision = 0
-        existing_raw = await self._redis.get(self._record_key(access_id))
-        if existing_raw is not None:
-            try:
-                existing_payload = json.loads(existing_raw)
-                created_at = int(existing_payload.get("created_at") or now)
-                existing_map = existing_payload.get("resource_grants") or {}
-                existing_grants = list(existing_map.get(resource_value or "*") or [])
-                existing_account_scope = {
-                    provider: {account_id: list(claims) for account_id, claims in accounts.items()}
-                    for provider, accounts in normalize_account_scope(
-                        existing_payload.get("account_scope")
-                    ).items()
-                }
-                existing_selection = _parse_named_service_selection(existing_payload)
-                existing_catalog_version = _clean(existing_payload.get("catalog_version"))
-                existing_card_revision = int(existing_payload.get("card_revision") or 0)
-                raw_named_services = existing_payload.get("named_services")
-                if isinstance(raw_named_services, Mapping):
-                    existing_named_services = copy.deepcopy(dict(raw_named_services))
-            except Exception:
-                created_at = now
+        try:
+            existing_card = await self._load_record(access_id, grantor_subject=grantor)
+        except CardUnavailable:
+            existing_card = None
+        if existing_card is not None:
+            created_at = existing_card.created_at or now
+            existing_grants = list(
+                existing_card.resource_grants.get(resource_value or "*", ())
+            )
+            existing_account_scope = {
+                provider: {account_id: list(claims) for account_id, claims in accounts.items()}
+                for provider, accounts in existing_card.account_scope.items()
+            }
+            existing_selection = existing_card.named_service_operations
+            existing_catalog_version = existing_card.catalog_version
+            existing_card_revision = existing_card.card_revision
+            existing_named_services = copy.deepcopy(dict(existing_card.named_services or {}))
         # Initial consent (not a refresh rotation): absorb superseded sibling
         # cards BEFORE composing this card, so their binding carries over.
-        is_initial_consent = existing_raw is None
+        is_initial_consent = existing_card is None
         inherited_account_scope: dict[str, dict[str, list[str]]] = {}
         superseded: list[AutomationAccessRecord] = []
         if is_initial_consent:
@@ -1619,9 +1771,7 @@ class AutomationAccessService:
             access_token=_clean(access_token),
             last_issued_at=now,
         )
-        await self._redis.setex(self._record_key(access_id), ttl, json.dumps(record.to_dict()))
-        await self._redis.sadd(self._index_key(grantor), access_id)
-        await self._redis.expire(self._index_key(grantor), BUNDLE_SESSION_MAX_TTL_SECONDS)
+        await self._persist_record(record, expected_revision=existing_card_revision)
         _LOGGER.info(
             "[automation-access] oauth grant recorded card=%s client=%s initial=%s "
             "account_scope_providers=%s siblings_superseded=%d",
@@ -1706,21 +1856,13 @@ class AutomationAccessService:
         own_origins = await self._client_redirect_origins(client_id)
         if not own_origins:
             return {}, []
-        raw_ids = await self._redis.smembers(self._index_key(grantor))
-        access_ids = [
-            item.decode("utf-8") if isinstance(item, (bytes, bytearray)) else str(item)
-            for item in (raw_ids or [])
-        ]
+        try:
+            candidates = await self._list_active_records(grantor)
+        except CardUnavailable:
+            return {}, []
         donated: dict[str, dict[str, list[str]]] = {}
         retire: list[AutomationAccessRecord] = []
-        for access_id in access_ids:
-            raw = await self._redis.get(self._record_key(access_id))
-            if raw is None:
-                continue
-            try:
-                candidate = AutomationAccessRecord.from_mapping(json.loads(raw))
-            except Exception:
-                continue
+        for candidate in candidates:
             if candidate.source != ACCESS_SOURCE_OAUTH:
                 continue
             if candidate.client_id == client_id or not candidate.client_id.startswith("dcr-"):
@@ -1780,20 +1922,13 @@ class AutomationAccessService:
         if not subject or not provider or not account:
             return {"pruned": 0, "grants": []}
         try:
-            raw_ids = await self._redis.smembers(self._index_key(subject))
+            candidates = await self._list_active_records(subject)
         except Exception:
             return {"pruned": 0, "grants": []}
-        access_ids = [
-            item.decode("utf-8") if isinstance(item, (bytes, bytearray)) else str(item)
-            for item in (raw_ids or [])
-        ]
         pruned: list[str] = []
-        for access_id in access_ids:
+        for record in candidates:
+            access_id = record.access_id
             try:
-                raw = await self._redis.get(self._record_key(access_id))
-                if raw is None:
-                    continue
-                record = AutomationAccessRecord.from_mapping(json.loads(raw))
                 accounts = dict(record.account_scope.get(provider) or {})
                 if account not in accounts:
                     continue
@@ -1808,23 +1943,21 @@ class AutomationAccessService:
                     scope[provider] = {a: list(cl) for a, cl in accounts.items()}
                 else:
                     scope.pop(provider, None)
-                record_dict = record.to_dict()
-                record_dict["account_scope"] = scope
-                ttl = 0
-                try:
-                    ttl = await self._redis.ttl(self._record_key(access_id))
-                except Exception:
-                    ttl = 0
-                await self._redis.setex(
-                    self._record_key(access_id),
-                    max(60, int(ttl or 0) or 60),
-                    json.dumps(record_dict),
+                pruned_record = replace_fields(
+                    record,
+                    account_scope={
+                        p: {a: tuple(cl) for a, cl in bound.items()}
+                        for p, bound in scope.items()
+                    },
+                    card_revision=record.card_revision + 1,
+                )
+                await self._persist_record(
+                    pruned_record, expected_revision=record.card_revision
                 )
                 pruned.append(access_id)
-                await self.notify_change(subject, action="edited", access={
-                    k: v for k, v in record_dict.items()
-                    if k not in ("access_token", "refresh_token", "session_id")
-                })
+                await self.notify_change(
+                    subject, action="edited", access=pruned_record.to_public_dict()
+                )
             except Exception:
                 _LOGGER.warning(
                     "[connection_hub.disconnect] pruning account binding failed "
@@ -1881,14 +2014,19 @@ class AutomationAccessService:
         ):
             return {"ok": False, "error": "delegated_access_requires_client_and_claims"}
         access_id = oauth_access_id(grantor_subject, client, resource_value)
-        raw = await self._redis.get(self._record_key(access_id))
-        if raw is None:
+        try:
+            record = await self._load_record(access_id, grantor_subject=grantor_subject)
+        except CardUnavailable as exc:
+            return {
+                "ok": False,
+                "error": "delegated_cards_unavailable",
+                "reason": exc.reason,
+                "retryable": True,
+                "status": 503,
+            }
+        if record is None:
             return {"ok": False, "error": "delegated_access_unknown_client",
                     "message": "This client has no existing grant to extend; it connects via its own consent flow first."}
-        try:
-            record = AutomationAccessRecord.from_mapping(json.loads(raw))
-        except Exception:
-            return {"ok": False, "error": "delegated_access_record_unreadable"}
         # Claims must stay inside the deployment's delegable ceiling for the
         # resource when the catalog knows it.
         cfg = self._config.resource_config(resource_value) if resource_value else None
@@ -1932,27 +2070,32 @@ class AutomationAccessService:
                             current.append(claim)
                     target[account_id] = tuple(current)
                 account_scope_out[provider] = target
-        try:
-            ttl = await self._redis.ttl(self._record_key(access_id))
-        except Exception:
-            ttl = 0
-        record_dict = record.to_dict()
-        record_dict["resource_grants"] = {res: list(vals) for res, vals in resource_grants.items()}
-        record_dict["account_scope"] = {
-            p: {a: list(cl) for a, cl in accounts.items()} for p, accounts in account_scope_out.items()
-        }
         # A DCR client registers one fixed name (every Claude connector arrives
         # as "Claude"), so the user may rename the card to tell connections
         # apart. Empty/absent label leaves the current one untouched.
         new_label = _clean(label)
-        if new_label:
-            record_dict["label"] = new_label
-        await self._redis.setex(
-            self._record_key(access_id), max(60, int(ttl or 0) or 60), json.dumps(record_dict),
+        updated = replace_fields(
+            record,
+            resource_grants=resource_grants,
+            account_scope=account_scope_out,
+            label=new_label or record.label,
+            card_revision=record.card_revision + 1,
         )
-        await self.notify_change(grantor_subject, action="edited" if replace else "extended", access={
-            k: v for k, v in record_dict.items() if k not in ("access_token", "refresh_token", "session_id")
-        })
+        try:
+            await self._persist_record(updated, expected_revision=record.card_revision)
+        except (CardUnavailable, CardConflict, CardCommitFailed) as exc:
+            return {
+                "ok": False,
+                "error": "delegated_card_not_committed",
+                "reason": getattr(exc, "reason", ""),
+                "retryable": True,
+                "status": 503,
+            }
+        await self.notify_change(
+            grantor_subject,
+            action="edited" if replace else "extended",
+            access=updated.to_public_dict(),
+        )
         return {
             "ok": True,
             "access_id": access_id,
@@ -1969,12 +2112,25 @@ class AutomationAccessService:
         access_id_value = _clean(access_id)
         if not access_id_value:
             return {"ok": False, "error": "delegated_access_id_required"}
-        raw = await self._redis.get(self._record_key(access_id_value))
-        if raw is None:
+        try:
+            record = await self._load_record(
+                access_id_value, grantor_subject=grantor_subject
+            )
+        except CardUnavailable as exc:
+            return {
+                "ok": False,
+                "error": "delegated_cards_unavailable",
+                "reason": exc.reason,
+                "retryable": True,
+                "status": 503,
+            }
+        if record is None:
             return {"ok": True, "removed": False}
-        record = AutomationAccessRecord.from_mapping(json.loads(raw))
         if record.grantor_subject != grantor_subject:
             return {"ok": False, "error": "delegated_access_cross_user_access_denied"}
+        # The revoked revision commits before any credential cleanup, so a
+        # failure below cannot leave the card usable.
+        await self._forget_record(record)
         removed_session = False
         if record.session_id:
             from kdcube_ai_app.auth.bundle import get_bundle_session_authority
@@ -1989,9 +2145,6 @@ class AutomationAccessService:
             refresh_revoked = bool(await self._store.revoke_refresh_token(record.refresh_token))
         if record.access_token:
             await self._store.revoke_access_grant(record.access_token)
-        await self._redis.delete(self._record_key(access_id_value))
-        if hasattr(self._redis, "srem"):
-            await self._redis.srem(self._index_key(grantor_subject), access_id_value)
         await self.notify_change(grantor_subject, action="revoked", access_id=access_id_value)
         return {
             "ok": True,

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/automation_access.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/automation_access.py
@@ -59,6 +59,14 @@ from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.nam
     narrow_named_service_config,
     operation_grants as _named_service_operation_grants,
 )
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.cards.model import (
+    NAMED_SERVICE_OPERATIONS_ALL,
+    CardRecordError,
+    NamedServiceSelection,
+)
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.catalog.resolver import (
+    CatalogUnavailable,
+)
 from kdcube_ai_app.apps.chat.sdk.solutions.named_services_providers.boundary_policy import (
     NamedServiceBoundaryCatalog,
 )
@@ -349,6 +357,51 @@ async def read_agent_grant_record(
     return record
 
 
+def _selection_policy_argument(
+    selection: NamedServiceSelection,
+) -> dict[str, dict[str, list[str]]] | None:
+    """The narrowing argument ``named_service_policy_for_resource`` expects.
+
+    ``None`` keeps the full descriptor policy, an empty map narrows every
+    resource to nothing, and an exact map narrows to its entries. A legacy
+    record without an explicit selection keeps its prior full-policy meaning
+    until its next successful save writes one.
+    """
+    if selection.is_all or selection.is_unknown:
+        return None
+    if selection.is_none:
+        return {}
+    return {
+        resource: {namespace: list(values) for namespace, values in namespaces.items()}
+        for resource, namespaces in selection.operations.items()
+    }
+
+
+def _materialized_has_namespaces(named_services: Any) -> bool:
+    if not isinstance(named_services, Mapping):
+        return False
+    namespaces = named_services.get("namespaces")
+    return isinstance(namespaces, Mapping) and bool(namespaces)
+
+
+def _parse_named_service_selection(value: Mapping[str, Any]) -> NamedServiceSelection:
+    """Read the stored selection.
+
+    A stored ``{}`` is an explicit empty policy only when the materialized
+    boundary carries no namespaces; otherwise the record predates the encoding.
+    """
+    try:
+        selection = NamedServiceSelection.from_stored(
+            value.get("named_service_operations"),
+            present="named_service_operations" in value,
+        )
+    except CardRecordError:
+        return NamedServiceSelection.unknown()
+    if selection.is_none and _materialized_has_namespaces(value.get("named_services")):
+        return NamedServiceSelection.unknown()
+    return selection
+
+
 @dataclass(frozen=True)
 class AutomationAccessRecord:
     access_id: str
@@ -358,8 +411,11 @@ class AutomationAccessRecord:
     delegate_subject: str
     operations: tuple[str, ...]
     resource_grants: Mapping[str, tuple[str, ...]]
-    named_service_operations: Mapping[str, Mapping[str, tuple[str, ...]]] = field(
-        default_factory=dict
+    # Exact user-visible selection in one of four states. A newly written card
+    # always carries "*", {}, or an exact map; `unknown` is a legacy-record
+    # condition only.
+    named_service_operations: NamedServiceSelection = field(
+        default_factory=NamedServiceSelection.unknown
     )
     # Boundary tree for the named-service bridge, narrowed from the descriptor
     # by `named_service_operations`. Empty on cards written before this field;
@@ -374,6 +430,11 @@ class AutomationAccessRecord:
     # enforcement can distinguish it from a non-delegated user turn.
     account_scope: Mapping[str, Mapping[str, tuple[str, ...]]] = field(default_factory=dict)
     identity_scope: str = ""
+    # The catalog generation this card was last saved against. "*" and every
+    # exact selection are defined relative to it.
+    catalog_version: str = ""
+    # Monotonic per-card revision; rejects concurrent lost updates.
+    card_revision: int = 0
     session_id: str = ""
     created_at: int = 0
     expires_at: int = 0
@@ -402,17 +463,7 @@ class AutomationAccessRecord:
                 for key, grants in dict(value.get("resource_grants") or {}).items()
                 if _clean(key)
             },
-            named_service_operations={
-                _clean(resource): {
-                    _clean(namespace).lower().rstrip(":"): tuple(_as_list(operations))
-                    for namespace, operations in dict(namespaces or {}).items()
-                    if _clean(namespace)
-                }
-                for resource, namespaces in dict(
-                    value.get("named_service_operations") or {}
-                ).items()
-                if _clean(resource) and isinstance(namespaces, Mapping)
-            },
+            named_service_operations=_parse_named_service_selection(value),
             named_services=(
                 dict(value.get("named_services"))
                 if isinstance(value.get("named_services"), Mapping)
@@ -420,6 +471,8 @@ class AutomationAccessRecord:
             ),
             account_scope=normalize_account_scope(value.get("account_scope")),
             identity_scope=_clean(value.get("identity_scope")),
+            catalog_version=_clean(value.get("catalog_version")),
+            card_revision=int(value.get("card_revision") or 0),
             session_id=_clean(value.get("session_id")),
             created_at=int(value.get("created_at") or 0),
             expires_at=int(value.get("expires_at") or 0),
@@ -431,7 +484,7 @@ class AutomationAccessRecord:
         )
 
     def to_dict(self) -> dict[str, Any]:
-        return {
+        payload: dict[str, Any] = {
             "schema": AUTOMATION_ACCESS_SCHEMA,
             "access_id": self.access_id,
             "label": self.label,
@@ -440,19 +493,14 @@ class AutomationAccessRecord:
             "delegate_subject": self.delegate_subject,
             "operations": list(self.operations),
             "resource_grants": {key: list(value) for key, value in self.resource_grants.items()},
-            "named_service_operations": {
-                resource: {
-                    namespace: list(operations)
-                    for namespace, operations in namespaces.items()
-                }
-                for resource, namespaces in self.named_service_operations.items()
-            },
             "named_services": dict(self.named_services or {}),
             "account_scope": {
                 provider: {account_id: list(claims) for account_id, claims in accounts.items()}
                 for provider, accounts in self.account_scope.items()
             },
             "identity_scope": self.identity_scope,
+            "catalog_version": self.catalog_version,
+            "card_revision": self.card_revision,
             "session_id": self.session_id,
             "created_at": self.created_at,
             "expires_at": self.expires_at,
@@ -462,6 +510,10 @@ class AutomationAccessRecord:
             "access_token": self.access_token,
             "last_issued_at": self.last_issued_at,
         }
+        stored_selection = self.named_service_operations.to_stored()
+        if stored_selection is not None:
+            payload["named_service_operations"] = stored_selection
+        return payload
 
     def to_public_dict(self) -> dict[str, Any]:
         payload = self.to_dict()
@@ -471,7 +523,13 @@ class AutomationAccessRecord:
         # Derived from the descriptor and only consumed by the guard; the
         # selection (`named_service_operations`) is what surfaces render.
         payload.pop("named_services", None)
-        return {key: value for key, value in payload.items() if value not in ("", [], {})}
+        # The selection is retained verbatim: an explicit {} must not render as
+        # unrestricted, and "*" must survive a refetch.
+        selection = payload.pop("named_service_operations", None)
+        public = {key: value for key, value in payload.items() if value not in ("", [], {})}
+        if selection is not None:
+            public["named_service_operations"] = selection
+        return public
 
 
 class AutomationAccessService:
@@ -486,6 +544,7 @@ class AutomationAccessService:
         config: OAuthDelegatedClientConfig,
         grant_store: GrantStore | None = None,
         authority: Any | None = None,
+        catalog_resolver: Any | None = None,
         minter: Any | None = None,
         named_service_discovery: Any | None = None,
     ) -> None:
@@ -497,6 +556,24 @@ class AutomationAccessService:
         self._authority = authority
         self._minter = minter
         self._named_service_discovery = named_service_discovery
+        # Required by the operations that stamp a card. Read-only and
+        # credential-lifecycle operations do not need it.
+        self._catalog_resolver = catalog_resolver
+
+    async def _active_catalog_version(self) -> str:
+        """The generation a save is stamped with.
+
+        A card may not be written without naming the catalog its selection is
+        defined against, so an absent resolver fails closed rather than
+        producing an unstamped record.
+        """
+        if self._catalog_resolver is None:
+            raise CatalogUnavailable("catalog_resolver_not_configured")
+        active = await self._catalog_resolver.resolve_active()
+        version = _clean(getattr(active, "version", ""))
+        if not version:
+            raise CatalogUnavailable("active_catalog_version_missing")
+        return version
 
     def _key(self, suffix: str) -> str:
         return f"{self._tenant}:{self._project}:kdcube:delegated-access:{suffix}"
@@ -652,29 +729,26 @@ class AutomationAccessService:
 
     def _named_service_operation_selection(
         self,
-        value: Mapping[str, Any] | None,
-    ) -> dict[str, dict[str, list[str]]] | None:
+        value: Any,
+    ) -> NamedServiceSelection | None:
+        """Parse a submitted selection. ``None`` means the field was omitted."""
         if value is None:
             return None
+        if isinstance(value, str):
+            if _clean(value) != NAMED_SERVICE_OPERATIONS_ALL:
+                raise ValueError("named_service_operations must be '*' or an object")
+            return NamedServiceSelection.all()
         if not isinstance(value, Mapping):
             raise ValueError("named_service_operations must be an object")
-        out: dict[str, dict[str, list[str]]] = {}
         for resource, raw_namespaces in value.items():
-            resource_value = _clean(resource)
-            if not resource_value:
-                continue
-            if not isinstance(raw_namespaces, Mapping):
+            if _clean(resource) and not isinstance(raw_namespaces, Mapping):
                 raise ValueError(
-                    f"named_service_operations[{resource_value!r}] must be an object"
+                    f"named_service_operations[{_clean(resource)!r}] must be an object"
                 )
-            namespaces: dict[str, list[str]] = {}
-            for namespace, raw_operations in raw_namespaces.items():
-                namespace_value = _clean(namespace).lower().rstrip(":")
-                if not namespace_value:
-                    continue
-                namespaces[namespace_value] = _as_list(raw_operations)
-            out[resource_value] = namespaces
-        return out
+        try:
+            return NamedServiceSelection.exact(value)
+        except CardRecordError as exc:
+            raise ValueError(str(exc)) from exc
 
     # Delegators; the managed guard calls the same functions per request.
     @staticmethod
@@ -847,9 +921,9 @@ class AutomationAccessService:
                 "resources": admin_required,
             }
         cfg_by_resource = {cfg.resource: cfg for cfg in resource_configs}
-        if selected_named_service_operations is not None:
+        if selected_named_service_operations is not None and selected_named_service_operations.is_exact:
             unknown_selection_resources = sorted(
-                set(selected_named_service_operations) - set(selected_resources)
+                set(selected_named_service_operations.operations) - set(selected_resources)
             )
             if unknown_selection_resources:
                 return {
@@ -892,6 +966,7 @@ class AutomationAccessService:
         requested_client_id = _clean(client_id)
         access_source = ACCESS_SOURCE_MANUAL
         created_at_override: int | None = None
+        existing: AutomationAccessRecord | None = None
         if requested_client_id:
             # Deterministic per-agent grant: one record per (grantor, client,
             # resources). Re-consent MERGES into it — sequential one-click
@@ -901,7 +976,6 @@ class AutomationAccessService:
             access_id = agent_grant_access_id(grantor_subject, client_id, selected_resources)
             access_source = ACCESS_SOURCE_AGENT
             existing_raw = await self._redis.get(self._record_key(access_id))
-            existing: AutomationAccessRecord | None = None
             if existing_raw is not None:
                 try:
                     existing = AutomationAccessRecord.from_mapping(json.loads(existing_raw))
@@ -920,17 +994,10 @@ class AutomationAccessService:
                         }
                         for provider, accounts in existing.account_scope.items()
                     }
-                if (
-                    not merge_existing
-                    and selected_named_service_operations is None
-                    and existing.named_service_operations
-                ):
+                if not merge_existing and selected_named_service_operations is None:
                     # Same rule for the namespace narrowing: omitting it keeps
-                    # the record's, an explicit {} clears it.
-                    selected_named_service_operations = {
-                        resource: {ns: list(ops) for ns, ops in namespaces.items()}
-                        for resource, namespaces in existing.named_service_operations.items()
-                    }
+                    # the record's own state, including an explicit empty one.
+                    selected_named_service_operations = existing.named_service_operations
             if existing is not None and merge_existing:
                 for resource_key, held in existing.resource_grants.items():
                     merged = list(selected_resource_grants.get(resource_key, []))
@@ -944,23 +1011,13 @@ class AutomationAccessService:
                     for grant in grants_for_resource
                 ])
                 if selected_named_service_operations is not None:
-                    existing_narrowing = {
-                        res: {ns: list(ops) for ns, ops in namespaces.items()}
-                        for res, namespaces in existing.named_service_operations.items()
-                    }
-                    if not existing_narrowing:
-                        # The existing grant carried the FULL namespace policy;
-                        # full ⊇ any narrowing, so the merge stays full.
-                        selected_named_service_operations = None
-                    else:
-                        for res, namespaces in existing_narrowing.items():
-                            target = selected_named_service_operations.setdefault(res, {})
-                            for ns, ops in namespaces.items():
-                                current = list(target.get(ns, []))
-                                for op_name in ops:
-                                    if op_name not in current:
-                                        current.append(op_name)
-                                target[ns] = current
+                    # A one-click extension accumulates: the merged boundary is
+                    # the wider of what the card holds and what was submitted.
+                    selected_named_service_operations = (
+                        selected_named_service_operations.union(
+                            existing.named_service_operations
+                        )
+                    )
                 # Merge the account binding per provider AND per account: union
                 # the claim lists (a one-click grant accumulates; a REPLACE edit
                 # sends the full desired scope and overwrites, same as
@@ -977,6 +1034,25 @@ class AutomationAccessService:
             access_id = "aut_" + secrets.token_urlsafe(10)
             client_id = f"{AUTOMATION_CLIENT_PREFIX}:{access_id}"
 
+        # A create call that names no selection grants the full policy of the
+        # catalog it is saved against, and a legacy card resolves to the same
+        # explicit state on its next save.
+        if (
+            selected_named_service_operations is None
+            or selected_named_service_operations.is_unknown
+        ):
+            selected_named_service_operations = NamedServiceSelection.all()
+        try:
+            catalog_version = await self._active_catalog_version()
+        except CatalogUnavailable as exc:
+            return {
+                "ok": False,
+                "error": "delegated_catalog_unavailable",
+                "reason": exc.reason,
+                "retryable": True,
+                "status": 503,
+            }
+
         named_services: dict[str, Any] = {}
         for cfg in resource_configs:
             if isinstance(cfg.named_services, Mapping):
@@ -984,7 +1060,7 @@ class AutomationAccessService:
                     selected_policy = named_service_policy_for_resource(
                         named_services=cfg.named_services,
                         resource=cfg.resource,
-                        selection=selected_named_service_operations,
+                        selection=_selection_policy_argument(selected_named_service_operations),
                         grants=selected_resource_grants.get(cfg.resource, []),
                     )
                 except ValueError as exc:
@@ -1065,21 +1141,15 @@ class AutomationAccessService:
             delegate_subject=integration_subject(grantor_subject, client_id=client_id),
             operations=tuple(selected_operations),
             resource_grants={key: tuple(value) for key, value in selected_resource_grants.items()},
-            named_service_operations={
-                resource: {
-                    namespace: tuple(operations_for_namespace)
-                    for namespace, operations_for_namespace in namespaces.items()
-                }
-                for resource, namespaces in (
-                    selected_named_service_operations or {}
-                ).items()
-            },
+            named_service_operations=selected_named_service_operations,
             named_services=copy.deepcopy(named_services),
             account_scope={
                 provider: {account_id: tuple(claims) for account_id, claims in accounts.items()}
                 for provider, accounts in selected_account_scope.items()
             },
             identity_scope=identity_scope,
+            catalog_version=catalog_version,
+            card_revision=(existing.card_revision + 1) if existing is not None else 1,
             session_id=session_id,
             created_at=created_at,
             expires_at=expires_at,
@@ -1189,8 +1259,10 @@ class AutomationAccessService:
         if admin_required and not _is_platform_admin(user):
             return {"ok": False, "error": "delegated_access_resource_requires_admin", "resources": admin_required}
         cfg_by_resource = {cfg.resource: cfg for cfg in resource_configs}
-        if selected_named_service_operations is not None:
-            unknown = sorted(set(selected_named_service_operations) - set(selected_resources))
+        if selected_named_service_operations is not None and selected_named_service_operations.is_exact:
+            unknown = sorted(
+                set(selected_named_service_operations.operations) - set(selected_resources)
+            )
             if unknown:
                 return {"ok": False, "error": "delegated_access_unknown_named_service_resources", "resources": unknown}
         for resource_value, grants_for_resource in selected_resource_grants.items():
@@ -1216,12 +1288,22 @@ class AutomationAccessService:
                 "resources": selected_resources,
             }
         # Same absent-vs-empty rule as account_scope below: an omitted narrowing
-        # keeps the record's, an explicit {} clears it. A record storing no
-        # narrowing keeps None — the shape that means "unrestricted".
-        if selected_named_service_operations is None and existing.named_service_operations:
-            selected_named_service_operations = {
-                resource: {ns: list(ops) for ns, ops in namespaces.items()}
-                for resource, namespaces in existing.named_service_operations.items()
+        # keeps the record's own state, whatever it is. An explicitly empty
+        # policy is preserved as empty, never widened back to the full one.
+        if selected_named_service_operations is None:
+            selected_named_service_operations = existing.named_service_operations
+        if selected_named_service_operations.is_unknown:
+            # A legacy card becomes explicit on its first successful save.
+            selected_named_service_operations = NamedServiceSelection.all()
+        try:
+            catalog_version = await self._active_catalog_version()
+        except CatalogUnavailable as exc:
+            return {
+                "ok": False,
+                "error": "delegated_catalog_unavailable",
+                "reason": exc.reason,
+                "retryable": True,
+                "status": 503,
             }
         # Recompute the boundary tree here: the descriptor is available in this
         # process, the guard's is not.
@@ -1235,7 +1317,7 @@ class AutomationAccessService:
                     resource=cfg.resource,
                     # Same value the record stores below, so the tree and the
                     # selection it was derived from cannot disagree.
-                    selection=selected_named_service_operations,
+                    selection=_selection_policy_argument(selected_named_service_operations),
                     grants=selected_resource_grants.get(cfg.resource, []),
                 )
             except ValueError as exc:
@@ -1267,19 +1349,15 @@ class AutomationAccessService:
             delegate_subject=existing.delegate_subject,
             operations=tuple(selected_operations),
             resource_grants={key: tuple(value) for key, value in selected_resource_grants.items()},
-            named_service_operations={
-                resource: {
-                    namespace: tuple(ops)
-                    for namespace, ops in namespaces.items()
-                }
-                for resource, namespaces in (selected_named_service_operations or {}).items()
-            },
+            named_service_operations=selected_named_service_operations,
             named_services=copy.deepcopy(named_services),
             account_scope={
                 provider: {account_id: tuple(claims) for account_id, claims in accounts.items()}
                 for provider, accounts in selected_account_scope.items()
             },
             identity_scope=next(iter(identity_scopes), existing.identity_scope or "grantor"),
+            catalog_version=catalog_version,
+            card_revision=existing.card_revision + 1,
             session_id=existing.session_id,
             created_at=existing.created_at,
             expires_at=existing.expires_at,
@@ -1389,9 +1467,13 @@ class AutomationAccessService:
             if record is not None:
                 held = set(record.resource_grants.get(cfg.resource, ()))
                 granted = required.issubset(held)
-                narrowed = record.named_service_operations.get(cfg.resource)
-                if granted and narrowed:
-                    granted = op in set(narrowed.get(ns, ()))
+                selection = record.named_service_operations
+                if granted and selection.is_none:
+                    granted = False
+                elif granted and selection.is_exact:
+                    narrowed = selection.operations.get(cfg.resource)
+                    if narrowed:
+                        granted = op in set(narrowed.get(ns, ()))
             return {
                 "governed": True,
                 "granted": granted,
@@ -1451,6 +1533,14 @@ class AutomationAccessService:
         created_at = now
         existing_grants: list[str] = []
         existing_account_scope: dict[str, dict[str, list[str]]] = {}
+        # A refresh rotation must not widen the card: the named-service
+        # selection and its materialized boundary carry forward untouched.
+        existing_selection = NamedServiceSelection.unknown()
+        existing_named_services: dict[str, Any] = {}
+        # Token rotation is not an authority change: the card keeps the catalog
+        # generation it was last saved against and only advances its revision.
+        existing_catalog_version = ""
+        existing_card_revision = 0
         existing_raw = await self._redis.get(self._record_key(access_id))
         if existing_raw is not None:
             try:
@@ -1464,6 +1554,12 @@ class AutomationAccessService:
                         existing_payload.get("account_scope")
                     ).items()
                 }
+                existing_selection = _parse_named_service_selection(existing_payload)
+                existing_catalog_version = _clean(existing_payload.get("catalog_version"))
+                existing_card_revision = int(existing_payload.get("card_revision") or 0)
+                raw_named_services = existing_payload.get("named_services")
+                if isinstance(raw_named_services, Mapping):
+                    existing_named_services = copy.deepcopy(dict(raw_named_services))
             except Exception:
                 created_at = now
         # Initial consent (not a refresh rotation): absorb superseded sibling
@@ -1510,6 +1606,10 @@ class AutomationAccessService:
             delegate_subject=integration_subject(grantor, client_id=client),
             operations=tuple(_as_list(list(operations))),
             resource_grants={resource_value or "*": tuple(scope_list)},
+            named_service_operations=existing_selection,
+            named_services=existing_named_services,
+            catalog_version=existing_catalog_version,
+            card_revision=existing_card_revision + 1,
             account_scope=normalize_account_scope(merged_account_scope),
             identity_scope=_clean(identity_scope),
             created_at=created_at,

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/automation_access.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/automation_access.py
@@ -43,6 +43,7 @@ from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.oau
 )
 from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.oauth.config import (
     OAuthDelegatedClientConfig,
+    oauth_delegated_config_from_connections,
 )
 from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.oauth.grants import (
     ACCESS_TOKEN_TTL_SECONDS,
@@ -83,6 +84,14 @@ from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.car
 )
 from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.catalog.resolver import (
     CatalogUnavailable,
+)
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.catalog.authorization import (
+    CAPABILITY_NAMED_SERVICE_OPERATION,
+    ActiveCatalogCapabilities,
+    CapabilityRequest,
+    CardProvenance,
+    authorize_current_capability,
+    capability_denial,
 )
 from kdcube_ai_app.apps.chat.sdk.solutions.named_services_providers.boundary_policy import (
     NamedServiceBoundaryCatalog,
@@ -700,6 +709,12 @@ class AutomationAccessService:
             subject_hash=_subject_key(grantor_subject), now=now
         )
         return [record_from_card(authority) for authority in authorities]
+
+    async def _active_catalog(self):
+        """The registered catalog a governed decision is taken against."""
+        if self._catalog_resolver is None:
+            raise CatalogUnavailable("catalog_resolver_not_configured")
+        return await self._catalog_resolver.resolve_active()
 
     async def _active_catalog_version(self) -> str:
         """The generation a save is stamped with.
@@ -1565,20 +1580,29 @@ class AutomationAccessService:
         operation: str,
     ) -> dict[str, Any]:
         """Whether an agent client holds the delegated-by grant a NATIVE
-        named-service call needs: the configured named-services resource that
-        publishes ``namespace``, the operation's declared grants plus the
-        resource's entry grants, checked against the agent's grant record
-        (claims AND, when the record narrowed operations, the narrowing).
+        named-service call needs.
 
-        Returns ``{"governed": False}`` when no configured resource publishes
-        the namespace (nothing to gate). Otherwise ``{"governed": True,
-        "granted": bool, "resource", "claims"}`` — ``claims`` is the full
-        required set, ready for the one-click grant payload."""
+        The ceiling is the registered catalog, not live props, so this answers
+        the same question the managed guard answers for the MCP door: the
+        catalog resource that publishes ``namespace``, the operation's declared
+        grants plus the resource's entry grants, intersected with the agent's
+        card.
+
+        Outcomes:
+
+            {"governed": False}                nothing publishes the namespace
+            {"governed": True, "granted": …}   the catalog offers it
+            {"removed": <structured denial>}   the card holds it, the catalog
+                                               no longer offers it
+            CatalogUnavailable                 current authority is unknown
+        """
         ns = _clean(namespace).lower().rstrip(":")
         op = _clean(operation)
         if not ns or not op:
             return {"governed": False}
-        for cfg in self._config.resources:
+        active = await self._active_catalog()
+        catalog = ActiveCatalogCapabilities(active)
+        for cfg in oauth_delegated_config_from_connections(active.connections).resources:
             named = cfg.named_services if isinstance(cfg.named_services, Mapping) else None
             raw_namespaces = named.get("namespaces") if named else None
             if not isinstance(raw_namespaces, Mapping):
@@ -1619,6 +1643,26 @@ class AutomationAccessService:
             )
             if record is not None and record.source != ACCESS_SOURCE_AGENT:
                 record = None
+            # The namespace survives, but the operation under it may not. A
+            # capability the catalog no longer offers is refused outright —
+            # consent cannot restore it.
+            removed = authorize_current_capability(
+                catalog=catalog,
+                provenance=CardProvenance(
+                    access_id=record.access_id if record is not None else "",
+                    card_revision=record.card_revision if record is not None else 0,
+                    catalog_version=record.catalog_version if record is not None else "",
+                ),
+                request=CapabilityRequest(
+                    kind=CAPABILITY_NAMED_SERVICE_OPERATION,
+                    resource=cfg.resource,
+                    surface="named_service",
+                    namespace=ns,
+                    operation=op,
+                ),
+            )
+            if removed is not None:
+                return {"governed": True, "granted": False, "removed": removed}
             granted = False
             if record is not None:
                 held = set(record.resource_grants.get(cfg.resource, ()))
@@ -1644,7 +1688,64 @@ class AutomationAccessService:
                     for provider, accounts in (record.account_scope.items() if record is not None else ())
                 },
             }
+        # Nothing in the active catalog publishes the namespace. A card that
+        # still carries it is a removed capability, not an ungoverned call: the
+        # user cannot consent their way back to something the deployment no
+        # longer offers.
+        removed = await self._removed_namespace_denial(
+            catalog=catalog,
+            grantor_subject=grantor_subject,
+            client_id=client_id,
+            namespace=ns,
+            operation=op,
+        )
+        if removed is not None:
+            return {"governed": True, "granted": False, "removed": removed}
         return {"governed": False}
+
+    async def _removed_namespace_denial(
+        self,
+        *,
+        catalog: "ActiveCatalogCapabilities",
+        grantor_subject: str,
+        client_id: str,
+        namespace: str,
+        operation: str,
+    ) -> dict[str, Any] | None:
+        """The structured denial for a namespace this agent's card still holds.
+
+        The card's materialized boundary is the expansion of its selection under
+        the catalog version it was saved against, so membership there is what
+        proves the capability was granted.
+        """
+        client = _clean(client_id)
+        for record in await self._list_active_records(grantor_subject):
+            if record.source != ACCESS_SOURCE_AGENT or _clean(record.client_id) != client:
+                continue
+            namespaces = (record.named_services or {}).get("namespaces")
+            if not isinstance(namespaces, Mapping):
+                continue
+            if not any(
+                _clean(name).lower().rstrip(":") == namespace for name in namespaces
+            ):
+                continue
+            resource = next(iter(record.resource_grants), "")
+            return capability_denial(
+                catalog=catalog,
+                provenance=CardProvenance(
+                    access_id=record.access_id,
+                    card_revision=record.card_revision,
+                    catalog_version=record.catalog_version,
+                ),
+                request=CapabilityRequest(
+                    kind=CAPABILITY_NAMED_SERVICE_OPERATION,
+                    resource=str(resource),
+                    surface="named_service",
+                    namespace=namespace,
+                    operation=operation,
+                ),
+            )
+        return None
 
     async def record_oauth_grant(
         self,

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/automation_access.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/automation_access.py
@@ -85,6 +85,13 @@ from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.car
 from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.catalog.resolver import (
     CatalogUnavailable,
 )
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.catalog.drift import (
+    card_drift,
+    drift_unavailable,
+)
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.catalog.reconcile import (
+    reconcile_selection,
+)
 from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.catalog.authorization import (
     CAPABILITY_NAMED_SERVICE_OPERATION,
     ActiveCatalogCapabilities,
@@ -710,6 +717,120 @@ class AutomationAccessService:
         )
         return [record_from_card(authority) for authority in authorities]
 
+    async def _save_precondition_conflict(
+        self,
+        *,
+        existing: AutomationAccessRecord,
+        active: Any,
+        expected_card_revision: int | None,
+        expected_catalog_version: str | None,
+    ) -> dict[str, Any] | None:
+        """``409`` with a refreshed projection when the editor's inputs moved.
+
+        Both preconditions are optional; a caller that sends neither keeps the
+        previous last-writer-wins behaviour.
+        """
+        mismatched: dict[str, Any] = {}
+        if expected_card_revision is not None and int(expected_card_revision) != int(
+            existing.card_revision
+        ):
+            mismatched["card_revision"] = {
+                "expected": int(expected_card_revision),
+                "actual": int(existing.card_revision),
+            }
+        expected_version = _clean(expected_catalog_version)
+        if expected_version and expected_version != _clean(getattr(active, "version", "")):
+            mismatched["catalog_version"] = {
+                "expected": expected_version,
+                "actual": _clean(getattr(active, "version", "")),
+            }
+        if not mismatched:
+            return None
+
+        refreshed = existing.to_public_dict()
+        try:
+            baseline, reason = await self._baseline_document(_clean(existing.catalog_version))
+            refreshed["catalog_drift"] = (
+                drift_unavailable(reason)
+                if reason
+                else card_drift(
+                    card=existing,
+                    active=active,
+                    baseline=baseline,
+                    baseline_confirmed_absent=baseline is None,
+                )
+            )
+        except Exception:
+            _LOGGER.warning(
+                "[automation-access] drift for conflict response failed card=%s",
+                existing.access_id,
+                exc_info=True,
+            )
+            refreshed["catalog_drift"] = drift_unavailable("catalog_unavailable")
+        return {
+            "ok": False,
+            "error": "delegated_access_precondition_failed",
+            "status": 409,
+            "mismatched": mismatched,
+            "access": refreshed,
+        }
+
+    async def _catalog_drift(
+        self, records: Iterable[AutomationAccessRecord]
+    ) -> dict[str, dict[str, Any]]:
+        """Drift per card: one active read, and one read per distinct baseline.
+
+        Listing explains cards; it never rewrites them, and an unreadable
+        comparison disables editing rather than hiding the card.
+        """
+        rows = list(records)
+        try:
+            active = await self._active_catalog()
+        except CatalogUnavailable as exc:
+            return {record.access_id: drift_unavailable(exc.reason) for record in rows}
+        except Exception:
+            _LOGGER.warning("[automation-access] active catalog unreadable", exc_info=True)
+            return {
+                record.access_id: drift_unavailable("catalog_unavailable") for record in rows
+            }
+
+        baselines: dict[str, tuple[Any, str]] = {}
+        out: dict[str, dict[str, Any]] = {}
+        for record in rows:
+            version = _clean(record.catalog_version)
+            if version and version == active.version:
+                out[record.access_id] = card_drift(
+                    card=record, active=active, baseline=active
+                )
+                continue
+            if version not in baselines:
+                baselines[version] = await self._baseline_document(version)
+            document, reason = baselines[version]
+            if reason:
+                out[record.access_id] = drift_unavailable(reason)
+                continue
+            out[record.access_id] = card_drift(
+                card=record,
+                active=active,
+                baseline=document,
+                baseline_confirmed_absent=document is None,
+            )
+        return out
+
+    async def _baseline_document(self, version: str) -> tuple[Any, str]:
+        """``(document, reason)``. No document and no reason is confirmed absence."""
+        if not version:
+            return None, ""
+        try:
+            return await self._catalog_resolver.resolve_version(version), ""
+        except CatalogUnavailable as exc:
+            return None, (exc.reason or "catalog_unavailable")
+        except Exception:
+            _LOGGER.warning(
+                "[automation-access] baseline unreadable version=%s", version, exc_info=True
+            )
+            return None, "catalog_unavailable"
+
     async def _active_catalog(self):
         """The registered catalog a governed decision is taken against."""
         if self._catalog_resolver is None:
@@ -946,7 +1067,12 @@ class AutomationAccessService:
                 "retryable": True,
                 "status": 503,
             }
-        records = [record.to_public_dict() for record in records_found]
+        drift_by_card = await self._catalog_drift(records_found)
+        records = []
+        for record in records_found:
+            item = record.to_public_dict()
+            item["catalog_drift"] = drift_by_card[record.access_id]
+            records.append(item)
 
         records.sort(key=lambda item: str(item.get("created_at") or ""), reverse=True)
         return {
@@ -1339,6 +1465,8 @@ class AutomationAccessService:
         named_service_operations: Mapping[str, Any] | None = None,
         account_scope: Mapping[str, Any] | None = None,
         label: str | None = None,
+        expected_card_revision: int | None = None,
+        expected_catalog_version: str | None = None,
     ) -> dict[str, Any]:
         """Edit a MANUAL automation access IN PLACE: replace its grants while
         keeping the same access_id and token. The card is the guard's authority
@@ -1371,6 +1499,34 @@ class AutomationAccessService:
         if existing.source != ACCESS_SOURCE_MANUAL:
             return {"ok": False, "error": "delegated_access_not_editable"}
 
+        try:
+            active = await self._active_catalog()
+        except CatalogUnavailable as exc:
+            return {
+                "ok": False,
+                "error": "delegated_catalog_unavailable",
+                "reason": exc.reason,
+                "retryable": True,
+                "status": 503,
+            }
+        catalog_version = _clean(getattr(active, "version", ""))
+        if not catalog_version:
+            return {
+                "ok": False,
+                "error": "delegated_catalog_unavailable",
+                "reason": "active_catalog_version_missing",
+                "retryable": True,
+                "status": 503,
+            }
+        conflict = await self._save_precondition_conflict(
+            existing=existing,
+            active=active,
+            expected_card_revision=expected_card_revision,
+            expected_catalog_version=expected_catalog_version,
+        )
+        if conflict is not None:
+            return conflict
+
         # Validate the new grants with the SAME rules as create_access.
         selected_resource_grants = self._resource_grants(resource_grants)
         try:
@@ -1379,6 +1535,40 @@ class AutomationAccessService:
             )
         except ValueError as exc:
             return {"ok": False, "error": "invalid_named_service_operation_selection", "message": str(exc)}
+        # Resolved before pruning: pruning acts on the selection about to be
+        # persisted. Omitted keeps the record's own state; legacy becomes "*".
+        if selected_named_service_operations is None:
+            selected_named_service_operations = existing.named_service_operations
+        if selected_named_service_operations.is_unknown:
+            selected_named_service_operations = NamedServiceSelection.all()
+
+        # Submitting nothing is a client error; pruning to nothing is a revoke.
+        if not any(selected_resource_grants.values()):
+            return {"ok": False, "error": "delegated_access_requires_resource_grants"}
+
+        # Values absent from the active catalog are pruned, not rejected.
+        reconciled = reconcile_selection(
+            resource_grants=selected_resource_grants,
+            named_service_operations=selected_named_service_operations,
+            active=active,
+        )
+        if reconciled.empty:
+            # No authority survives: revoke rather than keep an empty card.
+            revoked = await self.revoke_access(user, access_id=access_id)
+            if not revoked.get("ok"):
+                return revoked
+            return {
+                "ok": True,
+                "revoked": True,
+                "access_id": access_id,
+                "pruned": reconciled.to_public_dict(),
+                "message": (
+                    "Every selection on this card was withdrawn from the delegated-service "
+                    "catalog, so the card was revoked instead of saved."
+                ),
+            }
+        selected_resource_grants = reconciled.resource_grants
+        selected_named_service_operations = reconciled.named_service_operations
         selected_resources = list(selected_resource_grants)
         if self._config.resources and not selected_resources:
             return {"ok": False, "error": "delegated_access_requires_resource_grants"}
@@ -1449,24 +1639,6 @@ class AutomationAccessService:
                 "ok": False,
                 "error": "delegated_access_resources_have_conflicting_identity_scopes",
                 "resources": selected_resources,
-            }
-        # Same absent-vs-empty rule as account_scope below: an omitted narrowing
-        # keeps the record's own state, whatever it is. An explicitly empty
-        # policy is preserved as empty, never widened back to the full one.
-        if selected_named_service_operations is None:
-            selected_named_service_operations = existing.named_service_operations
-        if selected_named_service_operations.is_unknown:
-            # A legacy card becomes explicit on its first successful save.
-            selected_named_service_operations = NamedServiceSelection.all()
-        try:
-            catalog_version = await self._active_catalog_version()
-        except CatalogUnavailable as exc:
-            return {
-                "ok": False,
-                "error": "delegated_catalog_unavailable",
-                "reason": exc.reason,
-                "retryable": True,
-                "status": 503,
             }
         # Recompute the boundary tree here: the descriptor is available in this
         # process, the guard's is not.
@@ -1541,7 +1713,9 @@ class AutomationAccessService:
                 "status": 503,
             }
         await self.notify_change(grantor_subject, action="updated", access=updated.to_public_dict())
-        return {"ok": True, "access": updated.to_public_dict()}
+        saved = updated.to_public_dict()
+        saved["catalog_drift"] = card_drift(card=updated, active=active, baseline=active)
+        return {"ok": True, "access": saved, "pruned": reconciled.to_public_dict()}
 
     async def agent_access_token(
         self,

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/automation_access.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/automation_access.py
@@ -997,6 +997,22 @@ class AutomationAccessService:
             raise CatalogUnavailable("catalog_resolver_not_configured")
         return await self._catalog_resolver.resolve_active()
 
+    @staticmethod
+    def _catalog_config(active: Any) -> Any:
+        """The delegable config a save decides against: the registered catalog,
+        read with the same parser request paths use. Effective props are an
+        input to publication, not to a card write."""
+        return oauth_delegated_config_from_connections(
+            getattr(active, "connections", None) or {}
+        )
+
+    @staticmethod
+    def _version_of(active: Any) -> str:
+        version = _clean(getattr(active, "version", ""))
+        if not version:
+            raise CatalogUnavailable("active_catalog_version_missing")
+        return version
+
     async def _active_catalog_version(self) -> str:
         """The generation a save is stamped with.
 
@@ -1017,15 +1033,28 @@ class AutomationAccessService:
         user: Mapping[str, Any],
         *,
         requested_grants: Iterable[str] = (),
+        config: Any = None,
     ) -> AuthorityGrantInventory:
-        provider = PlatformAuthorityInventoryProvider(self._config.capabilities)
+        provider = PlatformAuthorityInventoryProvider((config or self._config).capabilities)
         return await provider.list_delegable_grants(
             platform_identity_from_user(user),
             requested_grants=requested_grants,
         )
 
+    async def _offer_config(self) -> Any | None:
+        """The catalog a form may offer from, or ``None`` when it cannot be
+        established. Offering from effective props would promise what a save,
+        which reads the catalog, then refuses."""
+        try:
+            return self._catalog_config(await self._active_catalog())
+        except CatalogUnavailable:
+            return None
+
     async def grant_options(self, user: Mapping[str, Any]) -> list[dict[str, Any]]:
-        inventory = await self._available_inventory(user)
+        offer = await self._offer_config()
+        if offer is None:
+            return []
+        inventory = await self._available_inventory(user, config=offer)
         return [item.to_dict() for item in inventory.grants]
 
     async def _named_service_options(
@@ -1099,12 +1128,19 @@ class AutomationAccessService:
 
         A card can never carry more than its grantor holds, so a claim outside
         their delegable set is not offered — the same rule the admin-only row
-        above already applies to whole resources.
+        above already applies to whole resources. The rows come from the
+        registered catalog, which is what a save decides against; an
+        unestablished catalog offers nothing rather than offering props.
         """
+        offer = await self._offer_config()
+        if offer is None:
+            return []
         platform_admin = _is_platform_admin(user)
-        delegable = set((await self._available_inventory(user)).grant_names())
+        delegable = set(
+            (await self._available_inventory(user, config=offer)).grant_names()
+        )
         out: list[dict[str, Any]] = []
-        for resource in self._config.resources:
+        for resource in offer.resources:
             if resource.admin_only and not platform_admin:
                 continue
             option = {
@@ -1136,16 +1172,19 @@ class AutomationAccessService:
             out.append(option)
         return out
 
-    def _configured_resource(self, resource: str) -> Any | None:
+    def _configured_resource(
+        self, resource: str, *, config: Any = None
+    ) -> Any | None:
         """The catalog row governing a card resource. Matched, not compared:
-        a card key is the row's pattern or a concrete URL."""
+        a card key is the row's pattern or a concrete URL. ``config`` defaults
+        to the process descriptor; a save passes the registered catalog."""
         text = _clean(resource)
         if not text:
             return None
-        return self._config.card_selector_config(text)
+        return (config or self._config).card_selector_config(text)
 
     def _configured_resource_pairs(
-        self, resources: Iterable[str]
+        self, resources: Iterable[str], *, config: Any = None
     ) -> tuple[tuple[str, Any], ...]:
         """``(card resource, governing row)``. Grants and the selection are
         keyed by the card resource, the descriptor subtree by the row."""
@@ -1153,7 +1192,7 @@ class AutomationAccessService:
         pairs: list[tuple[str, Any]] = []
         missing: list[str] = []
         for resource in selected:
-            cfg = self._configured_resource(resource)
+            cfg = self._configured_resource(resource, config=config)
             if cfg is None:
                 missing.append(resource)
             else:
@@ -1242,6 +1281,8 @@ class AutomationAccessService:
             active = await self._active_catalog()
         except CatalogUnavailable:
             active = None
+        # Without a catalog a card cannot be explained, only listed and revoked.
+        listing_config = self._catalog_config(active) if active is not None else None
         records = []
         for record in records_found:
             item = record.to_public_dict()
@@ -1253,7 +1294,11 @@ class AutomationAccessService:
                     resource
                     for resource in record.resource_grants
                     if isinstance(
-                        getattr(self._configured_resource(resource), "named_services", None),
+                        getattr(
+                            self._configured_resource(resource, config=listing_config),
+                            "named_services",
+                            None,
+                        ),
                         Mapping,
                     )
                 ],
@@ -1269,7 +1314,7 @@ class AutomationAccessService:
             # not re-derive this: the match is the resolver's, not a comparison.
             rows = {}
             for resource in record.resource_grants:
-                cfg = self._configured_resource(resource)
+                cfg = self._configured_resource(resource, config=listing_config)
                 if cfg is not None:
                     rows[resource] = str(getattr(cfg, "resource", "") or "")
             if rows:
@@ -1285,10 +1330,18 @@ class AutomationAccessService:
             "items": records,
         }
 
-    def _resolve_operations(self, *, grants: list[str], operations: list[str], resources: list[str]) -> list[str]:
+    def _resolve_operations(
+        self,
+        *,
+        grants: list[str],
+        operations: list[str],
+        resources: list[str],
+        config: Any = None,
+    ) -> list[str]:
+        source = config or self._config
         available_by_name: dict[str, Any] = {}
         for resource in resources:
-            for operation in self._config.tools_for_scopes(grants, resource=resource or None):
+            for operation in source.tools_for_scopes(grants, resource=resource or None):
                 available_by_name.setdefault(operation.name, operation)
         available_names = set(available_by_name)
         if operations:
@@ -1330,6 +1383,21 @@ class AutomationAccessService:
         if refusal is not None:
             return refusal
 
+        # Resolved before anything is decided: a card is written against the
+        # registered catalog, never against effective props.
+        try:
+            active = await self._active_catalog()
+            catalog_version = self._version_of(active)
+        except CatalogUnavailable as exc:
+            return {
+                "ok": False,
+                "error": "delegated_catalog_unavailable",
+                "reason": exc.reason,
+                "retryable": True,
+                "status": 503,
+            }
+        catalog_config = self._catalog_config(active)
+
         selected_resource_grants = self._resource_grants(resource_grants)
         try:
             selected_named_service_operations = self._named_service_operation_selection(
@@ -1342,7 +1410,7 @@ class AutomationAccessService:
                 "message": str(exc),
             }
         selected_resources = list(selected_resource_grants)
-        if self._config.resources and not selected_resources:
+        if catalog_config.resources and not selected_resources:
             return {"ok": False, "error": "delegated_access_requires_resource_grants"}
 
         selected_grants = _as_list([
@@ -1361,8 +1429,8 @@ class AutomationAccessService:
         # of that may be asked for here, and until it says so the answer is no.
         try:
             resource_pairs = (
-                self._configured_resource_pairs(selected_resources)
-                if self._config.resources else ()
+                self._configured_resource_pairs(selected_resources, config=catalog_config)
+                if catalog_config.resources else ()
             )
         except ValueError:
             return {
@@ -1377,7 +1445,9 @@ class AutomationAccessService:
             }
         resource_configs = tuple(cfg for _, cfg in resource_pairs)
 
-        inventory = await self._available_inventory(user, requested_grants=selected_grants)
+        inventory = await self._available_inventory(
+            user, requested_grants=selected_grants, config=catalog_config
+        )
         available = set(inventory.grant_names())
         denied = [grant for grant in selected_grants if grant not in available]
         if denied:
@@ -1415,7 +1485,7 @@ class AutomationAccessService:
             cfg = cfg_by_resource.get(resource_value)
             if cfg is None:
                 continue
-            allowed_for_resource = set(self._config.supported_scopes(resource_value))
+            allowed_for_resource = set(catalog_config.supported_scopes(resource_value))
             disallowed = [grant for grant in grants_for_resource if grant not in allowed_for_resource]
             if disallowed:
                 return {
@@ -1548,17 +1618,6 @@ class AutomationAccessService:
                 else NamedServiceSelection.none()
             )
         try:
-            catalog_version = await self._active_catalog_version()
-        except CatalogUnavailable as exc:
-            return {
-                "ok": False,
-                "error": "delegated_catalog_unavailable",
-                "reason": exc.reason,
-                "retryable": True,
-                "status": 503,
-            }
-
-        try:
             committed_revision = await self._committed_revision(
                 access_id, grantor_subject=grantor_subject
             )
@@ -1595,6 +1654,7 @@ class AutomationAccessService:
             grants=selected_grants,
             operations=_as_list(list(operations)),
             resources=selected_resources,
+            config=catalog_config,
         )
 
         ttl = _bounded_ttl(ttl_seconds)
@@ -1715,6 +1775,9 @@ class AutomationAccessService:
         credential fields their family carries.
         """
         selected_resource_grants = self._resource_grants(resource_grants)
+        # Every decision below reads the registered catalog. Effective props are
+        # an input to publication, not to a card write.
+        catalog_config = self._catalog_config(active)
         try:
             selected_named_service_operations = self._named_service_operation_selection(
                 named_service_operations
@@ -1732,7 +1795,11 @@ class AutomationAccessService:
                     resource
                     for resource in selected_resource_grants
                     if isinstance(
-                        getattr(self._configured_resource(resource), "named_services", None),
+                        getattr(
+                            self._configured_resource(resource, config=catalog_config),
+                            "named_services",
+                            None,
+                        ),
                         Mapping,
                     )
                 ],
@@ -1777,7 +1844,7 @@ class AutomationAccessService:
         selected_resource_grants = reconciled.resource_grants
         selected_named_service_operations = reconciled.named_service_operations
         selected_resources = list(selected_resource_grants)
-        if self._config.resources and not selected_resources:
+        if catalog_config.resources and not selected_resources:
             return ResolvedCardAuthority(error={
                 "ok": False, "error": "delegated_access_requires_resource_grants",
             })
@@ -1795,8 +1862,8 @@ class AutomationAccessService:
         # delegable is a different answer from a permission it will not delegate.
         try:
             resource_pairs = (
-                self._configured_resource_pairs(selected_resources)
-                if self._config.resources else ()
+                self._configured_resource_pairs(selected_resources, config=catalog_config)
+                if catalog_config.resources else ()
             )
         except ValueError:
             return ResolvedCardAuthority(error={
@@ -1810,7 +1877,9 @@ class AutomationAccessService:
                 ),
             })
         resource_configs = tuple(cfg for _, cfg in resource_pairs)
-        inventory = await self._available_inventory(user, requested_grants=selected_grants)
+        inventory = await self._available_inventory(
+            user, requested_grants=selected_grants, config=catalog_config
+        )
         denied = [grant for grant in selected_grants if grant not in set(inventory.grant_names())]
         if denied:
             return ResolvedCardAuthority(error={
@@ -1847,7 +1916,7 @@ class AutomationAccessService:
             cfg = cfg_by_resource.get(resource_value)
             if cfg is None:
                 continue
-            allowed_for_resource = set(self._config.supported_scopes(resource_value))
+            allowed_for_resource = set(catalog_config.supported_scopes(resource_value))
             disallowed = [grant for grant in grants_for_resource if grant not in allowed_for_resource]
             if disallowed:
                 return ResolvedCardAuthority(error={
@@ -1909,6 +1978,7 @@ class AutomationAccessService:
             resource_grants=selected_resource_grants,
             operations=self._resolve_operations(
                 grants=selected_grants, operations=(), resources=selected_resources,
+                config=catalog_config,
             ),
             named_service_operations=selected_named_service_operations,
             named_services=named_services,
@@ -2343,9 +2413,11 @@ class AutomationAccessService:
         selection: NamedServiceSelection,
         resource: str,
         grants: Iterable[str],
+        config: Any = None,
     ) -> dict[str, Any]:
         """The boundary tree a selection expands to for one resource."""
-        cfg = self._config.resource_config(resource) if resource else None
+        source = config or self._config
+        cfg = source.resource_config(resource) if resource else None
         if cfg is None or not isinstance(getattr(cfg, "named_services", None), Mapping):
             return {}
         try:
@@ -2435,21 +2507,29 @@ class AutomationAccessService:
         # Initial consent (not a refresh rotation): absorb superseded sibling
         # cards BEFORE composing this card, so their binding carries over.
         is_initial_consent = existing_card is None
-        if is_initial_consent:
-            # Born from what the consent screen submitted, stamped with the
-            # catalog it was chosen against. An absent selection is `{}`.
-            try:
-                selection = self._named_service_operation_selection(
-                    named_service_operations
-                )
-            except ValueError:
-                selection = None
-            existing_selection = selection or NamedServiceSelection.none()
+        # A submitted selection is a consent-screen choice and REPLACES what the
+        # card held: only the newest consent counts, even if an earlier one said
+        # `"*"`. Its absence is a refresh rotation, which carries the selection
+        # forward untouched. The grant type already separates the two:
+        # authorization_code passes both fields, refresh_token passes neither.
+        try:
+            submitted_selection = self._named_service_operation_selection(
+                named_service_operations
+            )
+        except ValueError:
+            submitted_selection = None
+        if submitted_selection is not None or is_initial_consent:
+            existing_selection = submitted_selection or NamedServiceSelection.none()
             existing_catalog_version = _clean(catalog_version)
+            try:
+                consent_config = self._catalog_config(await self._active_catalog())
+            except CatalogUnavailable:
+                consent_config = None
             existing_named_services = self._materialized_boundary_for(
                 selection=existing_selection,
                 resource=resource_value,
                 grants=_as_list(list(scopes)),
+                config=consent_config,
             )
         inherited_account_scope: dict[str, dict[str, list[str]]] = {}
         superseded: list[AutomationAccessRecord] = []
@@ -2572,6 +2652,44 @@ class AutomationAccessService:
                         if claim not in held:
                             held.append(str(claim))
         return seed
+
+    async def oauth_seed_named_service_operations(
+        self,
+        *,
+        grantor_subject: str,
+        client_id: str,
+        resource: str,
+    ) -> dict[str, list[str]]:
+        """The named-service operations a consent screen should pre-check.
+
+        Read from the card's MATERIALIZED boundary, not its selection: a
+        wildcard means "everything the acknowledged catalog offered", and the
+        boundary is that expansion under the version the card is pinned to. So
+        the pre-check reproduces exactly what the card grants today.
+
+        Only the client's own card. A superseded DCR sibling donates its
+        account binding at issuance and nothing else, so seeding this dimension
+        from one would promise what the writer does not keep.
+        """
+        grantor = _clean(grantor_subject)
+        client = _clean(client_id)
+        if not grantor or not client:
+            return {}
+        try:
+            record = await self._load_record(
+                oauth_access_id(grantor, client, _clean(resource)),
+                grantor_subject=grantor,
+            )
+        except CardUnavailable:
+            return {}
+        if record is None:
+            return {}
+        offered = configured_named_service_operations(record.named_services)
+        return {
+            namespace: sorted(operations)
+            for namespace, operations in offered.items()
+            if operations
+        }
 
     async def _collect_oauth_siblings(
         self,
@@ -2767,7 +2885,17 @@ class AutomationAccessService:
                     "message": "This client has no existing grant to extend; it connects via its own consent flow first."}
         # Claims must stay inside the deployment's delegable ceiling for the
         # resource when the catalog knows it.
-        cfg = self._config.resource_config(resource_value) if resource_value else None
+        try:
+            extend_config = self._catalog_config(await self._active_catalog())
+        except CatalogUnavailable as exc:
+            return {
+                "ok": False,
+                "error": "delegated_catalog_unavailable",
+                "reason": exc.reason,
+                "retryable": True,
+                "status": 503,
+            }
+        cfg = extend_config.resource_config(resource_value) if resource_value else None
         ceiling = set(_as_list(list(getattr(cfg, "grants", ()) or ()))) if cfg is not None else set()
         if ceiling:
             outside = sorted(set(claim_list) - ceiling)

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/cache_io.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/cache_io.py
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Elena Viter
+
+"""Shared encoding helpers for the delegated catalog/card Redis projections.
+
+Cached values are compared inside Lua, so they are always encoded with the same
+canonical separators and key order.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Mapping
+
+
+def encode_cache_value(payload: Mapping[str, Any]) -> str:
+    return json.dumps(payload, ensure_ascii=True, sort_keys=True, separators=(",", ":"))
+
+
+def decode_cache_value(raw: Any) -> dict[str, Any] | None:
+    """Parsed cached object, or ``None`` when the value is absent or unusable.
+
+    Unusable cache data is not an error: the caller read-throughs to durable
+    state and conditionally replaces the projection.
+    """
+    if raw is None:
+        return None
+    if isinstance(raw, memoryview):
+        raw = raw.tobytes()
+    if isinstance(raw, (bytes, bytearray)):
+        try:
+            raw = raw.decode("utf-8")
+        except UnicodeDecodeError:
+            return None
+    if not isinstance(raw, str) or not raw:
+        return None
+    try:
+        value = json.loads(raw)
+    except ValueError:
+        return None
+    return value if isinstance(value, dict) else None
+
+
+__all__ = ["decode_cache_value", "encode_cache_value"]

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/cache_settings.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/cache_settings.py
@@ -1,0 +1,121 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Elena Viter
+
+"""Descriptor-owned cache-residency settings for delegated catalogs and cards.
+
+These are residency lifetimes only. They decide how long a Redis projection or
+a temporary marker survives before a read-through or a retry; they never grant,
+extend, or revoke authority. Card authorization lifetime remains the card's own
+``expires_at``, and durable retention is a separate administrative policy.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+DEFAULT_ACTIVE_CACHE_SECONDS = 300
+DEFAULT_VERSION_CACHE_SECONDS = 3600
+DEFAULT_UPDATING_MARKER_SECONDS = 15
+DEFAULT_REVOKED_TOMBSTONE_SECONDS = 60
+
+_MIN_SECONDS = 1
+_MAX_SECONDS = 24 * 3600
+
+
+def _bounded_seconds(value: Any, default: int) -> int:
+    try:
+        seconds = int(value)
+    except (TypeError, ValueError):
+        return default
+    if seconds <= 0:
+        return default
+    return max(_MIN_SECONDS, min(seconds, _MAX_SECONDS))
+
+
+def _node(parent: Mapping[str, Any] | Any, key: str) -> Mapping[str, Any]:
+    if not isinstance(parent, Mapping):
+        return {}
+    value = parent.get(key)
+    return value if isinstance(value, Mapping) else {}
+
+
+@dataclass(frozen=True)
+class DelegatedCatalogCacheSettings:
+    """Residency of the serving catalog projections.
+
+    ``active`` is the ceiling every governed call intersects against; its expiry
+    forces a validated read-through, which is what repairs a corrupted entry.
+    ``version`` holds immutable historical documents used only to explain drift.
+    Neither is extended by an ordinary cache hit.
+    """
+
+    active_cache_seconds: int = DEFAULT_ACTIVE_CACHE_SECONDS
+    version_cache_seconds: int = DEFAULT_VERSION_CACHE_SECONDS
+
+    @classmethod
+    def from_mapping(cls, value: Any) -> "DelegatedCatalogCacheSettings":
+        return cls(
+            active_cache_seconds=_bounded_seconds(
+                _as_mapping(value).get("active_cache_seconds"), DEFAULT_ACTIVE_CACHE_SECONDS
+            ),
+            version_cache_seconds=_bounded_seconds(
+                _as_mapping(value).get("version_cache_seconds"), DEFAULT_VERSION_CACHE_SECONDS
+            ),
+        )
+
+
+@dataclass(frozen=True)
+class DelegatedCardCacheSettings:
+    """Lifetimes of the two short fail-closed card markers.
+
+    The updating marker must outlive a worst-case durable commit, or a delayed
+    read-through can restore the superseded revision mid-commit; it must stay
+    short, because a crashed mutation blocks that card until it expires.
+    """
+
+    updating_marker_seconds: int = DEFAULT_UPDATING_MARKER_SECONDS
+    revoked_tombstone_seconds: int = DEFAULT_REVOKED_TOMBSTONE_SECONDS
+
+    @classmethod
+    def from_mapping(cls, value: Any) -> "DelegatedCardCacheSettings":
+        return cls(
+            updating_marker_seconds=_bounded_seconds(
+                _as_mapping(value).get("updating_marker_seconds"),
+                DEFAULT_UPDATING_MARKER_SECONDS,
+            ),
+            revoked_tombstone_seconds=_bounded_seconds(
+                _as_mapping(value).get("revoked_tombstone_seconds"),
+                DEFAULT_REVOKED_TOMBSTONE_SECONDS,
+            ),
+        )
+
+
+@dataclass(frozen=True)
+class DelegatedCacheSettings:
+    catalog: DelegatedCatalogCacheSettings = DelegatedCatalogCacheSettings()
+    cards: DelegatedCardCacheSettings = DelegatedCardCacheSettings()
+
+    @classmethod
+    def from_connections(cls, connections: Any) -> "DelegatedCacheSettings":
+        """Read ``connections.delegated_credentials.{catalog,cards}``."""
+        delegated = _node(connections, "delegated_credentials")
+        return cls(
+            catalog=DelegatedCatalogCacheSettings.from_mapping(_node(delegated, "catalog")),
+            cards=DelegatedCardCacheSettings.from_mapping(_node(delegated, "cards")),
+        )
+
+
+def _as_mapping(value: Any) -> Mapping[str, Any]:
+    return value if isinstance(value, Mapping) else {}
+
+
+__all__ = [
+    "DEFAULT_ACTIVE_CACHE_SECONDS",
+    "DEFAULT_REVOKED_TOMBSTONE_SECONDS",
+    "DEFAULT_UPDATING_MARKER_SECONDS",
+    "DEFAULT_VERSION_CACHE_SECONDS",
+    "DelegatedCacheSettings",
+    "DelegatedCardCacheSettings",
+    "DelegatedCatalogCacheSettings",
+]

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/cards/__init__.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/cards/__init__.py
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Elena Viter
+
+"""Delegated cards: non-secret authority, credential handles, durable revisions."""
+
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.cards.model import (
+    CARD_STATE_ACTIVE,
+    CARD_STATE_REVOKED,
+    CardAuthority,
+    CardCredentialHandles,
+    CardCurrentPointer,
+    CardRecordError,
+    NamedServiceSelection,
+    card_revision_name,
+)
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.cards.cache import (
+    CardCacheEntry,
+    DelegatedCardRuntimeCache,
+)
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.cards.resolver import (
+    CardUnavailable,
+    DelegatedCardResolver,
+)
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.cards.store import (
+    BundleStorageDelegatedCardStore,
+    CardStorageError,
+    DelegatedCardStore,
+)
+
+__all__ = [
+    "CARD_STATE_ACTIVE",
+    "CARD_STATE_REVOKED",
+    "BundleStorageDelegatedCardStore",
+    "CardAuthority",
+    "CardCacheEntry",
+    "CardCredentialHandles",
+    "CardCurrentPointer",
+    "CardRecordError",
+    "CardStorageError",
+    "CardUnavailable",
+    "DelegatedCardResolver",
+    "DelegatedCardRuntimeCache",
+    "DelegatedCardStore",
+    "NamedServiceSelection",
+    "card_revision_name",
+]

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/cards/__init__.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/cards/__init__.py
@@ -21,6 +21,11 @@ from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.car
     CardUnavailable,
     DelegatedCardResolver,
 )
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.cards.service import (
+    CardCommitFailed,
+    CardConflict,
+    DelegatedCardService,
+)
 from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.cards.store import (
     BundleStorageDelegatedCardStore,
     CardStorageError,
@@ -33,12 +38,15 @@ __all__ = [
     "BundleStorageDelegatedCardStore",
     "CardAuthority",
     "CardCacheEntry",
+    "CardCommitFailed",
+    "CardConflict",
     "CardCredentialHandles",
     "CardCurrentPointer",
     "CardRecordError",
     "CardStorageError",
     "CardUnavailable",
     "DelegatedCardResolver",
+    "DelegatedCardService",
     "DelegatedCardRuntimeCache",
     "DelegatedCardStore",
     "NamedServiceSelection",

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/cards/cache.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/cards/cache.py
@@ -1,0 +1,313 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Elena Viter
+
+"""Redis live projection of committed card authority.
+
+One key per card holds exactly one of three states:
+
+    card       the latest committed non-secret authority projection
+    updating   a short fail-closed marker owned by one in-flight mutation
+    revoked    a short negative cache after a committed revocation
+
+The projection's TTL is the card's remaining authorization lifetime, so the
+live entry expires with the authority it describes. Markers carry their own
+short residency and never act as authority.
+
+Every install is a compare-and-transition: a delayed read-through may not
+displace a newer revision, an updating marker, or a revoked tombstone, and a
+mutation finalizer may replace only the marker carrying its own mutation id.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.cache_io import (
+    decode_cache_value,
+    encode_cache_value,
+)
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.cards.model import (
+    CardAuthority,
+    CardRecordError,
+)
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.cards.store import (
+    validated_access_id,
+    validated_subject_hash,
+)
+
+_LOGGER = logging.getLogger("connection_hub.delegated_cards.cache")
+
+CARD_CACHE_KIND_CARD = "card"
+CARD_CACHE_KIND_UPDATING = "updating"
+CARD_CACHE_KIND_REVOKED = "revoked"
+
+# Claim the card transition. Refused when another mutation owns the key, when a
+# revoked tombstone is present, or when the live revision is not the one the
+# caller read.
+_INSTALL_MARKER_LUA = """
+local existing = redis.call('GET', KEYS[1])
+if existing then
+  local ok, decoded = pcall(cjson.decode, existing)
+  if ok and type(decoded) == 'table' then
+    local kind = decoded['kind']
+    if kind ~= 'card' then
+      return 0
+    end
+    if tonumber(decoded['card_revision']) ~= tonumber(ARGV[2]) then
+      return 0
+    end
+  end
+end
+redis.call('SET', KEYS[1], ARGV[1], 'EX', ARGV[3])
+return 1
+"""
+
+# Finalize a mutation. Replaces only this mutation's own marker, or an absent
+# key left behind when that marker expired.
+_FINALIZE_LUA = """
+local existing = redis.call('GET', KEYS[1])
+if existing then
+  local ok, decoded = pcall(cjson.decode, existing)
+  if not ok or type(decoded) ~= 'table' then
+    return 0
+  end
+  if decoded['kind'] ~= 'updating' or decoded['mutation_id'] ~= ARGV[2] then
+    return 0
+  end
+end
+if ARGV[1] == '' then
+  redis.call('DEL', KEYS[1])
+else
+  redis.call('SET', KEYS[1], ARGV[1], 'EX', ARGV[3])
+end
+return 1
+"""
+
+# Read-through repair. Installs only over an absent key or a strictly older
+# ordinary projection.
+_RESTORE_LUA = """
+local existing = redis.call('GET', KEYS[1])
+if existing then
+  local ok, decoded = pcall(cjson.decode, existing)
+  if ok and type(decoded) == 'table' then
+    if decoded['kind'] ~= 'card' then
+      return 0
+    end
+    if tonumber(decoded['card_revision']) >= tonumber(ARGV[2]) then
+      return 0
+    end
+  end
+end
+redis.call('SET', KEYS[1], ARGV[1], 'EX', ARGV[3])
+return 1
+"""
+
+
+@dataclass(frozen=True)
+class CardCacheEntry:
+    kind: str
+    authority: CardAuthority | None = None
+    card_revision: int = 0
+    mutation_id: str = ""
+
+    @property
+    def is_card(self) -> bool:
+        return self.kind == CARD_CACHE_KIND_CARD
+
+    @property
+    def is_updating(self) -> bool:
+        return self.kind == CARD_CACHE_KIND_UPDATING
+
+    @property
+    def is_revoked(self) -> bool:
+        return self.kind == CARD_CACHE_KIND_REVOKED
+
+
+class DelegatedCardRuntimeCache:
+    """Async Redis projection of committed delegated-card authority."""
+
+    def __init__(self, redis: Any, *, tenant: str, project: str) -> None:
+        self._redis = redis
+        self._tenant = str(tenant or "").strip()
+        self._project = str(project or "").strip()
+
+    def card_key(self, access_id: str) -> str:
+        return (
+            f"{self._tenant}:{self._project}:kdcube:delegated-access:"
+            f"card:{validated_access_id(access_id)}"
+        )
+
+    async def read(self, access_id: str) -> CardCacheEntry | None:
+        payload = decode_cache_value(await self._redis.get(self.card_key(access_id)))
+        if payload is None:
+            return None
+        kind = str(payload.get("kind") or "").strip()
+        if kind == CARD_CACHE_KIND_UPDATING:
+            return CardCacheEntry(
+                kind=kind,
+                card_revision=int(payload.get("card_revision") or 0),
+                mutation_id=str(payload.get("mutation_id") or ""),
+            )
+        if kind == CARD_CACHE_KIND_REVOKED:
+            return CardCacheEntry(
+                kind=kind, card_revision=int(payload.get("card_revision") or 0)
+            )
+        if kind != CARD_CACHE_KIND_CARD:
+            _LOGGER.warning(
+                "[connection-hub.delegated-cards] discarding cached entry of unknown kind %r", kind
+            )
+            return None
+        try:
+            authority = CardAuthority.from_mapping(payload.get("authority"))
+        except CardRecordError as exc:
+            _LOGGER.warning(
+                "[connection-hub.delegated-cards] discarding cached card %s: %s",
+                access_id,
+                exc.reason,
+            )
+            return None
+        return CardCacheEntry(
+            kind=kind, authority=authority, card_revision=authority.card_revision
+        )
+
+    async def claim_transition(
+        self,
+        access_id: str,
+        *,
+        mutation_id: str,
+        expected_revision: int,
+        ttl_seconds: int,
+    ) -> bool:
+        """Install the updating marker so requests fail closed during a mutation."""
+        marker = {
+            "kind": CARD_CACHE_KIND_UPDATING,
+            "mutation_id": str(mutation_id),
+            "card_revision": int(expected_revision),
+        }
+        return await self._eval_bool(
+            _INSTALL_MARKER_LUA,
+            access_id,
+            encode_cache_value(marker),
+            str(int(expected_revision)),
+            str(max(1, int(ttl_seconds))),
+        )
+
+    async def commit_projection(
+        self,
+        authority: CardAuthority,
+        *,
+        mutation_id: str,
+        ttl_seconds: int,
+    ) -> bool:
+        """Replace this mutation's marker with the committed live projection."""
+        if ttl_seconds <= 0:
+            return await self.finalize_removal(
+                authority.access_id, mutation_id=mutation_id
+            )
+        payload = {
+            "kind": CARD_CACHE_KIND_CARD,
+            "card_revision": authority.card_revision,
+            "authority": authority.to_dict(),
+        }
+        return await self._eval_bool(
+            _FINALIZE_LUA,
+            authority.access_id,
+            encode_cache_value(payload),
+            str(mutation_id),
+            str(max(1, int(ttl_seconds))),
+        )
+
+    async def commit_tombstone(
+        self,
+        access_id: str,
+        *,
+        card_revision: int,
+        mutation_id: str,
+        ttl_seconds: int,
+    ) -> bool:
+        """Replace this mutation's marker with the short revoked tombstone."""
+        payload = {
+            "kind": CARD_CACHE_KIND_REVOKED,
+            "card_revision": int(card_revision),
+        }
+        return await self._eval_bool(
+            _FINALIZE_LUA,
+            access_id,
+            encode_cache_value(payload),
+            str(mutation_id),
+            str(max(1, int(ttl_seconds))),
+        )
+
+    async def finalize_removal(self, access_id: str, *, mutation_id: str) -> bool:
+        """Drop this mutation's marker without leaving a live projection."""
+        return await self._eval_bool(_FINALIZE_LUA, access_id, "", str(mutation_id), "1")
+
+    async def restore_projection(
+        self, authority: CardAuthority, *, ttl_seconds: int
+    ) -> bool:
+        """Repopulate after a miss. Never displaces a marker, tombstone, or
+        newer revision, so a delayed restoration cannot revive old authority."""
+        if ttl_seconds <= 0:
+            return False
+        payload = {
+            "kind": CARD_CACHE_KIND_CARD,
+            "card_revision": authority.card_revision,
+            "authority": authority.to_dict(),
+        }
+        return await self._eval_bool(
+            _RESTORE_LUA,
+            authority.access_id,
+            encode_cache_value(payload),
+            str(int(authority.card_revision)),
+            str(max(1, int(ttl_seconds))),
+        )
+
+    # -- per-grantor discovery index ------------------------------------------
+    #
+    # A sorted set scored by each card's own expires_at. There is no whole-key
+    # TTL, so one card's lifetime cannot shorten another card's discoverability.
+    # The index is never authority: every listed member is still resolved
+    # through the card cache/store.
+
+    def grantor_index_key(self, subject_hash: str) -> str:
+        return (
+            f"{self._tenant}:{self._project}:kdcube:delegated-access:"
+            f"cards-by-grantor:{validated_subject_hash(subject_hash)}"
+        )
+
+    async def index_add(self, *, subject_hash: str, access_id: str, expires_at: int) -> None:
+        await self._redis.zadd(
+            self.grantor_index_key(subject_hash),
+            {validated_access_id(access_id): float(int(expires_at))},
+        )
+
+    async def index_remove(self, *, subject_hash: str, access_id: str) -> None:
+        await self._redis.zrem(
+            self.grantor_index_key(subject_hash), validated_access_id(access_id)
+        )
+
+    async def index_members(self, *, subject_hash: str, now: int) -> list[str]:
+        """Unexpired member ids, pruning those whose own expiry has passed."""
+        key = self.grantor_index_key(subject_hash)
+        await self._redis.zremrangebyscore(key, "-inf", int(now))
+        raw = await self._redis.zrangebyscore(key, f"({int(now)}", "+inf")
+        members: list[str] = []
+        for item in raw or []:
+            value = item.decode("utf-8") if isinstance(item, (bytes, bytearray)) else str(item)
+            members.append(value)
+        return members
+
+    async def _eval_bool(self, script: str, access_id: str, *args: str) -> bool:
+        result = await self._redis.eval(script, 1, self.card_key(access_id), *args)
+        return bool(int(result or 0))
+
+
+__all__ = [
+    "CARD_CACHE_KIND_CARD",
+    "CARD_CACHE_KIND_REVOKED",
+    "CARD_CACHE_KIND_UPDATING",
+    "CardCacheEntry",
+    "DelegatedCardRuntimeCache",
+]

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/cards/cache.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/cards/cache.py
@@ -105,6 +105,20 @@ return 1
 """
 
 
+class CardCacheUnusable(RuntimeError):
+    """A cached card value exists but cannot be trusted.
+
+    Distinct from absence: absence is a definitive answer about authority,
+    while unusable data means the answer could not be determined. Callers with
+    a durable source repair it; callers without one report unavailability
+    rather than denying as if the card were gone.
+    """
+
+    def __init__(self, reason: str) -> None:
+        super().__init__(reason)
+        self.reason = reason
+
+
 @dataclass(frozen=True)
 class CardCacheEntry:
     kind: str
@@ -140,9 +154,17 @@ class DelegatedCardRuntimeCache:
         )
 
     async def read(self, access_id: str) -> CardCacheEntry | None:
-        payload = decode_cache_value(await self._redis.get(self.card_key(access_id)))
-        if payload is None:
+        """The cached state, or ``None`` when the key is absent.
+
+        Raises ``CardCacheUnusable`` when a value is present but cannot be
+        parsed, so a damaged projection is never mistaken for a revoked card.
+        """
+        raw = await self._redis.get(self.card_key(access_id))
+        if raw is None:
             return None
+        payload = decode_cache_value(raw)
+        if payload is None:
+            raise CardCacheUnusable("cached_card_not_decodable")
         kind = str(payload.get("kind") or "").strip()
         if kind == CARD_CACHE_KIND_UPDATING:
             return CardCacheEntry(
@@ -155,19 +177,15 @@ class DelegatedCardRuntimeCache:
                 kind=kind, card_revision=int(payload.get("card_revision") or 0)
             )
         if kind != CARD_CACHE_KIND_CARD:
-            _LOGGER.warning(
-                "[connection-hub.delegated-cards] discarding cached entry of unknown kind %r", kind
-            )
-            return None
+            raise CardCacheUnusable("cached_card_kind_unknown")
         try:
             authority = CardAuthority.from_mapping(payload.get("authority"))
         except CardRecordError as exc:
             _LOGGER.warning(
-                "[connection-hub.delegated-cards] discarding cached card %s: %s",
-                access_id,
-                exc.reason,
+                "[connection-hub.delegated-cards] unusable cached card %s: %s",
+                access_id, exc.reason,
             )
-            return None
+            raise CardCacheUnusable("cached_card_invalid") from exc
         return CardCacheEntry(
             kind=kind, authority=authority, card_revision=authority.card_revision
         )
@@ -309,5 +327,6 @@ __all__ = [
     "CARD_CACHE_KIND_REVOKED",
     "CARD_CACHE_KIND_UPDATING",
     "CardCacheEntry",
+    "CardCacheUnusable",
     "DelegatedCardRuntimeCache",
 ]

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/cards/cache.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/cards/cache.py
@@ -52,7 +52,10 @@ if existing then
   local ok, decoded = pcall(cjson.decode, existing)
   if ok and type(decoded) == 'table' then
     local kind = decoded['kind']
-    if kind ~= 'card' then
+    -- A revoked tombstone is displaced only by a writer whose expected
+    -- revision IS the revoked one: a re-consent commits the next revision of
+    -- the same id, while a stale writer still carries an older number.
+    if kind ~= 'card' and kind ~= 'revoked' then
       return 0
     end
     if tonumber(decoded['card_revision']) ~= tonumber(ARGV[2]) then

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/cards/handles.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/cards/handles.py
@@ -1,0 +1,66 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Elena Viter
+
+"""Live credential handles for a delegated card.
+
+These are the reusable secrets a card's lifecycle needs to revoke or replay:
+an agent's server-side bearer, an OAuth refresh/access handle, and the live
+session id. They are bounded by the card's authorization lifetime and are never
+part of durable card history, so a durable restore recovers authority only.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.cache_io import (
+    decode_cache_value,
+    encode_cache_value,
+)
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.cards.model import (
+    CardCredentialHandles,
+)
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.cards.store import (
+    validated_access_id,
+)
+
+
+class DelegatedCardHandleStore:
+    """TTL-managed Redis storage for one card's live credential handles."""
+
+    def __init__(self, redis: Any, *, tenant: str, project: str) -> None:
+        self._redis = redis
+        self._tenant = str(tenant or "").strip()
+        self._project = str(project or "").strip()
+
+    def handle_key(self, access_id: str) -> str:
+        return (
+            f"{self._tenant}:{self._project}:kdcube:delegated-access:"
+            f"card-handles:{validated_access_id(access_id)}"
+        )
+
+    async def read(self, access_id: str) -> CardCredentialHandles:
+        payload = decode_cache_value(await self._redis.get(self.handle_key(access_id)))
+        if payload is None:
+            return CardCredentialHandles(access_id=str(access_id))
+        return CardCredentialHandles.from_mapping(payload)
+
+    async def write(self, handles: CardCredentialHandles, *, ttl_seconds: int) -> None:
+        """Store the handles for the card's remaining lifetime.
+
+        Empty handles are removed rather than stored, so a card that holds no
+        reusable secret leaves no key behind.
+        """
+        key = self.handle_key(handles.access_id)
+        if handles.empty or ttl_seconds <= 0:
+            await self._redis.delete(key)
+            return
+        await self._redis.set(
+            key, encode_cache_value(handles.to_dict()), ex=max(1, int(ttl_seconds))
+        )
+
+    async def remove(self, access_id: str) -> None:
+        await self._redis.delete(self.handle_key(access_id))
+
+
+__all__ = ["DelegatedCardHandleStore"]

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/cards/migration.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/cards/migration.py
@@ -1,0 +1,101 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Elena Viter
+
+"""Pre-encoding records whose stored evidence cannot be read without guessing.
+
+A record written before the explicit ``"*" | {} | exact map`` encoding is
+migrated lazily: its selection is derived from the tree it materialized. Where
+that derivation would silently change authority, the server reports
+``migration_confirmation_required`` and leaves the record alone.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Iterable, Mapping, Sequence
+
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.named_service_policy import (
+    configured_named_service_operations,
+)
+
+MIGRATION_CONFIRMATION_REQUIRED = "migration_confirmation_required"
+
+REASON_UNREADABLE_BOUNDARY = "materialized_boundary_names_no_operation"
+REASON_EMPTY_AGAINST_CATALOG = "derived_set_is_empty_against_the_active_catalog"
+REASON_RESOURCE_ATTRIBUTION = "boundary_cannot_be_attributed_per_resource"
+
+
+def pre_migration_ambiguity(
+    card: Any,
+    *,
+    named_service_resources: Sequence[str] = (),
+    offered: Mapping[str, Iterable[str]] | None = None,
+) -> dict[str, Any] | None:
+    """``None`` when the record's prior set can be derived without guessing.
+
+    ``named_service_resources`` are the card's resources that configure named
+    services; ``offered`` is the active catalog's ``namespace -> operations``
+    for them.
+    """
+    selection = getattr(card, "named_service_operations", None)
+    if selection is None or not getattr(selection, "is_unknown", False):
+        return None
+    tree = dict(getattr(card, "named_services", None) or {})
+    if not tree:
+        # Nothing was materialized: the prior set is empty, unambiguously.
+        return None
+
+    derived = configured_named_service_operations(tree)
+    if not any(derived.values()):
+        return _state(
+            card,
+            reason=REASON_UNREADABLE_BOUNDARY,
+            evidence={"namespaces": sorted(derived)},
+        )
+    if len(list(named_service_resources)) > 1:
+        return _state(
+            card,
+            reason=REASON_RESOURCE_ATTRIBUTION,
+            evidence={"resources": sorted(named_service_resources)},
+        )
+    if offered is not None:
+        current = {
+            str(namespace): {str(op) for op in operations}
+            for namespace, operations in offered.items()
+        }
+        surviving = {
+            namespace: sorted(operations & current.get(namespace, set()))
+            for namespace, operations in derived.items()
+        }
+        if not any(surviving.values()):
+            return _state(
+                card,
+                reason=REASON_EMPTY_AGAINST_CATALOG,
+                evidence={
+                    "derived": {ns: sorted(ops) for ns, ops in derived.items() if ops},
+                    "offered": {ns: sorted(ops) for ns, ops in current.items() if ops},
+                },
+            )
+    return None
+
+
+def _state(card: Any, *, reason: str, evidence: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "state": MIGRATION_CONFIRMATION_REQUIRED,
+        "reason": reason,
+        "access_id": str(getattr(card, "access_id", "") or ""),
+        "card_revision": int(getattr(card, "card_revision", 0) or 0),
+        "evidence": dict(evidence),
+        "recovery": {
+            "action": "submit_an_explicit_named_service_selection",
+            "retry_same_request": False,
+        },
+    }
+
+
+__all__ = [
+    "MIGRATION_CONFIRMATION_REQUIRED",
+    "REASON_EMPTY_AGAINST_CATALOG",
+    "REASON_RESOURCE_ATTRIBUTION",
+    "REASON_UNREADABLE_BOUNDARY",
+    "pre_migration_ambiguity",
+]

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/cards/model.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/cards/model.py
@@ -1,0 +1,396 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Elena Viter
+
+"""Delegated-card authority, credential handles, and durable revision identity.
+
+Authority is reconstructable and non-secret: it is what a durable revision
+stores and what a Redis projection restores. Credential handles are live,
+bounded, and never part of durable history — restoring them from an immutable
+revision would defeat credential expiry.
+"""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Mapping
+
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.catalog.models import (
+    utc_stamp,
+    utc_timestamp,
+)
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.named_service_policy import (
+    as_string_list,
+    clean_text,
+)
+
+CARD_AUTHORITY_SCHEMA = "connection_hub.delegated_card_authority.v1"
+CARD_POINTER_SCHEMA = "connection_hub.delegated_card_current.v1"
+
+CARD_STATE_ACTIVE = "active"
+CARD_STATE_REVOKED = "revoked"
+
+NAMED_SERVICE_OPERATIONS_ALL = "*"
+
+SELECTION_ALL = "all"
+SELECTION_NONE = "none"
+SELECTION_EXACT = "exact"
+SELECTION_UNKNOWN = "unknown"
+
+_REVISION_HASH_CHARS = 12
+
+
+class CardRecordError(ValueError):
+    """A card payload could not be trusted as authorization state."""
+
+    def __init__(self, reason: str) -> None:
+        super().__init__(reason)
+        self.reason = reason
+
+
+def _normalized_namespace(value: Any) -> str:
+    return clean_text(value).lower().rstrip(":")
+
+
+@dataclass(frozen=True)
+class NamedServiceSelection:
+    """The card's named-service authority as one of four unambiguous states.
+
+    ``unknown`` is a legacy-record condition only. Newly written cards always
+    carry ``all``, ``none``, or ``exact``, so an explicitly empty policy can
+    never be mistaken for an absent one.
+    """
+
+    kind: str
+    operations: Mapping[str, Mapping[str, tuple[str, ...]]] = field(default_factory=dict)
+
+    @classmethod
+    def all(cls) -> "NamedServiceSelection":
+        return cls(kind=SELECTION_ALL)
+
+    @classmethod
+    def none(cls) -> "NamedServiceSelection":
+        return cls(kind=SELECTION_NONE)
+
+    @classmethod
+    def unknown(cls) -> "NamedServiceSelection":
+        return cls(kind=SELECTION_UNKNOWN)
+
+    @classmethod
+    def exact(cls, operations: Mapping[str, Any]) -> "NamedServiceSelection":
+        """An exact resource/namespace/operation map. An empty map is ``none``."""
+        normalized: dict[str, dict[str, tuple[str, ...]]] = {}
+        for resource, namespaces in dict(operations or {}).items():
+            resource_value = clean_text(resource)
+            if not resource_value:
+                continue
+            if not isinstance(namespaces, Mapping):
+                raise CardRecordError("named_service_operations_resource_invalid")
+            per_namespace: dict[str, tuple[str, ...]] = {}
+            for namespace, values in namespaces.items():
+                namespace_value = _normalized_namespace(namespace)
+                if not namespace_value:
+                    continue
+                per_namespace[namespace_value] = tuple(as_string_list(values))
+            normalized[resource_value] = per_namespace
+        if not normalized:
+            return cls.none()
+        return cls(kind=SELECTION_EXACT, operations=normalized)
+
+    @classmethod
+    def from_stored(cls, value: Any, *, present: bool) -> "NamedServiceSelection":
+        """Parse the stored field.
+
+        ``present`` is the raw field's presence in the payload, supplied by the
+        caller. It is the only thing that separates an explicitly empty policy
+        from a legacy record, so it is never inferred from the value itself.
+        """
+        if not present or value is None:
+            return cls.unknown()
+        if isinstance(value, str):
+            if clean_text(value) != NAMED_SERVICE_OPERATIONS_ALL:
+                raise CardRecordError("named_service_operations_invalid")
+            return cls.all()
+        if isinstance(value, Mapping):
+            if not value:
+                return cls.none()
+            return cls.exact(value)
+        raise CardRecordError("named_service_operations_invalid")
+
+    def to_stored(self) -> str | dict[str, dict[str, list[str]]] | None:
+        """The durable representation. ``unknown`` writes nothing."""
+        if self.kind == SELECTION_ALL:
+            return NAMED_SERVICE_OPERATIONS_ALL
+        if self.kind == SELECTION_NONE:
+            return {}
+        if self.kind == SELECTION_EXACT:
+            return {
+                resource: {namespace: list(values) for namespace, values in namespaces.items()}
+                for resource, namespaces in self.operations.items()
+            }
+        return None
+
+    @property
+    def is_all(self) -> bool:
+        return self.kind == SELECTION_ALL
+
+    @property
+    def is_none(self) -> bool:
+        return self.kind == SELECTION_NONE
+
+    @property
+    def is_exact(self) -> bool:
+        return self.kind == SELECTION_EXACT
+
+    @property
+    def is_unknown(self) -> bool:
+        return self.kind == SELECTION_UNKNOWN
+
+
+@dataclass(frozen=True)
+class CardAuthority:
+    """One card's complete non-secret authorization decision."""
+
+    access_id: str
+    client_id: str
+    grantor_subject: str
+    delegate_subject: str
+    source: str
+    label: str = ""
+    card_revision: int = 0
+    catalog_version: str = ""
+    state: str = CARD_STATE_ACTIVE
+    operations: tuple[str, ...] = ()
+    resource_grants: Mapping[str, tuple[str, ...]] = field(default_factory=dict)
+    named_service_operations: NamedServiceSelection = field(
+        default_factory=NamedServiceSelection.unknown
+    )
+    named_services: Mapping[str, Any] = field(default_factory=dict)
+    account_scope: Mapping[str, Mapping[str, tuple[str, ...]]] = field(default_factory=dict)
+    identity_scope: str = ""
+    created_at: int = 0
+    expires_at: int = 0
+    last_issued_at: int = 0
+    last_four: str = ""
+
+    @classmethod
+    def from_mapping(cls, value: Any) -> "CardAuthority":
+        if not isinstance(value, Mapping):
+            raise CardRecordError("record_not_object")
+        if str(value.get("schema") or "").strip() != CARD_AUTHORITY_SCHEMA:
+            raise CardRecordError("schema_mismatch")
+        resource_grants = value.get("resource_grants")
+        if not isinstance(resource_grants, Mapping):
+            raise CardRecordError("resource_grants_invalid")
+        operations = value.get("operations")
+        if not isinstance(operations, list):
+            raise CardRecordError("operations_invalid")
+        for name in ("named_services", "account_scope"):
+            if not isinstance(value.get(name, {}), Mapping):
+                raise CardRecordError(f"{name}_invalid")
+        state = clean_text(value.get("state")) or CARD_STATE_ACTIVE
+        if state not in (CARD_STATE_ACTIVE, CARD_STATE_REVOKED):
+            raise CardRecordError("state_invalid")
+        return cls(
+            access_id=clean_text(value.get("access_id")),
+            client_id=clean_text(value.get("client_id")),
+            grantor_subject=clean_text(value.get("grantor_subject")),
+            delegate_subject=clean_text(value.get("delegate_subject")),
+            source=clean_text(value.get("source")),
+            label=clean_text(value.get("label")),
+            card_revision=int(value.get("card_revision") or 0),
+            catalog_version=clean_text(value.get("catalog_version")),
+            state=state,
+            operations=tuple(as_string_list(operations)),
+            resource_grants={
+                clean_text(resource): tuple(as_string_list(grants))
+                for resource, grants in resource_grants.items()
+                if clean_text(resource)
+            },
+            named_service_operations=NamedServiceSelection.from_stored(
+                value.get("named_service_operations"),
+                present="named_service_operations" in value,
+            ),
+            named_services=copy.deepcopy(dict(value.get("named_services") or {})),
+            account_scope={
+                clean_text(provider): {
+                    clean_text(account_id): tuple(as_string_list(claims))
+                    for account_id, claims in dict(accounts or {}).items()
+                    if clean_text(account_id)
+                }
+                for provider, accounts in dict(value.get("account_scope") or {}).items()
+                if clean_text(provider)
+            },
+            identity_scope=clean_text(value.get("identity_scope")),
+            created_at=int(value.get("created_at") or 0),
+            expires_at=int(value.get("expires_at") or 0),
+            last_issued_at=int(value.get("last_issued_at") or 0),
+            last_four=clean_text(value.get("last_four")),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "schema": CARD_AUTHORITY_SCHEMA,
+            "access_id": self.access_id,
+            "client_id": self.client_id,
+            "grantor_subject": self.grantor_subject,
+            "delegate_subject": self.delegate_subject,
+            "source": self.source,
+            "label": self.label,
+            "card_revision": self.card_revision,
+            "catalog_version": self.catalog_version,
+            "state": self.state,
+            "operations": list(self.operations),
+            "resource_grants": {
+                resource: list(grants) for resource, grants in self.resource_grants.items()
+            },
+            "named_services": copy.deepcopy(dict(self.named_services or {})),
+            "account_scope": {
+                provider: {account_id: list(claims) for account_id, claims in accounts.items()}
+                for provider, accounts in self.account_scope.items()
+            },
+            "identity_scope": self.identity_scope,
+            "created_at": self.created_at,
+            "expires_at": self.expires_at,
+            "last_issued_at": self.last_issued_at,
+            "last_four": self.last_four,
+        }
+        stored_selection = self.named_service_operations.to_stored()
+        if stored_selection is not None:
+            payload["named_service_operations"] = stored_selection
+        return payload
+
+    def content_hash(self) -> str:
+        canonical = json.dumps(
+            self.to_dict(),
+            ensure_ascii=True,
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        ).encode("utf-8")
+        return hashlib.sha256(canonical).hexdigest()
+
+
+@dataclass(frozen=True)
+class CardCredentialHandles:
+    """Live, bounded credential material kept out of durable card history."""
+
+    access_id: str
+    access_token: str = ""
+    refresh_token: str = ""
+    session_id: str = ""
+
+    @classmethod
+    def from_mapping(cls, value: Mapping[str, Any]) -> "CardCredentialHandles":
+        return cls(
+            access_id=clean_text(value.get("access_id")),
+            access_token=clean_text(value.get("access_token")),
+            refresh_token=clean_text(value.get("refresh_token")),
+            session_id=clean_text(value.get("session_id")),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "access_id": self.access_id,
+            "access_token": self.access_token,
+            "refresh_token": self.refresh_token,
+            "session_id": self.session_id,
+        }
+
+    @property
+    def empty(self) -> bool:
+        return not (self.access_token or self.refresh_token or self.session_id)
+
+
+def card_revision_name(*, card_revision: int, content_hash: str, updated_at: datetime) -> str:
+    """Timestamp-first, ordered, verifiable immutable revision object name."""
+    return (
+        f"card_revision_{utc_stamp(updated_at)}"
+        f"_{max(0, int(card_revision)):08d}"
+        f"_{content_hash[:_REVISION_HASH_CHARS]}.json"
+    )
+
+
+@dataclass(frozen=True)
+class CardCurrentPointer:
+    """``current.json``: what is needed to read and trust the latest revision."""
+
+    access_id: str
+    card_revision: int
+    revision_name: str
+    content_hash: str
+    updated_at: str
+    expires_at: int
+    state: str
+
+    @classmethod
+    def for_revision(
+        cls,
+        authority: CardAuthority,
+        *,
+        revision_name: str,
+        content_hash: str,
+        updated_at: datetime,
+    ) -> "CardCurrentPointer":
+        return cls(
+            access_id=authority.access_id,
+            card_revision=authority.card_revision,
+            revision_name=revision_name,
+            content_hash=content_hash,
+            updated_at=utc_timestamp(updated_at),
+            expires_at=authority.expires_at,
+            state=authority.state,
+        )
+
+    @classmethod
+    def from_mapping(cls, value: Any) -> "CardCurrentPointer":
+        if not isinstance(value, Mapping):
+            raise CardRecordError("pointer_not_object")
+        if str(value.get("schema") or "").strip() != CARD_POINTER_SCHEMA:
+            raise CardRecordError("pointer_schema_mismatch")
+        revision_name = clean_text(value.get("revision_name"))
+        if not revision_name:
+            raise CardRecordError("pointer_revision_name_missing")
+        return cls(
+            access_id=clean_text(value.get("access_id")),
+            card_revision=int(value.get("card_revision") or 0),
+            revision_name=revision_name,
+            content_hash=clean_text(value.get("content_hash")).lower(),
+            updated_at=clean_text(value.get("updated_at")),
+            expires_at=int(value.get("expires_at") or 0),
+            state=clean_text(value.get("state")) or CARD_STATE_ACTIVE,
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema": CARD_POINTER_SCHEMA,
+            "access_id": self.access_id,
+            "card_revision": self.card_revision,
+            "revision_name": self.revision_name,
+            "content_hash": self.content_hash,
+            "updated_at": self.updated_at,
+            "expires_at": self.expires_at,
+            "state": self.state,
+        }
+
+
+__all__ = [
+    "CARD_AUTHORITY_SCHEMA",
+    "CARD_POINTER_SCHEMA",
+    "CARD_STATE_ACTIVE",
+    "CARD_STATE_REVOKED",
+    "NAMED_SERVICE_OPERATIONS_ALL",
+    "SELECTION_ALL",
+    "SELECTION_EXACT",
+    "SELECTION_NONE",
+    "SELECTION_UNKNOWN",
+    "CardAuthority",
+    "CardCredentialHandles",
+    "CardCurrentPointer",
+    "CardRecordError",
+    "NamedServiceSelection",
+    "card_revision_name",
+]

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/cards/model.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/cards/model.py
@@ -329,6 +329,13 @@ class CardCredentialHandles:
         return not (self.access_token or self.refresh_token or self.session_id)
 
 
+def authority_is_usable(authority: "CardAuthority", moment: int) -> bool:
+    """Whether this authority may still be served at ``moment``."""
+    if authority.state != CARD_STATE_ACTIVE:
+        return False
+    return authority.expires_at > moment
+
+
 def card_revision_name(*, card_revision: int, content_hash: str, updated_at: datetime) -> str:
     """Timestamp-first, ordered, verifiable immutable revision object name."""
     return (
@@ -416,5 +423,6 @@ __all__ = [
     "CardCurrentPointer",
     "CardRecordError",
     "NamedServiceSelection",
+    "authority_is_usable",
     "card_revision_name",
 ]

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/cards/model.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/cards/model.py
@@ -5,8 +5,7 @@
 
 Authority is reconstructable and non-secret: it is what a durable revision
 stores and what a Redis projection restores. Credential handles are live,
-bounded, and never part of durable history — restoring them from an immutable
-revision would defeat credential expiry.
+bounded, and never part of durable history.
 """
 
 from __future__ import annotations
@@ -57,11 +56,10 @@ def _normalized_namespace(value: Any) -> str:
 
 @dataclass(frozen=True)
 class NamedServiceSelection:
-    """The card's named-service authority as one of four unambiguous states.
+    """The card's named-service authority as one of four states.
 
-    ``unknown`` is a legacy-record condition only. Newly written cards always
-    carry ``all``, ``none``, or ``exact``, so an explicitly empty policy can
-    never be mistaken for an absent one.
+    ``unknown`` is a legacy-record condition only; newly written cards carry
+    ``all``, ``none``, or ``exact``.
     """
 
     kind: str
@@ -104,9 +102,8 @@ class NamedServiceSelection:
     def from_stored(cls, value: Any, *, present: bool) -> "NamedServiceSelection":
         """Parse the stored field.
 
-        ``present`` is the raw field's presence in the payload, supplied by the
-        caller. It is the only thing that separates an explicitly empty policy
-        from a legacy record, so it is never inferred from the value itself.
+        ``present`` is the raw field's presence in the payload; it separates an
+        explicitly empty policy from a legacy record.
         """
         if not present or value is None:
             return cls.unknown()
@@ -132,6 +129,33 @@ class NamedServiceSelection:
                 for resource, namespaces in self.operations.items()
             }
         return None
+
+    def union(self, other: "NamedServiceSelection") -> "NamedServiceSelection":
+        """Widest of the two selections.
+
+        A full or legacy-unknown side absorbs the other; two exact selections
+        merge per resource and namespace.
+        """
+        if self.is_all or self.is_unknown:
+            return self
+        if other.is_all or other.is_unknown:
+            return other
+        if self.is_none:
+            return other
+        if other.is_none:
+            return self
+        merged: dict[str, dict[str, list[str]]] = {
+            resource: {namespace: list(values) for namespace, values in namespaces.items()}
+            for resource, namespaces in self.operations.items()
+        }
+        for resource, namespaces in other.operations.items():
+            target = merged.setdefault(resource, {})
+            for namespace, values in namespaces.items():
+                held = target.setdefault(namespace, [])
+                for value in values:
+                    if value not in held:
+                        held.append(value)
+        return NamedServiceSelection.exact(merged)
 
     @property
     def is_all(self) -> bool:

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/cards/persistence.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/cards/persistence.py
@@ -8,6 +8,9 @@ policy code receives this contract instead of building the pieces itself.
 
     load          committed authority and its live handles, or None when the
                   card is absent, expired, or revoked
+    current_revision
+                  the committed revision whatever its state, 0 with no durable
+                  history — the expected_revision a write must pass
     persist       commits the next revision; a mismatched expected_revision
                   raises CardConflict
     forget        revokes the card and drops its handles
@@ -48,6 +51,8 @@ LoadedCard = tuple[CardAuthority, CardCredentialHandles]
 
 class CardPersistence(Protocol):
     async def load(self, access_id: str, *, subject_hash: str) -> LoadedCard | None: ...
+
+    async def current_revision(self, access_id: str, *, subject_hash: str) -> int: ...
 
     async def persist(
         self,
@@ -94,6 +99,11 @@ class DurableCardPersistence:
         if subject_hash_for(authority.grantor_subject) != str(subject_hash):
             return None
         return authority, await self._handles.read(access_id)
+
+    async def current_revision(self, access_id: str, *, subject_hash: str) -> int:
+        return await self._cards.current_revision(
+            subject_hash=subject_hash, access_id=access_id
+        )
 
     async def persist(
         self,

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/cards/persistence.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/cards/persistence.py
@@ -1,0 +1,133 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Elena Viter
+
+"""The card persistence port.
+
+Composing durable card storage belongs to whoever owns the storage root, so
+policy code receives this contract instead of building the pieces itself.
+
+    load          committed authority and its live handles, or None when the
+                  card is absent, expired, or revoked
+    persist       commits the next revision; a mismatched expected_revision
+                  raises CardConflict
+    forget        revokes the card and drops its handles
+    list_active   active, unexpired cards for one grantor, newest first
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any, Protocol
+
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.cache_settings import (
+    DelegatedCacheSettings,
+)
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.cards.cache import (
+    DelegatedCardRuntimeCache,
+)
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.cards.handles import (
+    DelegatedCardHandleStore,
+)
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.cards.model import (
+    CardAuthority,
+    CardCredentialHandles,
+)
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.cards.resolver import (
+    DelegatedCardResolver,
+)
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.cards.service import (
+    CardConflict,
+    DelegatedCardService,
+)
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.cards.store import (
+    subject_hash_for,
+)
+
+LoadedCard = tuple[CardAuthority, CardCredentialHandles]
+
+
+class CardPersistence(Protocol):
+    async def load(self, access_id: str, *, subject_hash: str) -> LoadedCard | None: ...
+
+    async def persist(
+        self,
+        authority: CardAuthority,
+        handles: CardCredentialHandles,
+        *,
+        subject_hash: str,
+        expected_revision: int,
+    ) -> None: ...
+
+    async def forget(self, authority: CardAuthority, *, subject_hash: str) -> None: ...
+
+    async def list_active(
+        self, *, subject_hash: str, now: int | None = None
+    ) -> list[CardAuthority]: ...
+
+
+class DurableCardPersistence:
+    """Immutable revisions in bundle storage, projected into Redis."""
+
+    def __init__(
+        self,
+        *,
+        redis: Any,
+        tenant: str,
+        project: str,
+        card_store: Any,
+        settings: DelegatedCacheSettings | None = None,
+    ) -> None:
+        resolved = settings or DelegatedCacheSettings()
+        cache = DelegatedCardRuntimeCache(redis, tenant=tenant, project=project)
+        self._cards = DelegatedCardService(store=card_store, cache=cache, settings=resolved)
+        self._resolver = DelegatedCardResolver(cache=cache, store=card_store, settings=resolved)
+        self._handles = DelegatedCardHandleStore(redis, tenant=tenant, project=project)
+
+    async def load(self, access_id: str, *, subject_hash: str) -> LoadedCard | None:
+        authority = await self._resolver.resolve(
+            subject_hash=subject_hash, access_id=access_id
+        )
+        if authority is None:
+            return None
+        # The projection is keyed by access_id alone, so ownership is confirmed
+        # against the card itself rather than the path it was read from.
+        if subject_hash_for(authority.grantor_subject) != str(subject_hash):
+            return None
+        return authority, await self._handles.read(access_id)
+
+    async def persist(
+        self,
+        authority: CardAuthority,
+        handles: CardCredentialHandles,
+        *,
+        subject_hash: str,
+        expected_revision: int,
+    ) -> None:
+        now = int(time.time())
+        await self._cards.commit(
+            authority,
+            subject_hash=subject_hash,
+            expected_revision=expected_revision,
+            now=now,
+        )
+        await self._handles.write(handles, ttl_seconds=max(0, authority.expires_at - now))
+
+    async def forget(self, authority: CardAuthority, *, subject_hash: str) -> None:
+        await self._cards.revoke(
+            subject_hash=subject_hash,
+            access_id=authority.access_id,
+            expected_revision=authority.card_revision,
+        )
+        await self._handles.remove(authority.access_id)
+
+    async def list_active(
+        self, *, subject_hash: str, now: int | None = None
+    ) -> list[CardAuthority]:
+        return await self._resolver.list_active(subject_hash=subject_hash, now=now)
+
+
+__all__ = [
+    "CardPersistence",
+    "DurableCardPersistence",
+    "LoadedCard",
+]

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/cards/resolver.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/cards/resolver.py
@@ -1,0 +1,197 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Elena Viter
+
+"""Redis-first card resolution with durable read-through.
+
+Outcomes are kept distinct:
+
+    authority       usable committed card authority
+    None            absent, revoked, or expired -> deny
+    unavailable     cannot be established -> structured 503
+
+Read-through restores only active, unexpired authority, and only the non-secret
+projection. Credential handles live in their own bounded stores and are never
+reconstructed from durable history.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any
+
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.cache_settings import (
+    DelegatedCacheSettings,
+)
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.cards.cache import (
+    DelegatedCardRuntimeCache,
+)
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.cards.model import (
+    CARD_STATE_ACTIVE,
+    CardAuthority,
+)
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.cards.store import (
+    BundleStorageDelegatedCardStore,
+    CardStorageError,
+)
+
+_LOGGER = logging.getLogger("connection_hub.delegated_cards.resolver")
+
+
+class CardUnavailable(RuntimeError):
+    """Card authority could not be established from cache or durable state."""
+
+    def __init__(self, reason: str) -> None:
+        super().__init__(reason)
+        self.reason = reason
+
+
+class DelegatedCardResolver:
+    def __init__(
+        self,
+        *,
+        cache: DelegatedCardRuntimeCache,
+        store: BundleStorageDelegatedCardStore,
+        settings: DelegatedCacheSettings | None = None,
+    ) -> None:
+        self._cache = cache
+        self._store = store
+        self._settings = settings or DelegatedCacheSettings()
+
+    async def resolve(
+        self, *, subject_hash: str, access_id: str, now: int | None = None
+    ) -> CardAuthority | None:
+        moment = int(now if now is not None else time.time())
+
+        try:
+            entry = await self._cache.read(access_id)
+        except CardStorageError:
+            raise
+        except Exception as exc:
+            raise CardUnavailable("cache_unavailable") from exc
+
+        if entry is not None:
+            if entry.is_updating:
+                # One mutation owns this transition; the prior revision must not
+                # be served after a newer one may already have committed.
+                raise CardUnavailable("card_updating")
+            if entry.is_revoked:
+                return None
+            authority = entry.authority
+            if authority is not None:
+                return authority if self._usable(authority, moment) else None
+
+        return await self._restore(subject_hash=subject_hash, access_id=access_id, moment=moment)
+
+    async def _restore(
+        self, *, subject_hash: str, access_id: str, moment: int
+    ) -> CardAuthority | None:
+        try:
+            current = await self._store.read_current_authority(
+                subject_hash=subject_hash, access_id=access_id
+            )
+        except Exception as exc:
+            raise CardUnavailable("durable_card_unreadable") from exc
+        if current is None:
+            return None
+
+        _, authority = current
+        if not self._usable(authority, moment):
+            # Expired or revoked durable state denies and is never re-cached.
+            return None
+
+        try:
+            await self._cache.restore_projection(
+                authority, ttl_seconds=max(0, authority.expires_at - moment)
+            )
+        except Exception:
+            _LOGGER.warning(
+                "[connection-hub.delegated-cards] projection restore failed card=%s",
+                access_id,
+                exc_info=True,
+            )
+        return authority
+
+    async def list_active(
+        self, *, subject_hash: str, now: int | None = None
+    ) -> list[CardAuthority]:
+        """Active, unexpired cards for one grantor.
+
+        The index only accelerates discovery: every member is resolved through
+        the card cache/store, and a member that no longer resolves is pruned.
+        Losing the index cannot hide a live durable card.
+        """
+        moment = int(now if now is not None else time.time())
+        try:
+            members = await self._cache.index_members(subject_hash=subject_hash, now=moment)
+        except Exception as exc:
+            raise CardUnavailable("cache_unavailable") from exc
+
+        if not members:
+            members = await self._rebuild_index(subject_hash=subject_hash, moment=moment)
+
+        found: list[CardAuthority] = []
+        for access_id in members:
+            try:
+                authority = await self.resolve(
+                    subject_hash=subject_hash, access_id=access_id, now=moment
+                )
+            except CardUnavailable:
+                raise
+            if authority is None:
+                await self._forget(subject_hash=subject_hash, access_id=access_id)
+                continue
+            found.append(authority)
+        found.sort(key=lambda item: item.created_at, reverse=True)
+        return found
+
+    async def _rebuild_index(self, *, subject_hash: str, moment: int) -> list[str]:
+        try:
+            card_ids = await self._store.list_card_ids(subject_hash=subject_hash)
+        except Exception as exc:
+            raise CardUnavailable("durable_card_unreadable") from exc
+
+        restored: list[str] = []
+        for access_id in card_ids:
+            try:
+                current = await self._store.read_current_authority(
+                    subject_hash=subject_hash, access_id=access_id
+                )
+            except Exception:
+                _LOGGER.warning(
+                    "[connection-hub.delegated-cards] index rebuild skipped card=%s",
+                    access_id,
+                    exc_info=True,
+                )
+                continue
+            if current is None:
+                continue
+            _, authority = current
+            if not self._usable(authority, moment):
+                continue
+            await self._cache.index_add(
+                subject_hash=subject_hash,
+                access_id=access_id,
+                expires_at=authority.expires_at,
+            )
+            restored.append(access_id)
+        return restored
+
+    async def _forget(self, *, subject_hash: str, access_id: str) -> None:
+        try:
+            await self._cache.index_remove(subject_hash=subject_hash, access_id=access_id)
+        except Exception:
+            _LOGGER.warning(
+                "[connection-hub.delegated-cards] index prune failed card=%s",
+                access_id,
+                exc_info=True,
+            )
+
+    @staticmethod
+    def _usable(authority: CardAuthority, moment: int) -> bool:
+        if authority.state != CARD_STATE_ACTIVE:
+            return False
+        return authority.expires_at > moment
+
+
+__all__ = ["CardUnavailable", "DelegatedCardResolver"]

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/cards/resolver.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/cards/resolver.py
@@ -24,11 +24,13 @@ from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.cac
     DelegatedCacheSettings,
 )
 from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.cards.cache import (
+    CardCacheEntry,
+    CardCacheUnusable,
     DelegatedCardRuntimeCache,
 )
 from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.cards.model import (
-    CARD_STATE_ACTIVE,
     CardAuthority,
+    authority_is_usable,
 )
 from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.cards.store import (
     BundleStorageDelegatedCardStore,
@@ -63,8 +65,16 @@ class DelegatedCardResolver:
     ) -> CardAuthority | None:
         moment = int(now if now is not None else time.time())
 
+        entry: CardCacheEntry | None = None
         try:
             entry = await self._cache.read(access_id)
+        except CardCacheUnusable:
+            # Unusable cache data is not authority: fall through to the durable
+            # revision, which also repairs the projection.
+            _LOGGER.warning(
+                "[connection-hub.delegated-cards] unusable projection card=%s; reading durable",
+                access_id,
+            )
         except CardStorageError:
             raise
         except Exception as exc:
@@ -79,7 +89,7 @@ class DelegatedCardResolver:
                 return None
             authority = entry.authority
             if authority is not None:
-                return authority if self._usable(authority, moment) else None
+                return authority if authority_is_usable(authority, moment) else None
 
         return await self._restore(subject_hash=subject_hash, access_id=access_id, moment=moment)
 
@@ -96,7 +106,7 @@ class DelegatedCardResolver:
             return None
 
         _, authority = current
-        if not self._usable(authority, moment):
+        if not authority_is_usable(authority, moment):
             # Expired or revoked durable state denies and is never re-cached.
             return None
 
@@ -167,7 +177,7 @@ class DelegatedCardResolver:
             if current is None:
                 continue
             _, authority = current
-            if not self._usable(authority, moment):
+            if not authority_is_usable(authority, moment):
                 continue
             await self._cache.index_add(
                 subject_hash=subject_hash,
@@ -187,11 +197,6 @@ class DelegatedCardResolver:
                 exc_info=True,
             )
 
-    @staticmethod
-    def _usable(authority: CardAuthority, moment: int) -> bool:
-        if authority.state != CARD_STATE_ACTIVE:
-            return False
-        return authority.expires_at > moment
 
 
 __all__ = ["CardUnavailable", "DelegatedCardResolver"]

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/cards/service.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/cards/service.py
@@ -190,6 +190,14 @@ class DelegatedCardService:
         except ObservedFileLockTimeout as exc:
             raise CardConflict("card_mutation_lock_timeout") from exc
 
+    async def current_revision(self, *, subject_hash: str, access_id: str) -> int:
+        """The committed revision whatever its state; 0 with no history. Same
+        read as the precondition below."""
+        current = await self._store.read_current_authority(
+            subject_hash=subject_hash, access_id=access_id
+        )
+        return int(current[1].card_revision) if current is not None else 0
+
     async def _assert_expected(
         self, *, subject_hash: str, access_id: str, expected_revision: int
     ) -> None:

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/cards/service.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/cards/service.py
@@ -1,0 +1,296 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Elena Viter
+
+"""Ordered card mutations over durable revisions and the Redis projection.
+
+Every mutation runs inside a per-card shared critical section. Two mechanisms
+serve two different populations:
+
+    critical section   mutual exclusion between writers, held for as long as
+                       the owning worker lives
+    updating marker    fails readers closed while the transition is in flight,
+                       so no request continues under superseded authority
+
+Inside the section the protocol is: read and validate the current durable
+revision, install the marker, write the immutable next revision, advance
+current.json, then replace the marker with the committed projection.
+"""
+
+from __future__ import annotations
+
+import logging
+import pathlib
+import time
+import uuid
+from datetime import datetime, timezone
+
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.cache_settings import (
+    DelegatedCacheSettings,
+)
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.cards.cache import (
+    DelegatedCardRuntimeCache,
+)
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.cards.model import (
+    CARD_STATE_ACTIVE,
+    CARD_STATE_REVOKED,
+    CardAuthority,
+    CardCurrentPointer,
+)
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.cards.store import (
+    BundleStorageDelegatedCardStore,
+)
+from kdcube_ai_app.storage.observed_file_locks import (
+    ObservedFileLockTimeout,
+    observed_file_lock_async,
+)
+
+_LOGGER = logging.getLogger("connection_hub.delegated_cards.service")
+
+CARD_LOCK_FILENAME = ".mutation.lock"
+# Bounds how long a caller waits for another mutation on the same card. The
+# lock itself is held for the owner's lifetime, so this only caps the wait.
+CARD_LOCK_WAIT_SECONDS = 30.0
+
+
+class CardConflict(RuntimeError):
+    """Another mutation owns this card, or its live revision moved."""
+
+    def __init__(self, reason: str, *, current_revision: int = 0) -> None:
+        super().__init__(reason)
+        self.reason = reason
+        self.current_revision = current_revision
+
+
+class CardCommitFailed(RuntimeError):
+    """The durable revision could not be committed; prior authority stands."""
+
+    def __init__(self, reason: str) -> None:
+        super().__init__(reason)
+        self.reason = reason
+
+
+class DelegatedCardService:
+    def __init__(
+        self,
+        *,
+        store: BundleStorageDelegatedCardStore,
+        cache: DelegatedCardRuntimeCache,
+        settings: DelegatedCacheSettings | None = None,
+    ) -> None:
+        self._store = store
+        self._cache = cache
+        self._settings = (settings or DelegatedCacheSettings()).cards
+
+    def _lock_path(self, *, subject_hash: str, access_id: str) -> pathlib.Path:
+        return (
+            self._store.card_path(subject_hash=subject_hash, access_id=access_id)
+            / CARD_LOCK_FILENAME
+        )
+
+    def _critical_section(self, *, subject_hash: str, access_id: str):
+        return observed_file_lock_async(
+            lock_path=self._lock_path(subject_hash=subject_hash, access_id=access_id),
+            resource_id=f"delegated-card:{access_id}",
+            operation="delegated-card-mutation",
+            wait_seconds=CARD_LOCK_WAIT_SECONDS,
+        )
+
+    async def commit(
+        self,
+        authority: CardAuthority,
+        *,
+        subject_hash: str,
+        expected_revision: int,
+        now: int | None = None,
+    ) -> CardCurrentPointer:
+        """Commit the next revision and expose it as live authority."""
+        moment = int(now if now is not None else time.time())
+        mutation_id = uuid.uuid4().hex
+        try:
+            async with self._critical_section(
+                subject_hash=subject_hash, access_id=authority.access_id
+            ):
+                await self._assert_expected(
+                    subject_hash=subject_hash,
+                    access_id=authority.access_id,
+                    expected_revision=expected_revision,
+                )
+                await self._mark_updating(
+                    access_id=authority.access_id,
+                    mutation_id=mutation_id,
+                    expected_revision=expected_revision,
+                )
+                pointer = await self._commit_durable(
+                    authority=authority, subject_hash=subject_hash, mutation_id=mutation_id
+                )
+                await self._cache.commit_projection(
+                    authority,
+                    mutation_id=mutation_id,
+                    ttl_seconds=max(0, authority.expires_at - moment),
+                )
+                await self._index(
+                    authority=authority, subject_hash=subject_hash, moment=moment
+                )
+                return pointer
+        except ObservedFileLockTimeout as exc:
+            raise CardConflict("card_mutation_lock_timeout") from exc
+
+    async def revoke(
+        self,
+        *,
+        subject_hash: str,
+        access_id: str,
+        expected_revision: int,
+    ) -> CardCurrentPointer | None:
+        """Commit a revoked revision before any credential cleanup.
+
+        Returns ``None`` when the card has no durable history. After the
+        revoked revision commits, a failure to clean a credential handle cannot
+        restore authority: live resolution observes the revoked state.
+        """
+        mutation_id = uuid.uuid4().hex
+        try:
+            async with self._critical_section(
+                subject_hash=subject_hash, access_id=access_id
+            ):
+                current = await self._store.read_current_authority(
+                    subject_hash=subject_hash, access_id=access_id
+                )
+                if current is None:
+                    await self._cache.finalize_removal(access_id, mutation_id=mutation_id)
+                    await self._cache.index_remove(
+                        subject_hash=subject_hash, access_id=access_id
+                    )
+                    return None
+                _, authority = current
+                if authority.card_revision != int(expected_revision):
+                    raise CardConflict(
+                        "card_revision_moved", current_revision=authority.card_revision
+                    )
+
+                await self._mark_updating(
+                    access_id=access_id,
+                    mutation_id=mutation_id,
+                    expected_revision=expected_revision,
+                )
+                revoked = replace_state(authority, CARD_STATE_REVOKED)
+                pointer = await self._commit_durable(
+                    authority=revoked, subject_hash=subject_hash, mutation_id=mutation_id
+                )
+                await self._cache.commit_tombstone(
+                    access_id,
+                    card_revision=revoked.card_revision,
+                    mutation_id=mutation_id,
+                    ttl_seconds=self._settings.revoked_tombstone_seconds,
+                )
+                await self._cache.index_remove(
+                    subject_hash=subject_hash, access_id=access_id
+                )
+                return pointer
+        except ObservedFileLockTimeout as exc:
+            raise CardConflict("card_mutation_lock_timeout") from exc
+
+    async def _assert_expected(
+        self, *, subject_hash: str, access_id: str, expected_revision: int
+    ) -> None:
+        """The lost-update check reads durable state, not the cache."""
+        current = await self._store.read_current_authority(
+            subject_hash=subject_hash, access_id=access_id
+        )
+        held = current[1].card_revision if current is not None else 0
+        if held != int(expected_revision):
+            raise CardConflict("card_revision_moved", current_revision=held)
+
+    async def _mark_updating(
+        self, *, access_id: str, mutation_id: str, expected_revision: int
+    ) -> None:
+        """Close readers for the transition. The section already excludes other
+        writers, so a refusal here means the live value is a marker or tombstone
+        this mutation must not displace."""
+        claimed = await self._cache.claim_transition(
+            access_id,
+            mutation_id=mutation_id,
+            expected_revision=expected_revision,
+            ttl_seconds=self._settings.updating_marker_seconds,
+        )
+        if claimed:
+            return
+        entry = await self._cache.read(access_id)
+        raise CardConflict(
+            "card_transition_not_claimed",
+            current_revision=entry.card_revision if entry is not None else 0,
+        )
+
+    async def _commit_durable(
+        self, *, authority: CardAuthority, subject_hash: str, mutation_id: str
+    ) -> CardCurrentPointer:
+        moment = datetime.now(timezone.utc)
+        try:
+            pointer = await self._store.write_revision(
+                subject_hash=subject_hash, authority=authority, updated_at=moment
+            )
+            await self._store.advance_current(subject_hash=subject_hash, pointer=pointer)
+        except Exception as exc:
+            # Nothing committed, or a revision written without becoming current.
+            # Drop the marker so the previously committed revision serves again.
+            await self._release(authority.access_id, mutation_id=mutation_id)
+            raise CardCommitFailed("durable_commit_failed") from exc
+        return pointer
+
+    async def _release(self, access_id: str, *, mutation_id: str) -> None:
+        try:
+            await self._cache.finalize_removal(access_id, mutation_id=mutation_id)
+        except Exception:
+            _LOGGER.warning(
+                "[connection-hub.delegated-cards] marker release failed card=%s",
+                access_id,
+                exc_info=True,
+            )
+
+    async def _index(
+        self, *, authority: CardAuthority, subject_hash: str, moment: int
+    ) -> None:
+        if authority.state != CARD_STATE_ACTIVE or authority.expires_at <= moment:
+            await self._cache.index_remove(
+                subject_hash=subject_hash, access_id=authority.access_id
+            )
+            return
+        await self._cache.index_add(
+            subject_hash=subject_hash,
+            access_id=authority.access_id,
+            expires_at=authority.expires_at,
+        )
+
+
+def replace_state(authority: CardAuthority, state: str) -> CardAuthority:
+    """The same authority at the next revision, in a new lifecycle state."""
+    return CardAuthority(
+        access_id=authority.access_id,
+        client_id=authority.client_id,
+        grantor_subject=authority.grantor_subject,
+        delegate_subject=authority.delegate_subject,
+        source=authority.source,
+        label=authority.label,
+        card_revision=authority.card_revision + 1,
+        catalog_version=authority.catalog_version,
+        state=state,
+        operations=authority.operations,
+        resource_grants=authority.resource_grants,
+        named_service_operations=authority.named_service_operations,
+        named_services=authority.named_services,
+        account_scope=authority.account_scope,
+        identity_scope=authority.identity_scope,
+        created_at=authority.created_at,
+        expires_at=authority.expires_at,
+        last_issued_at=authority.last_issued_at,
+        last_four=authority.last_four,
+    )
+
+
+__all__ = [
+    "CARD_LOCK_WAIT_SECONDS",
+    "CardCommitFailed",
+    "CardConflict",
+    "DelegatedCardService",
+    "replace_state",
+]

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/cards/store.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/cards/store.py
@@ -15,6 +15,7 @@ section, updating marker, ordered commit — belongs to the card service.
 
 from __future__ import annotations
 
+import hashlib
 import os
 import pathlib
 import re
@@ -51,6 +52,11 @@ _REVISION_NAME_PATTERN = re.compile(
 
 class CardStorageError(DurableStorageError):
     """Durable card storage could not be read or written."""
+
+
+def subject_hash_for(grantor_subject: str) -> str:
+    """The storage scope a grantor's cards live under."""
+    return hashlib.sha256(str(grantor_subject or "").encode("utf-8")).hexdigest()
 
 
 def validated_subject_hash(subject_hash: str) -> str:
@@ -223,5 +229,6 @@ __all__ = [
     "REVISIONS_DIRNAME",
     "validated_access_id",
     "validated_revision_name",
+    "subject_hash_for",
     "validated_subject_hash",
 ]

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/cards/store.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/cards/store.py
@@ -1,0 +1,227 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Elena Viter
+
+"""Durable storage for immutable card revisions and the current-revision pointer.
+
+Layout under a shared bundle-storage root:
+
+    delegated-cards/v1/grantors/<subject_hash>/cards/<access_id>/
+        revisions/card_revision_<stamp>_<revision>_<hash12>.json
+        current.json
+
+This module owns paths and object IO only. The mutation protocol — critical
+section, updating marker, ordered commit — belongs to the card service.
+"""
+
+from __future__ import annotations
+
+import os
+import pathlib
+import re
+from datetime import datetime
+from typing import Protocol
+
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.cards.model import (
+    CardAuthority,
+    CardCurrentPointer,
+    CardRecordError,
+    card_revision_name,
+)
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.durable_io import (
+    DurableStorageError,
+    list_child_names,
+    read_json_or_none,
+    write_json_atomic,
+)
+
+CARDS_DIRNAME = "delegated-cards"
+CARDS_LAYOUT_VERSION = "v1"
+GRANTORS_DIRNAME = "grantors"
+CARDS_SUBDIRNAME = "cards"
+REVISIONS_DIRNAME = "revisions"
+CURRENT_FILENAME = "current.json"
+
+_SUBJECT_HASH_PATTERN = re.compile(r"^[0-9a-f]{64}$")
+_ACCESS_ID_PATTERN = re.compile(r"^[A-Za-z0-9_-]{1,128}$")
+_REVISION_NAME_PATTERN = re.compile(
+    r"^card_revision_[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]{2}-[0-9]{2}-[0-9]{2}-[0-9]{3}"
+    r"_[0-9]{8}_[0-9a-f]{12}\.json$"
+)
+
+
+class CardStorageError(DurableStorageError):
+    """Durable card storage could not be read or written."""
+
+
+def validated_subject_hash(subject_hash: str) -> str:
+    value = str(subject_hash or "").strip().lower()
+    if not _SUBJECT_HASH_PATTERN.match(value):
+        raise CardStorageError("subject_hash_invalid")
+    return value
+
+
+def validated_access_id(access_id: str) -> str:
+    value = str(access_id or "").strip()
+    if not _ACCESS_ID_PATTERN.match(value):
+        raise CardStorageError("access_id_invalid")
+    return value
+
+
+def validated_revision_name(revision_name: str) -> str:
+    value = str(revision_name or "").strip()
+    if not _REVISION_NAME_PATTERN.match(value):
+        raise CardStorageError("revision_name_invalid")
+    return value
+
+
+class DelegatedCardStore(Protocol):
+    async def read_current(
+        self, *, subject_hash: str, access_id: str
+    ) -> CardCurrentPointer | None: ...
+
+    async def read_revision(
+        self, *, subject_hash: str, access_id: str, revision_name: str
+    ) -> CardAuthority | None: ...
+
+    async def write_revision(
+        self, *, subject_hash: str, authority: CardAuthority, updated_at: datetime
+    ) -> CardCurrentPointer: ...
+
+    async def advance_current(
+        self, *, subject_hash: str, pointer: CardCurrentPointer
+    ) -> None: ...
+
+    async def list_card_ids(self, *, subject_hash: str) -> list[str]: ...
+
+
+class BundleStorageDelegatedCardStore:
+    """``DelegatedCardStore`` over a shared bundle-storage root."""
+
+    def __init__(self, storage_root: str | os.PathLike[str]) -> None:
+        self._root = pathlib.Path(storage_root) / CARDS_DIRNAME / CARDS_LAYOUT_VERSION
+
+    @property
+    def root(self) -> pathlib.Path:
+        return self._root
+
+    def grantor_path(self, subject_hash: str) -> pathlib.Path:
+        return self._root / GRANTORS_DIRNAME / validated_subject_hash(subject_hash) / CARDS_SUBDIRNAME
+
+    def card_path(self, *, subject_hash: str, access_id: str) -> pathlib.Path:
+        return self.grantor_path(subject_hash) / validated_access_id(access_id)
+
+    def current_path(self, *, subject_hash: str, access_id: str) -> pathlib.Path:
+        return self.card_path(subject_hash=subject_hash, access_id=access_id) / CURRENT_FILENAME
+
+    def revision_path(
+        self, *, subject_hash: str, access_id: str, revision_name: str
+    ) -> pathlib.Path:
+        return (
+            self.card_path(subject_hash=subject_hash, access_id=access_id)
+            / REVISIONS_DIRNAME
+            / validated_revision_name(revision_name)
+        )
+
+    async def read_current(
+        self, *, subject_hash: str, access_id: str
+    ) -> CardCurrentPointer | None:
+        payload = await read_json_or_none(
+            self.current_path(subject_hash=subject_hash, access_id=access_id)
+        )
+        if payload is None:
+            return None
+        return CardCurrentPointer.from_mapping(payload)
+
+    async def read_revision(
+        self, *, subject_hash: str, access_id: str, revision_name: str
+    ) -> CardAuthority | None:
+        payload = await read_json_or_none(
+            self.revision_path(
+                subject_hash=subject_hash, access_id=access_id, revision_name=revision_name
+            )
+        )
+        if payload is None:
+            return None
+        return CardAuthority.from_mapping(payload)
+
+    async def read_current_authority(
+        self, *, subject_hash: str, access_id: str
+    ) -> tuple[CardCurrentPointer, CardAuthority] | None:
+        """The latest committed revision, with its pointer's hash verified.
+
+        ``None`` means the card is confirmed absent. A pointer that names a
+        missing or altered revision raises: that is corruption, not absence.
+        """
+        pointer = await self.read_current(subject_hash=subject_hash, access_id=access_id)
+        if pointer is None:
+            return None
+        authority = await self.read_revision(
+            subject_hash=subject_hash,
+            access_id=access_id,
+            revision_name=pointer.revision_name,
+        )
+        if authority is None:
+            raise CardStorageError("current_revision_missing")
+        if authority.content_hash() != pointer.content_hash:
+            raise CardRecordError("revision_content_hash_mismatch")
+        if authority.card_revision != pointer.card_revision:
+            raise CardRecordError("revision_number_mismatch")
+        return pointer, authority
+
+    async def write_revision(
+        self, *, subject_hash: str, authority: CardAuthority, updated_at: datetime
+    ) -> CardCurrentPointer:
+        """Write the immutable revision and return the pointer that commits it.
+
+        Advancing ``current.json`` is a separate step so the caller can validate
+        the written object first.
+        """
+        content_hash = authority.content_hash()
+        revision_name = card_revision_name(
+            card_revision=authority.card_revision,
+            content_hash=content_hash,
+            updated_at=updated_at,
+        )
+        await write_json_atomic(
+            self.revision_path(
+                subject_hash=subject_hash,
+                access_id=authority.access_id,
+                revision_name=revision_name,
+            ),
+            authority.to_dict(),
+        )
+        return CardCurrentPointer.for_revision(
+            authority,
+            revision_name=revision_name,
+            content_hash=content_hash,
+            updated_at=updated_at,
+        )
+
+    async def advance_current(self, *, subject_hash: str, pointer: CardCurrentPointer) -> None:
+        await write_json_atomic(
+            self.current_path(subject_hash=subject_hash, access_id=pointer.access_id),
+            pointer.to_dict(),
+        )
+
+    async def list_card_ids(self, *, subject_hash: str) -> list[str]:
+        names = await list_child_names(self.grantor_path(subject_hash))
+        return [name for name in names if _ACCESS_ID_PATTERN.match(name)]
+
+    async def list_revision_names(self, *, subject_hash: str, access_id: str) -> list[str]:
+        path = self.card_path(subject_hash=subject_hash, access_id=access_id) / REVISIONS_DIRNAME
+        names = await list_child_names(path)
+        return [name for name in names if _REVISION_NAME_PATTERN.match(name)]
+
+
+__all__ = [
+    "CARDS_DIRNAME",
+    "CARDS_LAYOUT_VERSION",
+    "CURRENT_FILENAME",
+    "BundleStorageDelegatedCardStore",
+    "CardStorageError",
+    "DelegatedCardStore",
+    "REVISIONS_DIRNAME",
+    "validated_access_id",
+    "validated_revision_name",
+    "validated_subject_hash",
+]

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/catalog/__init__.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/catalog/__init__.py
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Elena Viter
+
+"""Versioned delegated-service catalog: source, documents, and durable storage."""
+
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.catalog.hashing import (
+    connections_content_hash,
+)
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.catalog.models import (
+    CatalogDocument,
+    CatalogDocumentError,
+    catalog_version_name,
+)
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.catalog.resolver import (
+    CatalogUnavailable,
+    DelegatedCatalogResolver,
+)
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.catalog.runtime_cache import (
+    DelegatedCatalogRuntimeCache,
+)
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.catalog.source import (
+    connections_from_props,
+)
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.catalog.store import (
+    BundleStorageDelegatedCatalogStore,
+    CatalogStorageError,
+    DelegatedCatalogStore,
+)
+
+__all__ = [
+    "BundleStorageDelegatedCatalogStore",
+    "CatalogDocument",
+    "CatalogDocumentError",
+    "CatalogStorageError",
+    "CatalogUnavailable",
+    "DelegatedCatalogResolver",
+    "DelegatedCatalogRuntimeCache",
+    "DelegatedCatalogStore",
+    "catalog_version_name",
+    "connections_content_hash",
+    "connections_from_props",
+]

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/catalog/authorization.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/catalog/authorization.py
@@ -43,15 +43,31 @@ CAPABILITY_KINDS = (
 DENIAL_CODE = "delegated_capability_no_longer_available"
 DENIAL_REASON = "current_catalog_excludes_requested_capability"
 DENIAL_WHERE = "delegated_catalog.authorization"
+NOT_GRANTED_CODE = "delegated_capability_not_granted"
+NOT_GRANTED_REASON = "card_does_not_cover_requested_capability"
+NOT_GRANTED_WHERE = "delegated_card.authorization"
 UNAVAILABLE_CODE = "temporarily_unavailable"
 UNAVAILABLE_WHERE = "delegated_catalog.resolution"
 
+# The two sides of the same contract. A removal is addressed to whoever
+# configures the deployment; a card that never covered the capability is
+# addressed to its grantor, who can widen it. Saying which one it is, in words,
+# is the point: a reasoning consumer that reads "not available" for both
+# advises revoking a working card to recover something no consent can restore.
 _MESSAGES = {
-    CAPABILITY_RESOURCE: "The requested resource is not available in the current delegated-service catalog.",
-    CAPABILITY_RESOURCE_CLAIM: "The requested resource claim is not available in the current delegated-service catalog.",
-    CAPABILITY_OUTER_OPERATION: "The requested operation is not available in the current delegated-service catalog.",
-    CAPABILITY_NAMED_SERVICE_NAMESPACE: "The requested named-service namespace is not available in the current delegated-service catalog.",
-    CAPABILITY_NAMED_SERVICE_OPERATION: "The requested named-service operation is not available in the current delegated-service catalog.",
+    CAPABILITY_RESOURCE: "This deployment no longer offers the requested resource. Granting more access cannot restore it.",
+    CAPABILITY_RESOURCE_CLAIM: "This deployment no longer offers the requested resource claim. Granting more access cannot restore it.",
+    CAPABILITY_OUTER_OPERATION: "This deployment no longer offers the requested operation. Granting more access cannot restore it.",
+    CAPABILITY_NAMED_SERVICE_NAMESPACE: "This deployment no longer offers the requested named-service namespace. Granting more access cannot restore it.",
+    CAPABILITY_NAMED_SERVICE_OPERATION: "This deployment no longer offers the requested named-service operation. Granting more access cannot restore it.",
+}
+
+_NOT_GRANTED_MESSAGES = {
+    CAPABILITY_RESOURCE: "The delegated access card does not cover the requested resource. Its grantor can add it in Connection Hub.",
+    CAPABILITY_RESOURCE_CLAIM: "The delegated access card does not carry the requested resource claim. Its grantor can add it in Connection Hub.",
+    CAPABILITY_OUTER_OPERATION: "The delegated access card does not cover the requested operation. Its grantor can add it in Connection Hub.",
+    CAPABILITY_NAMED_SERVICE_NAMESPACE: "The delegated access card does not cover the requested named-service namespace. Its grantor can add it in Connection Hub.",
+    CAPABILITY_NAMED_SERVICE_OPERATION: "The delegated access card does not cover the requested named-service operation. Its grantor can add it in Connection Hub, under this card's named-service operations.",
 }
 
 # Fields each kind must carry, so a denial is actionable on its own.
@@ -132,10 +148,14 @@ class ActiveCatalogCapabilities:
         return self._document.version
 
     def resource_config(self, request: CapabilityRequest) -> Any:
-        # The concrete request URL selects the configured row; a card-stored
-        # selector is matched only when the transport supplies no URL.
-        return self._config.resource_config(
-            _clean(request.request_resource) or _clean(request.resource)
+        # The card's own selector selects the row, falling back to the request
+        # URL only when the caller supplies no selector. Judging a card by the
+        # URL lets the all-resource admin row answer for a door the deployment
+        # withdrew, which would leave the bearer holding authority nobody can
+        # take away through the catalog.
+        return self._config.card_selector_config(
+            _clean(request.resource),
+            request_resource=_clean(request.request_resource),
         )
 
     def resource_claims(self, request: CapabilityRequest) -> frozenset[str]:
@@ -207,6 +227,51 @@ def capability_denial(
             "recovery": {
                 "action": "refresh_discovery_or_review_delegated_access",
                 "retry_same_request": False,
+                # The design's retry meaning, machine-readable: "Do not blindly
+                # retry and do not request more user consent."
+                "request_user_consent": False,
+            },
+        },
+    }
+
+
+def card_boundary_denial(
+    *,
+    provenance: CardProvenance,
+    request: CapabilityRequest,
+    delegable: bool = True,
+) -> dict[str, Any]:
+    """The structured 403 body for a capability the CARD does not cover.
+
+    The mirror of ``capability_denial``: the active catalog still offers this,
+    so a remedy exists and the grantor owns it. ``delegable=False`` says the
+    deployment does not allow this capability to be asked for here, which
+    changes the answer from "ask for it" to "nobody here can grant it".
+    """
+    return {
+        "ok": False,
+        "error": {
+            "code": NOT_GRANTED_CODE,
+            "message": _NOT_GRANTED_MESSAGES.get(
+                request.kind, _NOT_GRANTED_MESSAGES[CAPABILITY_RESOURCE]
+            ),
+            "where": NOT_GRANTED_WHERE,
+            "retryable": False,
+        },
+        "ret": {
+            "reason": NOT_GRANTED_REASON,
+            "access_id": _clean(provenance.access_id),
+            "card_revision": int(provenance.card_revision or 0),
+            "requested_capability": request.path(),
+            "card_catalog_version": _clean(provenance.catalog_version),
+            "recovery": {
+                "action": (
+                    "grant_capability_in_delegated_access"
+                    if delegable
+                    else "capability_not_delegable_here"
+                ),
+                "retry_same_request": False,
+                "request_user_consent": bool(delegable),
             },
         },
     }
@@ -244,6 +309,12 @@ def denial_is_capability_removed(payload: Mapping[str, Any] | None) -> bool:
     return str(error.get("code") or "") == DENIAL_CODE
 
 
+def denial_is_capability_not_granted(payload: Mapping[str, Any] | None) -> bool:
+    error = (payload or {}).get("error")
+    error = error if isinstance(error, Mapping) else {}
+    return str(error.get("code") or "") == NOT_GRANTED_CODE
+
+
 __all__ = [
     "CAPABILITY_KINDS",
     "CAPABILITY_NAMED_SERVICE_NAMESPACE",
@@ -253,11 +324,15 @@ __all__ = [
     "CAPABILITY_RESOURCE_CLAIM",
     "DENIAL_CODE",
     "DENIAL_REASON",
+    "NOT_GRANTED_CODE",
+    "NOT_GRANTED_REASON",
     "ActiveCatalogCapabilities",
     "CapabilityRequest",
     "CardProvenance",
     "authorize_current_capability",
     "capability_denial",
+    "card_boundary_denial",
     "catalog_unavailable_denial",
+    "denial_is_capability_not_granted",
     "denial_is_capability_removed",
 ]

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/catalog/authorization.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/catalog/authorization.py
@@ -1,0 +1,263 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Elena Viter
+
+"""Current-catalog authorization for governed delegated calls.
+
+Effective authority is the stored card selection intersected with the active
+catalog. The card side is checked by the surface that owns it; this module owns
+the catalog side and produces the structured denial when a stored capability is
+no longer offered.
+
+Inputs are explicit: a capability path is never inferred from a tool name.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.catalog.models import (
+    CatalogDocument,
+)
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.named_service_policy import (
+    configured_named_service_operations,
+)
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.oauth.config import (
+    oauth_delegated_config_from_connections,
+)
+
+CAPABILITY_RESOURCE = "resource"
+CAPABILITY_RESOURCE_CLAIM = "resource_claim"
+CAPABILITY_OUTER_OPERATION = "outer_operation"
+CAPABILITY_NAMED_SERVICE_NAMESPACE = "named_service_namespace"
+CAPABILITY_NAMED_SERVICE_OPERATION = "named_service_operation"
+
+CAPABILITY_KINDS = (
+    CAPABILITY_RESOURCE,
+    CAPABILITY_RESOURCE_CLAIM,
+    CAPABILITY_OUTER_OPERATION,
+    CAPABILITY_NAMED_SERVICE_NAMESPACE,
+    CAPABILITY_NAMED_SERVICE_OPERATION,
+)
+
+DENIAL_CODE = "delegated_capability_no_longer_available"
+DENIAL_REASON = "current_catalog_excludes_requested_capability"
+DENIAL_WHERE = "delegated_catalog.authorization"
+UNAVAILABLE_CODE = "temporarily_unavailable"
+UNAVAILABLE_WHERE = "delegated_catalog.resolution"
+
+_MESSAGES = {
+    CAPABILITY_RESOURCE: "The requested resource is not available in the current delegated-service catalog.",
+    CAPABILITY_RESOURCE_CLAIM: "The requested resource claim is not available in the current delegated-service catalog.",
+    CAPABILITY_OUTER_OPERATION: "The requested operation is not available in the current delegated-service catalog.",
+    CAPABILITY_NAMED_SERVICE_NAMESPACE: "The requested named-service namespace is not available in the current delegated-service catalog.",
+    CAPABILITY_NAMED_SERVICE_OPERATION: "The requested named-service operation is not available in the current delegated-service catalog.",
+}
+
+# Fields each kind must carry, so a denial is actionable on its own.
+_REQUIRED_PATH = {
+    CAPABILITY_RESOURCE: ("resource",),
+    CAPABILITY_RESOURCE_CLAIM: ("resource", "claim"),
+    CAPABILITY_OUTER_OPERATION: ("resource", "surface", "outer_operation"),
+    CAPABILITY_NAMED_SERVICE_NAMESPACE: ("resource", "surface", "namespace"),
+    CAPABILITY_NAMED_SERVICE_OPERATION: ("resource", "surface", "namespace", "operation"),
+}
+
+# Carried in addition when the surface knows them.
+_OPTIONAL_PATH = {
+    CAPABILITY_NAMED_SERVICE_NAMESPACE: ("outer_operation",),
+    CAPABILITY_NAMED_SERVICE_OPERATION: ("outer_operation",),
+}
+
+
+def _clean(value: Any) -> str:
+    return str(value or "").strip()
+
+
+@dataclass(frozen=True)
+class CardProvenance:
+    """Non-secret card identity carried into a denial."""
+
+    access_id: str = ""
+    card_revision: int = 0
+    catalog_version: str = ""
+
+
+@dataclass(frozen=True)
+class CapabilityRequest:
+    """One capability path, as the calling surface parsed it.
+
+    ``resource`` is the configured selector that matched; ``request_resource``
+    is the concrete URL the caller targeted.
+    """
+
+    kind: str
+    resource: str = ""
+    request_resource: str = ""
+    surface: str = ""
+    outer_operation: str = ""
+    claim: str = ""
+    namespace: str = ""
+    operation: str = ""
+
+    def path(self) -> dict[str, Any]:
+        fields = {
+            "kind": self.kind,
+            "resource": _clean(self.resource),
+            "request_resource": _clean(self.request_resource),
+            "surface": _clean(self.surface),
+            "outer_operation": _clean(self.outer_operation),
+            "claim": _clean(self.claim),
+            "namespace": _clean(self.namespace),
+            "operation": _clean(self.operation),
+        }
+        carried = {
+            "kind",
+            "request_resource",
+            *_REQUIRED_PATH.get(self.kind, ()),
+            *_OPTIONAL_PATH.get(self.kind, ()),
+        }
+        return {key: value for key, value in fields.items() if value and key in carried}
+
+
+class ActiveCatalogCapabilities:
+    """What the active catalog offers, read through the delegated-config reader."""
+
+    def __init__(self, document: CatalogDocument) -> None:
+        self._document = document
+        self._config = oauth_delegated_config_from_connections(document.connections)
+
+    @property
+    def version(self) -> str:
+        return self._document.version
+
+    def resource_config(self, request: CapabilityRequest) -> Any:
+        # The concrete request URL selects the configured row; a card-stored
+        # selector is matched only when the transport supplies no URL.
+        return self._config.resource_config(
+            _clean(request.request_resource) or _clean(request.resource)
+        )
+
+    def resource_claims(self, request: CapabilityRequest) -> frozenset[str]:
+        """The claim ceiling the active catalog still allows for this resource."""
+        resource_cfg = self.resource_config(request)
+        if resource_cfg is None:
+            return frozenset()
+        return frozenset(_clean(grant) for grant in (resource_cfg.grants or ()) if _clean(grant))
+
+    def permits(self, request: CapabilityRequest) -> bool:
+        """Whether the active catalog still offers this capability.
+
+        A dimension the resource does not enumerate carries no ceiling and is
+        not a denial. A dimension it enumerates is authoritative even when what
+        it enumerates is empty — that is a removal, not an absent section.
+        """
+        resource_cfg = self.resource_config(request)
+        if resource_cfg is None:
+            return False
+        if request.kind == CAPABILITY_RESOURCE:
+            return True
+        if request.kind == CAPABILITY_RESOURCE_CLAIM:
+            configured = {_clean(grant) for grant in (resource_cfg.grants or ())}
+            if not configured:
+                return True
+            return _clean(request.claim) in configured
+        if request.kind == CAPABILITY_OUTER_OPERATION:
+            configured = {
+                _clean(getattr(tool, "name", "")) for tool in (resource_cfg.tools or ())
+            }
+            if not configured:
+                return True
+            return _clean(request.outer_operation) in configured
+        named_services = resource_cfg.named_services
+        if not isinstance(named_services, Mapping) or not named_services:
+            return True
+        namespaces = configured_named_service_operations(named_services)
+        namespace = _clean(request.namespace).lower().rstrip(":")
+        if request.kind == CAPABILITY_NAMED_SERVICE_NAMESPACE:
+            return bool(namespace) and namespace in namespaces
+        if request.kind == CAPABILITY_NAMED_SERVICE_OPERATION:
+            operation = _clean(request.operation)
+            return bool(operation) and operation in namespaces.get(namespace, set())
+        return False
+
+
+def capability_denial(
+    *,
+    catalog: ActiveCatalogCapabilities,
+    provenance: CardProvenance,
+    request: CapabilityRequest,
+) -> dict[str, Any]:
+    """The structured 403 body for a capability the catalog no longer offers."""
+    return {
+        "ok": False,
+        "error": {
+            "code": DENIAL_CODE,
+            "message": _MESSAGES.get(request.kind, _MESSAGES[CAPABILITY_RESOURCE]),
+            "where": DENIAL_WHERE,
+            "retryable": False,
+        },
+        "ret": {
+            "reason": DENIAL_REASON,
+            "access_id": _clean(provenance.access_id),
+            "card_revision": int(provenance.card_revision or 0),
+            "requested_capability": request.path(),
+            "card_catalog_version": _clean(provenance.catalog_version),
+            "active_catalog_version": catalog.version,
+            "recovery": {
+                "action": "refresh_discovery_or_review_delegated_access",
+                "retry_same_request": False,
+            },
+        },
+    }
+
+
+def catalog_unavailable_denial(reason: str = "") -> dict[str, Any]:
+    """The structured 503 body for a catalog that cannot be established."""
+    return {
+        "ok": False,
+        "error": {
+            "code": UNAVAILABLE_CODE,
+            "message": "The current delegated-service catalog is unavailable.",
+            "where": UNAVAILABLE_WHERE,
+            "retryable": True,
+        },
+        "ret": {"reason": _clean(reason) or "catalog_unavailable"},
+    }
+
+
+def authorize_current_capability(
+    *,
+    catalog: ActiveCatalogCapabilities,
+    provenance: CardProvenance,
+    request: CapabilityRequest,
+) -> dict[str, Any] | None:
+    """``None`` when the active catalog still offers the capability."""
+    if catalog.permits(request):
+        return None
+    return capability_denial(catalog=catalog, provenance=provenance, request=request)
+
+
+def denial_is_capability_removed(payload: Mapping[str, Any] | None) -> bool:
+    error = (payload or {}).get("error")
+    error = error if isinstance(error, Mapping) else {}
+    return str(error.get("code") or "") == DENIAL_CODE
+
+
+__all__ = [
+    "CAPABILITY_KINDS",
+    "CAPABILITY_NAMED_SERVICE_NAMESPACE",
+    "CAPABILITY_NAMED_SERVICE_OPERATION",
+    "CAPABILITY_OUTER_OPERATION",
+    "CAPABILITY_RESOURCE",
+    "CAPABILITY_RESOURCE_CLAIM",
+    "DENIAL_CODE",
+    "DENIAL_REASON",
+    "ActiveCatalogCapabilities",
+    "CapabilityRequest",
+    "CardProvenance",
+    "authorize_current_capability",
+    "capability_denial",
+    "catalog_unavailable_denial",
+    "denial_is_capability_removed",
+]

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/catalog/drift.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/catalog/drift.py
@@ -50,7 +50,10 @@ class _CatalogView:
         self._config = oauth_delegated_config_from_connections(document.connections)
 
     def resource(self, resource: str) -> Any:
-        return self._config.resource_config(resource)
+        # A card selector, so the all-resource row answers only a card that
+        # holds it: otherwise a withdrawn door reads as still offered and its
+        # claims are reported "already ineffective" while they still work.
+        return self._config.card_selector_config(resource)
 
     def claims(self, resource: str) -> set[str] | None:
         """``None`` when the resource declares no claim ceiling."""
@@ -80,12 +83,16 @@ class _CatalogView:
         return configured_named_service_operations(block)
 
 
-def _selected_named_service_operations(card: Any) -> dict[str, dict[str, set[str]]]:
+def selected_named_service_operations(card: Any) -> dict[str, dict[str, set[str]]]:
     """``resource -> namespace -> operations`` the card selected.
 
     An exact selection says it directly. A wildcard or a pre-encoding card is
     read from the materialized boundary, which is that selection expanded under
     the catalog version the card was saved against.
+
+    Derived, never authority. Drift computes against it, and the public card
+    projection carries it so a surface can render a wildcard card's actual
+    coverage instead of an empty picker.
     """
     selection = card.named_service_operations
     out: dict[str, dict[str, set[str]]] = {}
@@ -119,7 +126,7 @@ def _removed(
     outer_operations: list[dict[str, Any]] = []
     named_service_operations: list[dict[str, Any]] = []
 
-    selected_inner = _selected_named_service_operations(card)
+    selected_inner = selected_named_service_operations(card)
     selected_outer = {_clean(name) for name in (card.operations or ()) if _clean(name)}
 
     for raw_resource, grants in card.resource_grants.items():
@@ -289,4 +296,5 @@ __all__ = [
     "EFFECT_DENIED",
     "card_drift",
     "drift_unavailable",
+    "selected_named_service_operations",
 ]

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/catalog/drift.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/catalog/drift.py
@@ -1,0 +1,292 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Elena Viter
+
+"""Backend-computed drift between a card's baseline and the active catalog.
+
+The comparison is transient: it explains a card, and never rewrites one. A
+surface renders what this module returns instead of comparing catalogs itself.
+
+Removals are computed against the active catalog alone, so they survive a
+missing baseline. Additions need the baseline, because "new" means "absent when
+this card was last saved".
+"""
+
+from __future__ import annotations
+
+from typing import Any, Iterable, Mapping
+
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.catalog.models import (
+    CatalogDocument,
+)
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.named_service_policy import (
+    configured_named_service_operations,
+)
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.oauth.config import (
+    oauth_delegated_config_from_connections,
+)
+
+DRIFT_CURRENT = "current"
+DRIFT_CHANGED = "changed"
+DRIFT_NO_RELEVANT_CHANGE = "no_relevant_change"
+DRIFT_BASELINE_MISSING = "baseline_missing"
+DRIFT_UNAVAILABLE = "unavailable"
+
+EFFECT_DENIED = "denied_immediately"
+
+
+def _clean(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _namespace(value: Any) -> str:
+    return _clean(value).lower().rstrip(":")
+
+
+class _CatalogView:
+    """What one catalog generation offers, per card resource."""
+
+    def __init__(self, document: CatalogDocument) -> None:
+        self.version = document.version
+        self._config = oauth_delegated_config_from_connections(document.connections)
+
+    def resource(self, resource: str) -> Any:
+        return self._config.resource_config(resource)
+
+    def claims(self, resource: str) -> set[str] | None:
+        """``None`` when the resource declares no claim ceiling."""
+        cfg = self.resource(resource)
+        if cfg is None:
+            return set()
+        configured = {_clean(grant) for grant in (cfg.grants or ()) if _clean(grant)}
+        return configured or None
+
+    def outer_operations(self, resource: str) -> set[str] | None:
+        cfg = self.resource(resource)
+        if cfg is None:
+            return set()
+        configured = {
+            _clean(getattr(tool, "name", "")) for tool in (cfg.tools or ())
+        } - {""}
+        return configured or None
+
+    def named_service_operations(self, resource: str) -> dict[str, set[str]] | None:
+        """``None`` when the resource declares no named-service block."""
+        cfg = self.resource(resource)
+        if cfg is None:
+            return {}
+        block = getattr(cfg, "named_services", None)
+        if not isinstance(block, Mapping) or not block:
+            return None
+        return configured_named_service_operations(block)
+
+
+def _selected_named_service_operations(card: Any) -> dict[str, dict[str, set[str]]]:
+    """``resource -> namespace -> operations`` the card selected.
+
+    An exact selection says it directly. A wildcard or a pre-encoding card is
+    read from the materialized boundary, which is that selection expanded under
+    the catalog version the card was saved against.
+    """
+    selection = card.named_service_operations
+    out: dict[str, dict[str, set[str]]] = {}
+    if selection.is_none:
+        return out
+    if selection.is_exact:
+        for resource, namespaces in selection.operations.items():
+            per_resource = out.setdefault(_clean(resource), {})
+            for namespace, operations in namespaces.items():
+                per_resource[_namespace(namespace)] = {
+                    _clean(op) for op in operations if _clean(op)
+                }
+        return out
+    materialized = configured_named_service_operations(card.named_services)
+    if not materialized:
+        return out
+    # The boundary is one tree for the whole card; attribute it to the resources
+    # the card actually holds.
+    for resource in card.resource_grants:
+        out[_clean(resource)] = {
+            namespace: set(operations) for namespace, operations in materialized.items()
+        }
+    return out
+
+
+def _removed(
+    *, card: Any, active: _CatalogView
+) -> dict[str, list[dict[str, Any]]]:
+    resources: list[dict[str, Any]] = []
+    claims: list[dict[str, Any]] = []
+    outer_operations: list[dict[str, Any]] = []
+    named_service_operations: list[dict[str, Any]] = []
+
+    selected_inner = _selected_named_service_operations(card)
+    selected_outer = {_clean(name) for name in (card.operations or ()) if _clean(name)}
+
+    for raw_resource, grants in card.resource_grants.items():
+        resource = _clean(raw_resource)
+        if active.resource(resource) is None:
+            resources.append(
+                {"resource": resource, "was_selected": True, "effect": EFFECT_DENIED}
+            )
+            continue
+
+        ceiling = active.claims(resource)
+        if ceiling is not None:
+            for claim in sorted({_clean(g) for g in (grants or ()) if _clean(g)} - ceiling):
+                claims.append(
+                    {
+                        "resource": resource,
+                        "claim": claim,
+                        "was_selected": True,
+                        "effect": EFFECT_DENIED,
+                    }
+                )
+
+        offered_outer = active.outer_operations(resource)
+        if offered_outer is not None:
+            for operation in sorted(selected_outer - offered_outer):
+                outer_operations.append(
+                    {
+                        "resource": resource,
+                        "operation": operation,
+                        "was_selected": True,
+                        "effect": EFFECT_DENIED,
+                    }
+                )
+
+        offered_inner = active.named_service_operations(resource)
+        if offered_inner is None:
+            continue
+        for namespace, operations in sorted(selected_inner.get(resource, {}).items()):
+            for operation in sorted(operations - offered_inner.get(namespace, set())):
+                named_service_operations.append(
+                    {
+                        "resource": resource,
+                        "namespace": namespace,
+                        "operation": operation,
+                        "was_selected": True,
+                        "effect": EFFECT_DENIED,
+                    }
+                )
+
+    return {
+        "resources": resources,
+        "claims": claims,
+        "outer_operations": outer_operations,
+        "named_service_operations": named_service_operations,
+    }
+
+
+def _added(
+    *, card: Any, active: _CatalogView, baseline: _CatalogView
+) -> dict[str, list[dict[str, Any]]]:
+    """What the active catalog offers for this card's resources and the baseline
+    did not. Never selected: an addition is an option, not a grant."""
+    claims: list[dict[str, Any]] = []
+    outer_operations: list[dict[str, Any]] = []
+    named_service_operations: list[dict[str, Any]] = []
+
+    for raw_resource in card.resource_grants:
+        resource = _clean(raw_resource)
+        if active.resource(resource) is None:
+            continue
+
+        for claim in sorted((active.claims(resource) or set()) - (baseline.claims(resource) or set())):
+            claims.append({"resource": resource, "claim": claim, "selected": False})
+
+        for operation in sorted(
+            (active.outer_operations(resource) or set())
+            - (baseline.outer_operations(resource) or set())
+        ):
+            outer_operations.append(
+                {"resource": resource, "operation": operation, "selected": False}
+            )
+
+        offered = active.named_service_operations(resource) or {}
+        known = baseline.named_service_operations(resource) or {}
+        for namespace in sorted(offered):
+            for operation in sorted(offered[namespace] - known.get(namespace, set())):
+                named_service_operations.append(
+                    {
+                        "resource": resource,
+                        "namespace": namespace,
+                        "operation": operation,
+                        "selected": False,
+                    }
+                )
+
+    return {
+        "claims": claims,
+        "outer_operations": outer_operations,
+        "named_service_operations": named_service_operations,
+    }
+
+
+def _any(block: Mapping[str, Iterable[Any]]) -> bool:
+    return any(bool(rows) for rows in block.values())
+
+
+def card_drift(
+    *,
+    card: Any,
+    active: CatalogDocument,
+    baseline: CatalogDocument | None,
+    baseline_confirmed_absent: bool = False,
+) -> dict[str, Any]:
+    """The drift block for one card.
+
+    ``baseline`` is the card's saved version document; pass ``None`` with
+    ``baseline_confirmed_absent`` when durable absence was confirmed.
+    """
+    saved_version = _clean(getattr(card, "catalog_version", ""))
+    if saved_version and saved_version == active.version:
+        return {
+            "status": DRIFT_CURRENT,
+            "saved_version": saved_version,
+            "current_version": active.version,
+        }
+
+    active_view = _CatalogView(active)
+    removed = _removed(card=card, active=active_view)
+
+    if baseline is None:
+        # Removals still hold against the verified current catalog; additions
+        # since the last save cannot be established without the baseline.
+        return {
+            "status": DRIFT_BASELINE_MISSING,
+            "saved_version": saved_version,
+            "current_version": active.version,
+            "removed": removed,
+            "added": {"claims": [], "outer_operations": [], "named_service_operations": []},
+            "baseline_confirmed_absent": bool(baseline_confirmed_absent),
+        }
+
+    added = _added(card=card, active=active_view, baseline=_CatalogView(baseline))
+    changed = _any(removed) or _any(added)
+    return {
+        "status": DRIFT_CHANGED if changed else DRIFT_NO_RELEVANT_CHANGE,
+        "saved_version": saved_version,
+        "current_version": active.version,
+        "removed": removed,
+        "added": added,
+    }
+
+
+def drift_unavailable(reason: str = "") -> dict[str, Any]:
+    """Editing authority is disabled: the comparison could not be made."""
+    return {
+        "status": DRIFT_UNAVAILABLE,
+        "reason": _clean(reason) or "catalog_unavailable",
+    }
+
+
+__all__ = [
+    "DRIFT_BASELINE_MISSING",
+    "DRIFT_CHANGED",
+    "DRIFT_CURRENT",
+    "DRIFT_NO_RELEVANT_CHANGE",
+    "DRIFT_UNAVAILABLE",
+    "EFFECT_DENIED",
+    "card_drift",
+    "drift_unavailable",
+]

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/catalog/hashing.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/catalog/hashing.py
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Elena Viter
+
+"""Canonical content hash for the delegated-service catalog body."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any, Mapping
+
+
+def connections_content_hash(connections: Mapping[str, Any]) -> str:
+    """Full lowercase SHA-256 of the canonical JSON encoding of ``connections``.
+
+    The input must already be JSON-compatible parsed effective props. An
+    unsupported value raises instead of being coerced to a string, so a
+    publication error cannot silently become a different hash.
+
+    Map-key order and source formatting do not affect the result; list order
+    and every actual value do.
+    """
+    canonical = json.dumps(
+        connections,
+        ensure_ascii=True,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
+    return hashlib.sha256(canonical).hexdigest()
+
+
+__all__ = ["connections_content_hash"]

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/catalog/models.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/catalog/models.py
@@ -1,0 +1,129 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Elena Viter
+
+"""Immutable delegated-catalog version documents.
+
+A catalog document is version metadata plus one exact copy of a Connection Hub
+``connections`` mapping. Publication never renames, flattens, reorders, or
+enriches that mapping.
+"""
+
+from __future__ import annotations
+
+import copy
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Mapping
+
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.catalog.hashing import (
+    connections_content_hash,
+)
+
+CATALOG_DOCUMENT_SCHEMA = "connection_hub.delegated_catalog.v1"
+CATALOG_VERSION_PREFIX = "delegated_catalog"
+_VERSION_HASH_CHARS = 12
+
+
+class CatalogDocumentError(ValueError):
+    """A catalog document could not be trusted as a registered catalog."""
+
+    def __init__(self, reason: str) -> None:
+        super().__init__(reason)
+        self.reason = reason
+
+
+def utc_stamp(moment: datetime) -> str:
+    """Sortable ``YYYY-MM-DD-HH-MM-SS-mmm`` UTC stamp used in resource names."""
+    value = moment.astimezone(timezone.utc)
+    return value.strftime("%Y-%m-%d-%H-%M-%S-") + f"{value.microsecond // 1000:03d}"
+
+
+def utc_timestamp(moment: datetime) -> str:
+    """ISO-8601 UTC timestamp with milliseconds."""
+    value = moment.astimezone(timezone.utc)
+    return value.strftime("%Y-%m-%dT%H:%M:%S.") + f"{value.microsecond // 1000:03d}Z"
+
+
+def catalog_version_name(content_hash: str, *, created_at: datetime) -> str:
+    return f"{CATALOG_VERSION_PREFIX}_{utc_stamp(created_at)}_{content_hash[:_VERSION_HASH_CHARS]}"
+
+
+@dataclass(frozen=True)
+class CatalogDocument:
+    version: str
+    content_hash: str
+    created_at: str
+    connections: Mapping[str, Any]
+
+    @classmethod
+    def build(
+        cls,
+        connections: Mapping[str, Any],
+        *,
+        created_at: datetime | None = None,
+    ) -> "CatalogDocument":
+        """Create a document for a mapping, deep-copied at capture time."""
+        moment = created_at or datetime.now(timezone.utc)
+        body = copy.deepcopy(dict(connections or {}))
+        content_hash = connections_content_hash(body)
+        return cls(
+            version=catalog_version_name(content_hash, created_at=moment),
+            content_hash=content_hash,
+            created_at=utc_timestamp(moment),
+            connections=body,
+        )
+
+    @classmethod
+    def from_mapping(cls, value: Any) -> "CatalogDocument":
+        """Parse a stored document. Raises ``CatalogDocumentError`` when the
+        payload is not a usable registered catalog."""
+        if not isinstance(value, Mapping):
+            raise CatalogDocumentError("document_not_object")
+        if str(value.get("schema") or "").strip() != CATALOG_DOCUMENT_SCHEMA:
+            raise CatalogDocumentError("schema_mismatch")
+        version = str(value.get("version") or "").strip()
+        if not version:
+            raise CatalogDocumentError("version_missing")
+        content_hash = str(value.get("content_hash") or "").strip().lower()
+        if not content_hash:
+            raise CatalogDocumentError("content_hash_missing")
+        connections = value.get("connections")
+        if not isinstance(connections, Mapping):
+            raise CatalogDocumentError("connections_invalid")
+        document = cls(
+            version=version,
+            content_hash=content_hash,
+            created_at=str(value.get("created_at") or "").strip(),
+            connections=copy.deepcopy(dict(connections)),
+        )
+        document.verify()
+        return document
+
+    def verify(self) -> None:
+        """Re-derive the hash of the embedded body and compare it."""
+        try:
+            actual = connections_content_hash(self.connections)
+        except (TypeError, ValueError) as exc:
+            raise CatalogDocumentError("connections_not_hashable") from exc
+        if actual != self.content_hash:
+            raise CatalogDocumentError("content_hash_mismatch")
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema": CATALOG_DOCUMENT_SCHEMA,
+            "version": self.version,
+            "content_hash": self.content_hash,
+            "created_at": self.created_at,
+            "connections": copy.deepcopy(dict(self.connections)),
+        }
+
+
+__all__ = [
+    "CATALOG_DOCUMENT_SCHEMA",
+    "CATALOG_VERSION_PREFIX",
+    "CatalogDocument",
+    "CatalogDocumentError",
+    "catalog_version_name",
+    "utc_stamp",
+    "utc_timestamp",
+]

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/catalog/publisher.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/catalog/publisher.py
@@ -1,0 +1,170 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Elena Viter
+
+"""Idempotent publication of the delegated-service catalog.
+
+``ensure_delegated_catalog`` is the only path that writes catalog history. It
+runs under the shared bundle-storage critical section and commits one immutable
+version plus the complete active document. Request paths may restore an expired
+Redis projection from committed durable state, but never publish.
+
+The app generation is ready only after both the durable and the serving
+publication succeed.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.cache_settings import (
+    DelegatedCacheSettings,
+)
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.catalog.hashing import (
+    connections_content_hash,
+)
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.catalog.models import (
+    CatalogDocument,
+)
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.catalog.runtime_cache import (
+    DelegatedCatalogRuntimeCache,
+)
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.catalog.store import (
+    BundleStorageDelegatedCatalogStore,
+)
+from kdcube_ai_app.infra.plugin.bundle_once import run_once_for_shared_bundle_storage
+
+_LOGGER = logging.getLogger("connection_hub.delegated_catalog.publisher")
+
+CATALOG_OPERATION = "delegated-catalog-publish"
+SIGNATURE_FILENAME = "publication.signature"
+
+
+class CatalogPublicationError(RuntimeError):
+    """The catalog could not be published for this app generation."""
+
+    def __init__(self, reason: str) -> None:
+        super().__init__(reason)
+        self.reason = reason
+
+
+@dataclass(frozen=True)
+class CatalogPublicationResult:
+    version: str
+    content_hash: str
+    created: bool
+
+
+async def ensure_delegated_catalog(
+    *,
+    connections: Mapping[str, Any],
+    store: BundleStorageDelegatedCatalogStore,
+    cache: DelegatedCatalogRuntimeCache,
+    reason: str = "",
+    settings: DelegatedCacheSettings | None = None,
+    logger: Any = None,
+) -> CatalogPublicationResult:
+    """Register ``connections`` as the active catalog, creating a version if it changed.
+
+    ``reason`` is audit metadata only; it does not affect hashing, comparison,
+    or control flow. The critical section serializes concurrent publishers onto
+    one immutable version.
+    """
+    residency = (settings or DelegatedCacheSettings()).catalog
+    try:
+        expected_hash = connections_content_hash(connections)
+    except (TypeError, ValueError) as exc:
+        raise CatalogPublicationError("connections_not_hashable") from exc
+
+    outcome: dict[str, Any] = {}
+
+    async def _publish() -> None:
+        document = CatalogDocument.build(connections)
+        active = await store.read_active()
+        created = True
+        if active is not None and active.content_hash == document.content_hash:
+            # Unchanged content: keep the registered version identity and only
+            # verify that its immutable document still exists.
+            document = active
+            created = False
+            if not await store.version_exists(document.version):
+                await store.write_version(document)
+        else:
+            await store.write_version(document)
+            await store.publish_active(document)
+
+        await cache.cache_version(document, ttl_seconds=residency.version_cache_seconds)
+        if not await cache.publish_active(
+            document, ttl_seconds=residency.active_cache_seconds
+        ):
+            # A newer generation already owns the serving entry; that catalog is
+            # the one requests must use, so this generation is still ready.
+            _LOGGER.info(
+                "[connection-hub.delegated-catalog] serving entry holds a newer catalog "
+                "than version=%s reason=%s",
+                document.version,
+                reason,
+            )
+        outcome["result"] = CatalogPublicationResult(
+            version=document.version,
+            content_hash=document.content_hash,
+            created=created,
+        )
+
+    async def _ready() -> bool:
+        active = await store.read_active()
+        if active is None or active.content_hash != expected_hash:
+            return False
+        if not await store.version_exists(active.version):
+            return False
+        cached = await cache.read_active()
+        return cached is not None and cached.version >= active.version
+
+    await run_once_for_shared_bundle_storage(
+        storage_root=store.root,
+        operation=CATALOG_OPERATION,
+        signature_path=store.root / SIGNATURE_FILENAME,
+        signature=expected_hash,
+        ready=_ready,
+        action=_publish,
+        logger=logger,
+        owner_metadata={"kind": "delegated-catalog", "reason": reason},
+        log_prefix="[connection-hub.delegated-catalog]",
+    )
+
+    result = outcome.get("result")
+    if result is None:
+        # Another worker published this generation; adopt the registered state.
+        result = await _adopt_registered(store=store, cache=cache, residency=residency)
+    _LOGGER.info(
+        "[connection-hub.delegated-catalog] ensured version=%s created=%s reason=%s",
+        result.version,
+        result.created,
+        reason,
+    )
+    return result
+
+
+async def _adopt_registered(
+    *,
+    store: BundleStorageDelegatedCatalogStore,
+    cache: DelegatedCatalogRuntimeCache,
+    residency: Any,
+) -> CatalogPublicationResult:
+    active = await store.read_active()
+    if active is None:
+        raise CatalogPublicationError("active_catalog_not_registered")
+    await cache.cache_version(active, ttl_seconds=residency.version_cache_seconds)
+    await cache.publish_active(active, ttl_seconds=residency.active_cache_seconds)
+    return CatalogPublicationResult(
+        version=active.version, content_hash=active.content_hash, created=False
+    )
+
+
+__all__ = [
+    "CATALOG_OPERATION",
+    "CatalogPublicationError",
+    "CatalogPublicationResult",
+    "ensure_delegated_catalog",
+]

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/catalog/reconcile.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/catalog/reconcile.py
@@ -91,7 +91,7 @@ def reconcile_selection(
 
     for raw_resource, grants in resource_grants.items():
         resource = _clean(raw_resource)
-        cfg = config.resource_config(resource)
+        cfg = config.card_selector_config(resource)
         if cfg is None:
             pruned_resources.append(resource)
             continue
@@ -126,7 +126,7 @@ def reconcile_selection(
                             }
                         )
                 continue
-            cfg = config.resource_config(resource)
+            cfg = config.card_selector_config(resource)
             block = getattr(cfg, "named_services", None)
             offered = (
                 configured_named_service_operations(block)

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/catalog/reconcile.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/catalog/reconcile.py
@@ -1,0 +1,168 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Elena Viter
+
+"""Save-time reconciliation of a submitted selection against the active catalog.
+
+A drifted card must stay editable. Strict validation alone makes it a dead end:
+the picker renders rows from the current catalog, so an operator cannot untick
+what the catalog no longer offers, and every save then fails on the invisible
+value. Pruning first removes exactly those values and validates what survives.
+
+Pruning never adds. An option the catalog gained is not selected here; it is
+offered unselected by the drift response and granted only if the operator
+submits it.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Iterable, Mapping
+
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.catalog.models import (
+    CatalogDocument,
+)
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.cards.model import (
+    NamedServiceSelection,
+)
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.named_service_policy import (
+    configured_named_service_operations,
+)
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.oauth.config import (
+    oauth_delegated_config_from_connections,
+)
+
+
+def _clean(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _namespace(value: Any) -> str:
+    return _clean(value).lower().rstrip(":")
+
+
+@dataclass(frozen=True)
+class Reconciled:
+    """What survives the active catalog, and what did not."""
+
+    resource_grants: dict[str, list[str]]
+    named_service_operations: NamedServiceSelection
+    pruned_resources: list[str] = field(default_factory=list)
+    pruned_claims: list[dict[str, str]] = field(default_factory=list)
+    pruned_named_service_operations: list[dict[str, str]] = field(default_factory=list)
+
+    @property
+    def anything_pruned(self) -> bool:
+        return bool(
+            self.pruned_resources
+            or self.pruned_claims
+            or self.pruned_named_service_operations
+        )
+
+    @property
+    def empty(self) -> bool:
+        """No resource carries a claim: the card has no authority left."""
+        return not any(self.resource_grants.values())
+
+    def to_public_dict(self) -> dict[str, Any]:
+        return {
+            "resources": list(self.pruned_resources),
+            "claims": list(self.pruned_claims),
+            "named_service_operations": list(self.pruned_named_service_operations),
+        }
+
+
+def reconcile_selection(
+    *,
+    resource_grants: Mapping[str, Iterable[str]],
+    named_service_operations: NamedServiceSelection,
+    active: CatalogDocument,
+) -> Reconciled:
+    """Drop everything the active catalog no longer offers.
+
+    A wildcard selection is kept as a wildcard: it means "everything shown by
+    the catalog this save acknowledges", so it re-expands rather than being
+    pruned.
+    """
+    config = oauth_delegated_config_from_connections(active.connections)
+
+    kept_grants: dict[str, list[str]] = {}
+    pruned_resources: list[str] = []
+    pruned_claims: list[dict[str, str]] = []
+
+    for raw_resource, grants in resource_grants.items():
+        resource = _clean(raw_resource)
+        cfg = config.resource_config(resource)
+        if cfg is None:
+            pruned_resources.append(resource)
+            continue
+        ceiling = {_clean(grant) for grant in (cfg.grants or ()) if _clean(grant)}
+        kept: list[str] = []
+        for grant in grants or ():
+            claim = _clean(grant)
+            if not claim:
+                continue
+            # A resource that enumerates no claims carries no ceiling.
+            if ceiling and claim not in ceiling:
+                pruned_claims.append({"resource": resource, "claim": claim})
+                continue
+            if claim not in kept:
+                kept.append(claim)
+        kept_grants[resource] = kept
+
+    selection = named_service_operations
+    pruned_operations: list[dict[str, str]] = []
+    if selection.is_exact:
+        surviving: dict[str, dict[str, list[str]]] = {}
+        for raw_resource, namespaces in selection.operations.items():
+            resource = _clean(raw_resource)
+            if resource not in kept_grants:
+                for namespace, operations in namespaces.items():
+                    for operation in operations:
+                        pruned_operations.append(
+                            {
+                                "resource": resource,
+                                "namespace": _namespace(namespace),
+                                "operation": _clean(operation),
+                            }
+                        )
+                continue
+            cfg = config.resource_config(resource)
+            block = getattr(cfg, "named_services", None)
+            offered = (
+                configured_named_service_operations(block)
+                if isinstance(block, Mapping) and block
+                else None
+            )
+            for raw_namespace, operations in namespaces.items():
+                namespace = _namespace(raw_namespace)
+                for raw_operation in operations:
+                    operation = _clean(raw_operation)
+                    if not operation:
+                        continue
+                    if offered is not None and operation not in offered.get(namespace, set()):
+                        pruned_operations.append(
+                            {
+                                "resource": resource,
+                                "namespace": namespace,
+                                "operation": operation,
+                            }
+                        )
+                        continue
+                    surviving.setdefault(resource, {}).setdefault(namespace, []).append(
+                        operation
+                    )
+        # Rebuilt only when something was dropped, so an untouched selection
+        # keeps its exact stored shape.
+        if pruned_operations:
+            selection = NamedServiceSelection.exact(surviving)
+
+    return Reconciled(
+        resource_grants=kept_grants,
+        named_service_operations=selection,
+        pruned_resources=pruned_resources,
+        pruned_claims=pruned_claims,
+        pruned_named_service_operations=pruned_operations,
+    )
+
+
+__all__ = ["Reconciled", "reconcile_selection"]

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/catalog/resolver.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/catalog/resolver.py
@@ -1,0 +1,131 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Elena Viter
+
+"""Redis-first catalog resolution with durable read-through.
+
+The active document is the ceiling every governed call intersects against. A
+historical version is loaded only when list/open must explain drift from a
+card's saved baseline.
+
+Three outcomes are kept distinct:
+
+    document        usable current or historical catalog
+    None            confirmed absent historical version -> baseline_missing
+    unavailable     cannot be validated -> structured 503 / drift unavailable
+
+Read-through may repair the serving projection. It never publishes catalog
+history and never derives a catalog from effective props.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.cache_settings import (
+    DelegatedCacheSettings,
+)
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.catalog.models import (
+    CatalogDocument,
+)
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.catalog.runtime_cache import (
+    DelegatedCatalogRuntimeCache,
+)
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.catalog.store import (
+    CatalogStorageError,
+    DelegatedCatalogStore,
+    validated_version_name,
+)
+
+_LOGGER = logging.getLogger("connection_hub.delegated_catalog.resolver")
+
+
+class CatalogUnavailable(RuntimeError):
+    """Current or historical catalog authority could not be established."""
+
+    def __init__(self, reason: str) -> None:
+        super().__init__(reason)
+        self.reason = reason
+
+
+class DelegatedCatalogResolver:
+    """Resolve registered catalog documents for request-serving code."""
+
+    def __init__(
+        self,
+        *,
+        cache: DelegatedCatalogRuntimeCache,
+        store: DelegatedCatalogStore,
+        settings: DelegatedCacheSettings | None = None,
+    ) -> None:
+        self._cache = cache
+        self._store = store
+        self._settings = settings or DelegatedCacheSettings()
+
+    async def resolve_active(self) -> CatalogDocument:
+        """The complete active catalog. Raises when it cannot be validated."""
+        try:
+            cached = await self._cache.read_active()
+        except Exception as exc:
+            raise CatalogUnavailable("cache_unavailable") from exc
+        if cached is not None:
+            return cached
+
+        try:
+            document = await self._store.read_active()
+        except Exception as exc:
+            raise CatalogUnavailable("durable_active_unreadable") from exc
+        if document is None:
+            raise CatalogUnavailable("active_catalog_not_registered")
+
+        try:
+            await self._cache.restore_active(
+                document, ttl_seconds=self._settings.catalog.active_cache_seconds
+            )
+        except Exception:
+            # The document is already validated; failing to repair the
+            # projection must not deny a request that can proceed.
+            _LOGGER.warning(
+                "[connection-hub.delegated-catalog] active restore failed version=%s",
+                document.version,
+                exc_info=True,
+            )
+        return document
+
+    async def resolve_version(self, version: str) -> CatalogDocument | None:
+        """A card's saved baseline. ``None`` means confirmed durable absence."""
+        try:
+            validated_version_name(version)
+        except CatalogStorageError:
+            # A card whose baseline cannot even be named has no comparable
+            # history; that is baseline_missing, not an availability failure.
+            return None
+
+        try:
+            cached = await self._cache.read_version(version)
+        except Exception as exc:
+            raise CatalogUnavailable("cache_unavailable") from exc
+        if cached is not None:
+            return cached
+
+        try:
+            document = await self._store.read_version(version)
+        except Exception as exc:
+            raise CatalogUnavailable("durable_version_unreadable") from exc
+        if document is None:
+            return None
+
+        try:
+            await self._cache.cache_version(
+                document, ttl_seconds=self._settings.catalog.version_cache_seconds
+            )
+        except Exception:
+            _LOGGER.warning(
+                "[connection-hub.delegated-catalog] version restore failed version=%s",
+                version,
+                exc_info=True,
+            )
+        return document
+
+
+__all__ = ["CatalogUnavailable", "DelegatedCatalogResolver"]

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/catalog/runtime_cache.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/catalog/runtime_cache.py
@@ -1,0 +1,131 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Elena Viter
+
+"""Redis serving projection for the delegated catalog.
+
+Two independent lifetimes live here. ``catalog:active`` is the ceiling every
+governed call intersects against; ``catalog:version:<version>`` holds immutable
+historical documents used only to explain drift. Neither carries authority
+beyond what the document itself says, and neither is extended by a read.
+
+Installation of ``catalog:active`` is a compare-and-set on the sortable version
+so a delayed restoration cannot replace a newer published catalog.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.cache_io import (
+    decode_cache_value,
+    encode_cache_value,
+)
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.catalog.models import (
+    CatalogDocument,
+    CatalogDocumentError,
+)
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.catalog.store import (
+    validated_version_name,
+)
+
+_LOGGER = logging.getLogger("connection_hub.delegated_catalog.cache")
+
+# Install the active document unless the cached one is already at least as new.
+# ARGV[3] == "1" lets a publication reinstall an equal version with a fresh
+# residency TTL; a restoration passes "0" so it never slides a live entry.
+_INSTALL_ACTIVE_LUA = """
+local existing = redis.call('GET', KEYS[1])
+if existing then
+  local ok, decoded = pcall(cjson.decode, existing)
+  if ok and type(decoded) == 'table' and decoded['version'] then
+    if decoded['version'] > ARGV[2] then
+      return 0
+    end
+    if decoded['version'] == ARGV[2] and ARGV[3] ~= '1' then
+      return 0
+    end
+  end
+end
+redis.call('SET', KEYS[1], ARGV[1], 'EX', ARGV[4])
+return 1
+"""
+
+
+class DelegatedCatalogRuntimeCache:
+    """Async Redis projection of the registered catalog documents."""
+
+    def __init__(self, redis: Any, *, tenant: str, project: str) -> None:
+        self._redis = redis
+        self._tenant = str(tenant or "").strip()
+        self._project = str(project or "").strip()
+
+    def _key(self, suffix: str) -> str:
+        return f"{self._tenant}:{self._project}:kdcube:delegated-catalog:{suffix}"
+
+    def active_key(self) -> str:
+        return self._key("active")
+
+    def version_key(self, version: str) -> str:
+        return self._key(f"version:{validated_version_name(version)}")
+
+    async def read_active(self) -> CatalogDocument | None:
+        return await self._read(self.active_key(), label="active")
+
+    async def read_version(self, version: str) -> CatalogDocument | None:
+        return await self._read(self.version_key(version), label=f"version:{version}")
+
+    async def publish_active(self, document: CatalogDocument, *, ttl_seconds: int) -> bool:
+        """Install a newly registered active document, refreshing residency."""
+        return await self._install_active(document, ttl_seconds=ttl_seconds, allow_equal=True)
+
+    async def restore_active(self, document: CatalogDocument, *, ttl_seconds: int) -> bool:
+        """Repopulate after a miss. Never displaces a newer or equal live entry."""
+        return await self._install_active(document, ttl_seconds=ttl_seconds, allow_equal=False)
+
+    async def cache_version(self, document: CatalogDocument, *, ttl_seconds: int) -> None:
+        """Immutable historical documents need no compare: identity is the key."""
+        document.verify()
+        await self._redis.set(
+            self.version_key(document.version),
+            encode_cache_value(document.to_dict()),
+            ex=max(1, int(ttl_seconds)),
+        )
+
+    async def _install_active(
+        self, document: CatalogDocument, *, ttl_seconds: int, allow_equal: bool
+    ) -> bool:
+        document.verify()
+        result = await self._redis.eval(
+            _INSTALL_ACTIVE_LUA,
+            1,
+            self.active_key(),
+            encode_cache_value(document.to_dict()),
+            document.version,
+            "1" if allow_equal else "0",
+            str(max(1, int(ttl_seconds))),
+        )
+        installed = bool(int(result or 0))
+        if not installed:
+            _LOGGER.info(
+                "[connection-hub.delegated-catalog] refused active install version=%s allow_equal=%s",
+                document.version,
+                allow_equal,
+            )
+        return installed
+
+    async def _read(self, key: str, *, label: str) -> CatalogDocument | None:
+        payload = decode_cache_value(await self._redis.get(key))
+        if payload is None:
+            return None
+        try:
+            return CatalogDocument.from_mapping(payload)
+        except CatalogDocumentError as exc:
+            # Unusable cache data, not authority: the caller read-throughs.
+            _LOGGER.warning(
+                "[connection-hub.delegated-catalog] discarding cached %s: %s", label, exc.reason
+            )
+            return None
+
+
+__all__ = ["DelegatedCatalogRuntimeCache"]

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/catalog/source.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/catalog/source.py
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Elena Viter
+
+"""The catalog body source: exact effective Connection Hub ``connections`` props.
+
+Only ``on_app_deploy`` reads this. Request paths consume the registered catalog
+document instead.
+"""
+
+from __future__ import annotations
+
+import copy
+from typing import Any, Mapping
+
+
+def connections_from_props(props: Any) -> dict[str, Any]:
+    """The ``connections`` mapping exactly as it appears in effective props."""
+    if not isinstance(props, Mapping):
+        return {}
+    raw = props.get("connections")
+    if not isinstance(raw, Mapping):
+        return {}
+    return copy.deepcopy(dict(raw))
+
+
+__all__ = ["connections_from_props"]

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/catalog/store.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/catalog/store.py
@@ -1,0 +1,124 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Elena Viter
+
+"""Durable storage for immutable catalog versions and the active catalog.
+
+``active.json`` is self-contained: one read yields the active version, its hash,
+and the exact ``connections`` mapping. The immutable file under ``versions/``
+preserves the same document for card baselines and provenance.
+
+Absence and unreadability are different outcomes. A missing object returns
+``None``; an unreadable or malformed one raises, so a caller can answer
+``baseline_missing`` and ``unavailable`` distinctly.
+"""
+
+from __future__ import annotations
+
+import os
+import pathlib
+import re
+from typing import Protocol
+
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.catalog.models import (
+    CatalogDocument,
+)
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.durable_io import (
+    DurableStorageError,
+    path_is_file,
+    read_json_or_none,
+    write_json_atomic,
+)
+
+CATALOG_DIRNAME = "delegated-catalog"
+CATALOG_LAYOUT_VERSION = "v1"
+ACTIVE_FILENAME = "active.json"
+VERSIONS_DIRNAME = "versions"
+
+_VERSION_PATTERN = re.compile(
+    r"^delegated_catalog_[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]{2}-[0-9]{2}-[0-9]{2}-[0-9]{3}_[0-9a-f]{12}$"
+)
+
+
+class CatalogStorageError(DurableStorageError):
+    """Durable catalog storage could not be read or written."""
+
+
+def validated_version_name(version: str) -> str:
+    """Reject anything that is not a well-formed version identity.
+
+    The value reaches storage from a stored card field, so it is checked before
+    it is interpolated into a path.
+    """
+    value = str(version or "").strip()
+    if not _VERSION_PATTERN.match(value):
+        raise CatalogStorageError("version_name_invalid")
+    return value
+
+
+class DelegatedCatalogStore(Protocol):
+    async def read_active(self) -> CatalogDocument | None: ...
+
+    async def read_version(self, version: str) -> CatalogDocument | None: ...
+
+    async def write_version(self, document: CatalogDocument) -> None: ...
+
+    async def publish_active(self, document: CatalogDocument) -> None: ...
+
+    async def version_exists(self, version: str) -> bool: ...
+
+
+class BundleStorageDelegatedCatalogStore:
+    """``DelegatedCatalogStore`` over a shared bundle-storage root.
+
+    Local filesystems and shared mounts such as EFS are both implementations of
+    that root; the catalog model names neither.
+    """
+
+    def __init__(self, storage_root: str | os.PathLike[str]) -> None:
+        self._root = pathlib.Path(storage_root) / CATALOG_DIRNAME / CATALOG_LAYOUT_VERSION
+
+    @property
+    def root(self) -> pathlib.Path:
+        return self._root
+
+    def active_path(self) -> pathlib.Path:
+        return self._root / ACTIVE_FILENAME
+
+    def version_path(self, version: str) -> pathlib.Path:
+        return self._root / VERSIONS_DIRNAME / f"{validated_version_name(version)}.json"
+
+    async def read_active(self) -> CatalogDocument | None:
+        return await self._read_document(self.active_path())
+
+    async def read_version(self, version: str) -> CatalogDocument | None:
+        return await self._read_document(self.version_path(version))
+
+    async def write_version(self, document: CatalogDocument) -> None:
+        document.verify()
+        await write_json_atomic(self.version_path(document.version), document.to_dict())
+
+    async def publish_active(self, document: CatalogDocument) -> None:
+        document.verify()
+        await write_json_atomic(self.active_path(), document.to_dict())
+
+    async def version_exists(self, version: str) -> bool:
+        return await path_is_file(self.version_path(version))
+
+    @staticmethod
+    async def _read_document(path: pathlib.Path) -> CatalogDocument | None:
+        payload = await read_json_or_none(path)
+        if payload is None:
+            return None
+        return CatalogDocument.from_mapping(payload)
+
+
+__all__ = [
+    "ACTIVE_FILENAME",
+    "BundleStorageDelegatedCatalogStore",
+    "CATALOG_DIRNAME",
+    "CATALOG_LAYOUT_VERSION",
+    "CatalogStorageError",
+    "DelegatedCatalogStore",
+    "VERSIONS_DIRNAME",
+    "validated_version_name",
+]

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/consent_denial.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/consent_denial.py
@@ -60,6 +60,8 @@ def connection_hub_grant_url(
     hub_bundle_id: str = "connection-hub@1-0",
     account_id: str = "",
     account_claim: str = "",
+    namespace: str = "",
+    operation: str = "",
 ) -> str:
     """An absolute Connection Hub deep link that lands on the Delegated by
     KDCube tab with THIS client's access request focused (the pending pane:
@@ -70,6 +72,9 @@ def connection_hub_grant_url(
     landed there, names the exact account+claim to tick, and opens that
     provider's section — ticking is always the user's own action, nothing is
     pre-checked.
+
+    ``namespace`` / ``operation`` name the inner capability the pane
+    pre-selects.
 
     Openable outside the app origin — an external agent (Claude Code) relays
     it verbatim; the user signs in with their platform credentials and sees the
@@ -113,6 +118,10 @@ def connection_hub_grant_url(
         "resource": resource,
         "claims": ",".join(str(c) for c in claims if str(c or "").strip()),
     }
+    if str(namespace or "").strip():
+        query["namespace"] = str(namespace).strip()
+    if str(operation or "").strip():
+        query["operation"] = str(operation).strip()
     if str(account_id or "").strip():
         query["account_id"] = str(account_id).strip()
     if str(account_claim or "").strip():
@@ -181,6 +190,8 @@ def agent_grant_consent_denial(
         client_id=client_id or external_client_id,
         resource=resource,
         claims=missing_list,
+        namespace=namespace,
+        operation=operation,
     )
     if not client_id and not external_client_id:
         LOGGER.info(
@@ -200,6 +211,7 @@ def agent_grant_consent_denial(
         # Self-describing contract: the block names its namespace so a consumer
         # never re-derives it.
         "namespace": namespace,
+        "operation": operation,
     }
     if hub_url:
         consent["connection_hub_url"] = hub_url
@@ -208,9 +220,16 @@ def agent_grant_consent_denial(
         # The one-click grant action rides only for hosted agents today; an
         # external client's approval flows through the hub link (its record
         # extension is the hub's own operation).
+        grant_payload: dict[str, Any] = {
+            "client_id": client_id,
+            "resource": resource,
+            "claims": missing_list,
+        }
+        if namespace and operation:
+            grant_payload["named_service_operations"] = {namespace: [operation]}
         consent["grant"] = {
             "operation": "delegated_agent_grant_create",
-            "payload": {"client_id": client_id, "resource": resource, "claims": missing_list},
+            "payload": grant_payload,
         }
         denial["next_step"] = (
             "The user extends this agent's grant with the missing access in "

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/credential_view.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/credential_view.py
@@ -39,6 +39,13 @@ def _as_list(value: Any) -> tuple[str, ...]:
     return ()
 
 
+def _as_int(value: Any) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
 def _normalize_account_scope(value: Any) -> dict[str, dict[str, tuple[str, ...]]]:
     """Nested per-account claim binding {provider: {account_id: (claims...)}}.
 
@@ -89,12 +96,19 @@ class DelegatedCredentialView:
     identity_scope: str = ""
     grantor_user_id: str = ""
     registry_access_id: str = ""
+    # Card provenance, for denials that must name which card and which catalog
+    # generation produced the stored selection.
+    card_revision: int = 0
+    catalog_version: str = ""
     resource_grants: Mapping[str, tuple[str, ...]] = field(default_factory=dict)
     grants: frozenset[str] = field(default_factory=frozenset)
     operations: tuple[str, ...] = ()
     tools: tuple[str, ...] = ()
     grantor_roles: tuple[str, ...] = ()
     named_services: Mapping[str, Any] = field(default_factory=dict)
+    # Whether the card carried a materialized boundary at all. An empty tree is
+    # a real boundary; a missing one is a card written before the field.
+    named_services_present: bool = False
     # Per-agent, per-account claim binding:
     # {provider_id: {account_id: (claims...)}}. For a provider, which connected
     # account(s) this client may use AND, per account, the claims it may use
@@ -241,6 +255,8 @@ class DelegatedCredentialView:
                 cred_attrs.get("grantor_subject") or cred_attrs.get("grantor_user_id") or ""
             ).strip(),
             registry_access_id=str(grant_record.get("registry_access_id") or "").strip(),
+            card_revision=_as_int(grant_record.get("card_revision")),
+            catalog_version=str(grant_record.get("catalog_version") or "").strip(),
             resource_grants=resource_grants,
             grants=frozenset(g for g in grants if g),
             operations=_as_list(grant_record.get("operations") or cred_attrs.get("operations")),
@@ -251,6 +267,7 @@ class DelegatedCredentialView:
                 if isinstance(grant_record.get("named_services"), Mapping)
                 else {}
             ),
+            named_services_present=isinstance(grant_record.get("named_services"), Mapping),
             account_scope=_normalize_account_scope(
                 grant_record.get("account_scope")
                 if isinstance(grant_record.get("account_scope"), Mapping)

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/durable_io.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/durable_io.py
@@ -1,0 +1,108 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Elena Viter
+
+"""Atomic JSON object IO for durable delegated-access storage.
+
+Shared by the catalog and card stores. Absence, unreadability, and malformed
+content are three distinct outcomes so callers can answer "confirmed absent"
+and "unavailable" differently.
+
+Filesystem work runs off the event loop. Publication is a temporary file
+followed by a same-directory rename, which is atomic on local filesystems and
+on shared mounts such as EFS.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import pathlib
+from typing import Any, Mapping
+
+
+class DurableStorageError(RuntimeError):
+    """Durable storage could not be read or written."""
+
+    def __init__(self, reason: str) -> None:
+        super().__init__(reason)
+        self.reason = reason
+
+
+class DurableDecodeError(ValueError):
+    """A durable object exists but is not usable JSON."""
+
+    def __init__(self, reason: str) -> None:
+        super().__init__(reason)
+        self.reason = reason
+
+
+async def read_json_or_none(path: pathlib.Path) -> Any | None:
+    """Parsed JSON, or ``None`` when the object is confirmed absent."""
+    result = await asyncio.to_thread(_read_text, path)
+    if result is None:
+        return None
+    if isinstance(result, OSError):
+        raise DurableStorageError("read_failed")
+    try:
+        return json.loads(result)
+    except ValueError as exc:
+        raise DurableDecodeError("object_not_json") from exc
+
+
+async def write_json_atomic(path: pathlib.Path, payload: Mapping[str, Any]) -> None:
+    text = json.dumps(payload, ensure_ascii=True, sort_keys=True, indent=2) + "\n"
+    try:
+        await asyncio.to_thread(_write_text_atomic, path, text)
+    except OSError as exc:
+        raise DurableStorageError("write_failed") from exc
+
+
+async def list_child_names(path: pathlib.Path) -> list[str]:
+    """Sorted child names, or an empty list when the directory is absent."""
+    result = await asyncio.to_thread(_list_children, path)
+    if isinstance(result, OSError):
+        raise DurableStorageError("list_failed")
+    return result
+
+
+async def path_is_file(path: pathlib.Path) -> bool:
+    return await asyncio.to_thread(path.is_file)
+
+
+def _read_text(path: pathlib.Path) -> str | OSError | None:
+    try:
+        return path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return None
+    except OSError as exc:
+        return exc
+
+
+def _write_text_atomic(path: pathlib.Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = path.with_name(f".{path.name}.tmp.{os.getpid()}.{os.urandom(6).hex()}")
+    try:
+        tmp_path.write_text(text, encoding="utf-8")
+        tmp_path.replace(path)
+    finally:
+        tmp_path.unlink(missing_ok=True)
+
+
+def _list_children(path: pathlib.Path) -> list[str] | OSError:
+    try:
+        return sorted(child.name for child in path.iterdir())
+    except FileNotFoundError:
+        return []
+    except OSError as exc:
+        return exc
+
+
+__all__ = [
+    "DurableDecodeError",
+    "DurableStorageError",
+    "list_child_names",
+    "path_is_file",
+    "read_json_or_none",
+    "write_json_atomic",
+]

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/live_grant.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/live_grant.py
@@ -77,8 +77,8 @@ async def resolve_live_grant_card(
         try:
             entry = await cache.read(pointer)
         except CardCacheUnusable as exc:
-            # The guard has no durable source by design, so a damaged
-            # projection is unavailability, not a revoked card.
+            # Without a durable source a damaged projection cannot be repaired,
+            # so it is unavailability rather than a revoked card.
             raise LiveGrantCardError(exc.reason) from exc
         except Exception as exc:
             raise LiveGrantCardError("lookup_unavailable") from exc

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/live_grant.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/live_grant.py
@@ -5,21 +5,27 @@
 
 from __future__ import annotations
 
-import json
+import hashlib
 import time
-from typing import Any, Mapping
+from typing import Any
 
-from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.automation_access import (
-    ACCESS_SOURCE_AGENT,
-    ACCESS_SOURCE_MANUAL,
-    ACCESS_SOURCE_OAUTH,
-    AUTOMATION_ACCESS_SCHEMA,
-    AutomationAccessRecord,
-    automation_record_key,
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.cards.cache import (
+    CardCacheUnusable,
+    DelegatedCardRuntimeCache,
+)
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.cards.model import (
+    CARD_STATE_ACTIVE,
+    CardAuthority,
+)
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.cards.resolver import (
+    CardUnavailable,
+    DelegatedCardResolver,
 )
 from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.credential_view import (
     resource_matches,
 )
+
+ACCESS_SOURCES = ("manual", "oauth", "agent")
 
 
 class LiveGrantCardError(RuntimeError):
@@ -46,48 +52,56 @@ async def resolve_live_grant_card(
     expected_client_id: str = "",
     expected_grantor_subject: str = "",
     expected_delegate_subject: str = "",
-) -> AutomationAccessRecord | None:
+    card_store: Any = None,
+) -> CardAuthority | None:
     """Return the current valid card, None when revoked/expired, or raise.
 
     A pointer-bearing token has no snapshot fallback. Store failures, malformed
-    records, and binding mismatches are authorization failures.
+    records, and binding mismatches are authorization failures. A card whose
+    Redis projection is missing is restored from its durable revision when a
+    card store and the binding's grantor are both available.
     """
 
     pointer = _required_text(access_id, "access_id_missing")
-    try:
-        raw = await redis.get(automation_record_key(tenant, project, pointer))
-    except Exception as exc:
-        raise LiveGrantCardError("lookup_unavailable") from exc
-    if raw is None:
+    cache = DelegatedCardRuntimeCache(redis, tenant=tenant, project=project)
+    grantor = str(expected_grantor_subject or "").strip()
+    subject_hash = hashlib.sha256(grantor.encode("utf-8")).hexdigest() if grantor else ""
+
+    if card_store is not None and subject_hash:
+        resolver = DelegatedCardResolver(cache=cache, store=card_store)
+        try:
+            record = await resolver.resolve(subject_hash=subject_hash, access_id=pointer)
+        except CardUnavailable as exc:
+            raise LiveGrantCardError(exc.reason) from exc
+    else:
+        try:
+            entry = await cache.read(pointer)
+        except CardCacheUnusable as exc:
+            # The guard has no durable source by design, so a damaged
+            # projection is unavailability, not a revoked card.
+            raise LiveGrantCardError(exc.reason) from exc
+        except Exception as exc:
+            raise LiveGrantCardError("lookup_unavailable") from exc
+        if entry is None:
+            return None
+        if entry.is_updating:
+            raise LiveGrantCardError("card_updating")
+        if entry.is_revoked:
+            return None
+        record = entry.authority
+
+    if record is None:
         return None
-    try:
-        payload = json.loads(raw)
-    except Exception as exc:
-        raise LiveGrantCardError("malformed_json") from exc
-    if not isinstance(payload, Mapping):
-        raise LiveGrantCardError("record_not_object")
-    if str(payload.get("schema") or "").strip() != AUTOMATION_ACCESS_SCHEMA:
-        raise LiveGrantCardError("schema_mismatch")
-    if not isinstance(payload.get("resource_grants"), Mapping):
-        raise LiveGrantCardError("resource_grants_invalid")
-    if not isinstance(payload.get("operations"), list):
-        raise LiveGrantCardError("operations_invalid")
-    for field_name in ("account_scope", "named_service_operations", "named_services"):
-        value = payload.get(field_name)
-        if value is not None and not isinstance(value, Mapping):
-            raise LiveGrantCardError(f"{field_name}_invalid")
-    try:
-        record = AutomationAccessRecord.from_mapping(payload)
-    except Exception as exc:
-        raise LiveGrantCardError("record_invalid") from exc
 
     _required_text(record.client_id, "client_id_missing")
     _required_text(record.grantor_subject, "grantor_subject_missing")
     _required_text(record.delegate_subject, "delegate_subject_missing")
     if record.access_id != pointer:
         raise LiveGrantCardError("access_id_mismatch")
-    if record.source not in {ACCESS_SOURCE_MANUAL, ACCESS_SOURCE_OAUTH, ACCESS_SOURCE_AGENT}:
+    if record.source not in ACCESS_SOURCES:
         raise LiveGrantCardError("source_invalid")
+    if record.state != CARD_STATE_ACTIVE:
+        return None
     if record.expires_at <= 0:
         raise LiveGrantCardError("expiry_missing")
     if record.expires_at <= int(time.time()):
@@ -106,7 +120,7 @@ async def resolve_live_grant_card(
 
 
 def live_grants_for_resource(
-    record: AutomationAccessRecord,
+    record: CardAuthority,
     resource: str,
 ) -> tuple[str, ...] | None:
     """Return the live grant union for a resource, preserving an empty grant."""

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/named_service_policy.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/named_service_policy.py
@@ -47,6 +47,41 @@ def operation_grants(policy: Mapping[str, Any], fallback: Mapping[str, Any]) -> 
     )
 
 
+def configured_named_service_operations(
+    config: Mapping[str, Any] | None,
+) -> dict[str, set[str]]:
+    """``namespace -> operations`` a named-service descriptor configures.
+
+    Namespace keys are normalized the way a selection normalizes them;
+    operations keep the descriptor's own spelling.
+    """
+    namespaces = config.get("namespaces") if isinstance(config, Mapping) else None
+    if not isinstance(namespaces, Mapping):
+        return {}
+    out: dict[str, set[str]] = {}
+    for namespace, raw_policy in namespaces.items():
+        name = clean_text(namespace).lower().rstrip(":")
+        if not name or not isinstance(raw_policy, Mapping):
+            continue
+        operations = out.setdefault(name, set())
+        raw_tools = raw_policy.get("tools")
+        raw_tools = dict(raw_tools or {}) if isinstance(raw_tools, Mapping) else {}
+        for tool_name, raw_tool_policy in raw_tools.items():
+            if not isinstance(raw_tool_policy, Mapping):
+                continue
+            operation_policies = raw_tool_policy.get("operations")
+            if isinstance(operation_policies, Mapping) and operation_policies:
+                for operation in operation_policies:
+                    value = clean_text(operation)
+                    if value:
+                        operations.add(value)
+                continue
+            value = clean_text(raw_tool_policy.get("operation") or tool_name)
+            if value:
+                operations.add(value)
+    return out
+
+
 def narrow_named_service_config(
     *,
     config: Mapping[str, Any],
@@ -206,6 +241,7 @@ def named_service_policy_for_resource(
 __all__ = [
     "as_string_list",
     "clean_text",
+    "configured_named_service_operations",
     "merge_named_service_configs",
     "named_service_policy_for_resource",
     "narrow_named_service_config",

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/named_service_policy.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/named_service_policy.py
@@ -49,12 +49,20 @@ def operation_grants(policy: Mapping[str, Any], fallback: Mapping[str, Any]) -> 
 
 def configured_named_service_operations(
     config: Mapping[str, Any] | None,
+    *,
+    grants: Iterable[str] | None = None,
 ) -> dict[str, set[str]]:
     """``namespace -> operations`` a named-service descriptor configures.
 
     Namespace keys are normalized the way a selection normalizes them;
     operations keep the descriptor's own spelling.
+
+    With ``grants``, only operations those claims authorize are returned. A
+    boundary materialized from a wildcard is the descriptor tree unfiltered —
+    the claim check happens per call — so anything turning a boundary back into
+    a storable selection has to apply that filter itself.
     """
+    available = set(as_string_list(list(grants))) if grants is not None else None
     namespaces = config.get("namespaces") if isinstance(config, Mapping) else None
     if not isinstance(namespaces, Mapping):
         return {}
@@ -71,15 +79,53 @@ def configured_named_service_operations(
                 continue
             operation_policies = raw_tool_policy.get("operations")
             if isinstance(operation_policies, Mapping) and operation_policies:
-                for operation in operation_policies:
+                for operation, raw_operation_policy in operation_policies.items():
                     value = clean_text(operation)
-                    if value:
-                        operations.add(value)
+                    if not value:
+                        continue
+                    if available is not None:
+                        required = operation_grants(
+                            dict(raw_operation_policy)
+                            if isinstance(raw_operation_policy, Mapping)
+                            else {},
+                            dict(raw_tool_policy),
+                        )
+                        if not required.issubset(available):
+                            continue
+                    operations.add(value)
                 continue
             value = clean_text(raw_tool_policy.get("operation") or tool_name)
-            if value:
-                operations.add(value)
+            if not value:
+                continue
+            if available is not None and not operation_grants(
+                dict(raw_tool_policy), {}
+            ).issubset(available):
+                continue
+            operations.add(value)
     return out
+
+
+def boundary_permits_operation(
+    named_services: Mapping[str, Any] | None,
+    *,
+    namespace: str,
+    operation: str,
+) -> bool:
+    """Whether a card's materialized boundary covers one inner operation.
+
+    The boundary is the card's selection already expanded under the catalog
+    version it was saved against, so it answers every stored state without
+    re-deriving one: an exact map narrowed it, ``{}`` produced an empty tree,
+    and ``"*"`` produced the expansion of that generation — which is why a
+    wildcard card does not gain operations added later.
+
+    An absent boundary is not an empty one. A pre-encoding record carries no
+    tree and is not decided here; its caller owns that compatibility path.
+    """
+    offered = configured_named_service_operations(named_services)
+    return clean_text(operation) in offered.get(
+        clean_text(namespace).lower().rstrip(":"), set()
+    )
 
 
 def narrow_named_service_config(
@@ -240,6 +286,7 @@ def named_service_policy_for_resource(
 
 __all__ = [
     "as_string_list",
+    "boundary_permits_operation",
     "clean_text",
     "configured_named_service_operations",
     "merge_named_service_configs",

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/oauth/config.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/oauth/config.py
@@ -171,6 +171,36 @@ class OAuthDelegatedClientConfig:
         }
 
     def resource_config(self, resource: str | None) -> OAuthDelegatedResourceConfig | None:
+        """The row that serves a REQUESTED resource.
+
+        The all-resource row answers whatever no specific row claims, which is
+        what makes it usable as the declared admin surface at issuance time.
+        """
+        return self._match_resource(resource, wildcard_row_is_fallback=True)
+
+    def card_selector_config(
+        self,
+        selector: str | None,
+        *,
+        request_resource: str = "",
+    ) -> OAuthDelegatedResourceConfig | None:
+        """The row that governs a CARD holding ``selector``.
+
+        The concrete request URL still picks the row, because a card selector
+        may be broader than the row it was granted through. What the selector
+        decides is whether the all-resource row is reachable at all: it is a
+        declared admin surface, answering only a card that holds ``*``. A card
+        whose door left the catalog therefore matches nothing, which is the
+        removal the guard, Save pruning, and drift each have to report.
+        """
+        return self._match_resource(
+            str(request_resource or "").strip() or selector,
+            wildcard_row_is_fallback=str(selector or "").strip().rstrip("/") == "*",
+        )
+
+    def _match_resource(
+        self, resource: str | None, *, wildcard_row_is_fallback: bool
+    ) -> OAuthDelegatedResourceConfig | None:
         text = str(resource or "").strip().rstrip("/")
         if not text:
             return None
@@ -180,12 +210,15 @@ class OAuthDelegatedClientConfig:
             if pattern == text:
                 return item
             if pattern == "*":
+                # Deferred so declaration order cannot let it shadow a specific
+                # row; whether it is reachable at all is the caller's question.
                 fallback = item
                 continue
             if fnmatch(text, pattern):
                 return item
-        if fallback is not None and fnmatch(text, fallback.resource.rstrip("/")):
-            return fallback
+        if wildcard_row_is_fallback and fallback is not None:
+            if fnmatch(text, fallback.resource.rstrip("/")):
+                return fallback
         return None
 
     def supported_scopes(self, resource: str | None = None) -> tuple[str, ...]:

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/oauth/config.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/oauth/config.py
@@ -579,6 +579,21 @@ def _parse_config(raw: Any, *, settings: Any | None = None) -> OAuthDelegatedCli
     )
 
 
+def oauth_delegated_config_from_connections(
+    connections: Mapping[str, Any] | None,
+) -> OAuthDelegatedClientConfig:
+    """Parse a ``connections`` mapping with the same reader request paths use.
+
+    The mapping comes from a registered catalog document, not from live props,
+    so this never consults request or app state.
+    """
+    node = connections if isinstance(connections, Mapping) else {}
+    delegated = node.get("delegated_credentials")
+    delegated = delegated if isinstance(delegated, Mapping) else {}
+    oauth = delegated.get("oauth")
+    return _parse_config(oauth if isinstance(oauth, Mapping) else {})
+
+
 def oauth_delegated_config(source: Any | None = None) -> OAuthDelegatedClientConfig:
     """Resolve OAuth delegated-credential config from app state or assembly.
 

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/oauth/consent.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/oauth/consent.py
@@ -34,6 +34,10 @@ from kdcube_ai_app.apps.chat.sdk.solutions.named_services_providers.boundary_pol
     NamedServiceBoundaryCatalog,
 )
 
+# Version of the consent view model. A renderer states the version it
+# implements; an absent or mismatched version is refused, not rendered.
+CONSENT_CONTRACT_VERSION = "2026-08-20.1"
+
 CONSENT_AUTHORIZE_FIELD_NAMES: tuple[str, ...] = (
     "client_id",
     "redirect_uri",
@@ -202,6 +206,65 @@ def named_service_rows_for_scopes(
     return out
 
 
+def named_service_selection_rows(
+    scopes: Iterable[str],
+    *,
+    config: OAuthDelegatedClientConfig | None = None,
+    resource: str | None = None,
+) -> List[dict]:
+    """Selectable named-service operations for the consent view model.
+
+    Carries the machine values a submission needs — the namespace key and the
+    operation id — beside the labels, and the claims each operation requires.
+    """
+    cfg = config or oauth_delegated_config()
+    resource_cfg = cfg.resource_config(resource)
+    if resource_cfg is None or not isinstance(resource_cfg.named_services, Mapping):
+        return []
+    allowed = {str(scope or "").strip() for scope in (scopes or ()) if str(scope or "").strip()}
+    out: list[dict] = []
+    seen: set[tuple[str, str]] = set()
+    catalog = NamedServiceBoundaryCatalog(resource_cfg.named_services)
+    for namespace in catalog.list_public():
+        key = str(namespace.get("namespace") or "").strip()
+        namespace_label = str(namespace.get("label") or key or "").strip()
+        tools = namespace.get("tools")
+        if not key or not isinstance(tools, Mapping):
+            continue
+        for tool_name, raw_tool in tools.items():
+            tool = raw_tool if isinstance(raw_tool, Mapping) else {}
+            operations = tool.get("operations")
+            entries = (
+                list(operations.items())
+                if isinstance(operations, Mapping) and operations
+                else [(str(tool.get("operation") or tool_name).strip(), tool)]
+            )
+            for operation, raw_policy in entries:
+                operation_id = str(operation or "").strip()
+                policy = raw_policy if isinstance(raw_policy, Mapping) else {}
+                grants = [
+                    str(item).strip()
+                    for item in (policy.get("grants") or tool.get("grants") or ())
+                    if str(item).strip()
+                ]
+                if not operation_id or (grants and not set(grants).issubset(allowed)):
+                    continue
+                if (key, operation_id) in seen:
+                    continue
+                seen.add((key, operation_id))
+                out.append({
+                    "namespace": key,
+                    "namespace_label": namespace_label or key,
+                    "operation": operation_id,
+                    "label": str(policy.get("label") or operation_id or tool_name).strip(),
+                    "description": str(
+                        policy.get("description") or tool.get("description") or ""
+                    ).strip(),
+                    "grants": grants,
+                })
+    return out
+
+
 def _brand_monogram(brand: str) -> str:
     """1-2 uppercase initials from the brand name (first letters of first two words)."""
     words = [w for w in brand.split() if w]
@@ -350,6 +413,7 @@ def render_consent_html(
     seeded_account_scope: Mapping[str, Any] | None = None,
     connection_hub_url: str = "",
     accounts_needed: AccountRequirements | None = None,
+    catalog_version: str = "",
 ) -> str:
     esc = _html.escape
     # Base URL of the Connection Hub widget (no query). The consent page must
@@ -360,7 +424,6 @@ def render_consent_html(
     hub_base = str(connection_hub_url or "").strip().rstrip("?&")
     tools = tools_for_scopes(req.scopes, config=config, resource=req.resource)
     platform_edge_grants = platform_edge_grants_for_scopes(req.scopes, config=config)
-    named_service_rows = named_service_rows_for_scopes(req.scopes, config=config, resource=req.resource)
     monogram = _brand_monogram(brand)
 
     tool_rows = _render_grouped((
@@ -383,20 +446,33 @@ def render_consent_html(
         for grant, label, desc in platform_edge_grants
     ), css_class="edge") or '    <p class="desc">No platform-authority grants are requested.</p>'
 
+    selection_rows = named_service_selection_rows(
+        req.scopes, config=config, resource=req.resource,
+    )
     namespace_rows = _render_grouped((
         (
-            namespace,
-            f'    <div class="namespace-row"><b>{esc(label)}</b>'
-            f'<span class="desc">{esc(desc)}</span>'
-            f'<span class="grants">{esc(", ".join(grants) or "none")}</span></div>'
+            row["namespace_label"],
+            f'    <label class="namespace-row">'
+            f'<input type="checkbox" name="named_service_operations" '
+            f'value="{esc(row["namespace"])}:{esc(row["operation"])}"> '
+            f'<span class="row-text"><b>{esc(row["label"])}</b>'
+            f'<span class="desc">{esc(row["description"])}</span>'
+            f'<span class="grants">{esc(", ".join(row["grants"]) or "none")}</span></span></label>'
         )
-        for namespace, label, desc, grants in named_service_rows
+        for row in selection_rows
     ), css_class="namespace")
     namespace_section = ""
     if namespace_rows:
         namespace_section = f"""
-    <p class="pick">Named-service namespace boundaries:</p>
-    <p class="desc">These are the concrete namespace operations covered by the selected grants.</p>
+    <p class="pick">Named-service operations:</p>
+    <p class="desc">Nothing is selected by default. A claim lets an operation
+    through the claim gate; it does not select the operation. Selecting none
+    connects this client without named-service access — it can be widened later
+    in Connection Hub.</p>
+    <label class="namespace-row"><input type="checkbox" name="named_service_operations_all" value="1">
+    <span class="row-text"><b>Every operation offered right now</b>
+    <span class="desc">Bound to the current service catalog; operations added
+    later are not included.</span></span></label>
 {namespace_rows}
 """
 
@@ -500,6 +576,8 @@ def render_consent_html(
         ("code_challenge", req.code_challenge),
         ("code_challenge_method", req.code_challenge_method),
         ("csrf_token", csrf_token),
+        ("consent_contract_version", CONSENT_CONTRACT_VERSION),
+        ("expected_catalog_version", catalog_version),
     ]
     hidden = "\n".join(
         f'    <input type="hidden" name="{esc(k)}" value="{esc(v)}">' for k, v in hidden_fields

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/oauth/consent.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/oauth/consent.py
@@ -36,7 +36,7 @@ from kdcube_ai_app.apps.chat.sdk.solutions.named_services_providers.boundary_pol
 
 # Version of the consent view model. A renderer states the version it
 # implements; an absent or mismatched version is refused, not rendered.
-CONSENT_CONTRACT_VERSION = "2026-08-20.1"
+CONSENT_CONTRACT_VERSION = "2026-08-25.1"
 
 CONSENT_AUTHORIZE_FIELD_NAMES: tuple[str, ...] = (
     "client_id",
@@ -211,12 +211,21 @@ def named_service_selection_rows(
     *,
     config: OAuthDelegatedClientConfig | None = None,
     resource: str | None = None,
+    seeded: Mapping[str, Iterable[str]] | None = None,
 ) -> List[dict]:
     """Selectable named-service operations for the consent view model.
 
     Carries the machine values a submission needs — the namespace key and the
     operation id — beside the labels, and the claims each operation requires.
+
+    ``held`` states whether the client's existing card already covers the
+    operation. A submission replaces what the card held, so a renderer that
+    cannot tell the two apart cannot offer an informed choice.
     """
+    held_by_namespace = {
+        str(namespace).strip(): {str(op).strip() for op in (operations or ())}
+        for namespace, operations in dict(seeded or {}).items()
+    }
     cfg = config or oauth_delegated_config()
     resource_cfg = cfg.resource_config(resource)
     if resource_cfg is None or not isinstance(resource_cfg.named_services, Mapping):
@@ -256,6 +265,7 @@ def named_service_selection_rows(
                     "namespace": key,
                     "namespace_label": namespace_label or key,
                     "operation": operation_id,
+                    "held": operation_id in held_by_namespace.get(key, set()),
                     "label": str(policy.get("label") or operation_id or tool_name).strip(),
                     "description": str(
                         policy.get("description") or tool.get("description") or ""
@@ -411,6 +421,7 @@ def render_consent_html(
     return_to: str = "",
     connected_accounts: list | None = None,
     seeded_account_scope: Mapping[str, Any] | None = None,
+    seeded_named_service_operations: Mapping[str, Any] | None = None,
     connection_hub_url: str = "",
     accounts_needed: AccountRequirements | None = None,
     catalog_version: str = "",
@@ -447,22 +458,55 @@ def render_consent_html(
     ), css_class="edge") or '    <p class="desc">No platform-authority grants are requested.</p>'
 
     selection_rows = named_service_selection_rows(
-        req.scopes, config=config, resource=req.resource,
+        req.scopes,
+        config=config,
+        resource=req.resource,
+        seeded=seeded_named_service_operations,
     )
-    namespace_rows = _render_grouped((
-        (
-            row["namespace_label"],
-            f'    <label class="namespace-row">'
-            f'<input type="checkbox" name="named_service_operations" '
-            f'value="{esc(row["namespace"])}:{esc(row["operation"])}"> '
-            f'<span class="row-text"><b>{esc(row["label"])}</b>'
-            f'<span class="desc">{esc(row["description"])}</span>'
-            f'<span class="grants">{esc(", ".join(row["grants"]) or "none")}</span></span></label>'
-        )
-        for row in selection_rows
-    ), css_class="namespace")
-    namespace_section = ""
-    if namespace_rows:
+    # A submission REPLACES what the card held, so the picker starts from what
+    # the client has rather than from nothing: leaving the section alone must
+    # keep the grant, not empty it. Operations the catalog added since that
+    # consent are listed apart and unchecked — drift is a decision, not a
+    # default.
+    re_consent = any(row["held"] for row in selection_rows)
+
+    def _rows(rows: list[dict]) -> str:
+        return _render_grouped((
+            (
+                row["namespace_label"],
+                f'    <label class="namespace-row">'
+                f'<input type="checkbox" name="named_service_operations" '
+                f'value="{esc(row["namespace"])}:{esc(row["operation"])}"'
+                f'{" checked" if row["held"] else ""}> '
+                f'<span class="row-text"><b>{esc(row["label"])}</b>'
+                f'<span class="desc">{esc(row["description"])}</span>'
+                f'<span class="grants">{esc(", ".join(row["grants"]) or "none")}</span></span></label>'
+            )
+            for row in rows
+        ), css_class="namespace")
+
+    if re_consent:
+        current_rows = _rows([row for row in selection_rows if row["held"]])
+        added_rows = _rows([row for row in selection_rows if not row["held"]])
+        added_section = f"""
+    <p class="pick">Added since this client was last approved:</p>
+    <p class="desc">Offered by the service catalog now, and not part of the
+    grant this client holds. Left unchecked, they stay out of it.</p>
+{added_rows}
+""" if added_rows else ""
+        namespace_section = f"""
+    <p class="pick">Named-service operations this client has now:</p>
+    <p class="desc">Checked is what the current grant covers. Your choice here
+    REPLACES it — unchecking removes the operation from this client. A claim
+    lets an operation through the claim gate; it does not select the operation.</p>
+    <label class="namespace-row"><input type="checkbox" name="named_service_operations_all" value="1">
+    <span class="row-text"><b>Every operation offered right now</b>
+    <span class="desc">Replaces the list below with everything the current
+    service catalog offers, including anything added since.</span></span></label>
+{current_rows}{added_section}
+""" if current_rows else ""
+    else:
+        namespace_rows = _rows(selection_rows)
         namespace_section = f"""
     <p class="pick">Named-service operations:</p>
     <p class="desc">Nothing is selected by default. A claim lets an operation
@@ -474,7 +518,7 @@ def render_consent_html(
     <span class="desc">Bound to the current service catalog; operations added
     later are not included.</span></span></label>
 {namespace_rows}
-"""
+""" if namespace_rows else ""
 
     # Per-account access is granted SEPARATELY from the connection ceiling
     # above, and the runtime is DEFAULT-CLOSED: a connected account this client

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/oauth/http/deps.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/oauth/http/deps.py
@@ -162,6 +162,29 @@ def get_grant_store(request: Request) -> Any:
     return GrantStore(redis, tenant, project)
 
 
+class AutomationAccessUnavailable(RuntimeError):
+    """No delegated-access capability was bound to this request."""
+
+
+def get_automation_access(request: Request) -> Any:
+    """The delegated-access service the hosting app bound to this request.
+
+    Request code consumes the capability; composing it belongs to the app that
+    owns card storage and the delegated catalog. An unbound request fails
+    closed rather than building a service with unknown storage.
+    """
+    factory = getattr(getattr(request, "state", None), "automation_access_factory", None)
+    if not callable(factory):
+        # A host that mounts the router instead of calling the handlers binds
+        # the capability once, at application scope.
+        factory = getattr(
+            getattr(request.app, "state", None), "automation_access_factory", None
+        )
+    if not callable(factory):
+        raise AutomationAccessUnavailable("automation_access_not_bound")
+    return factory()
+
+
 def get_access_token_minter(request: Request) -> Callable[[str, list], Awaitable[dict]]:
     """Returns ``async (sub, scopes) -> {access_token, expires_in}``."""
     fn = getattr(request.app.state, "oauth_mint_access_token", None)

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/oauth/http/routes.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/oauth/http/routes.py
@@ -44,6 +44,8 @@ from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.oau
     oauth_delegated_config,
 )
 from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.oauth.consent import (
+    CONSENT_CONTRACT_VERSION,
+    named_service_selection_rows,
     platform_edge_grants_for_scopes,
     render_consent_html,
     tools_for_scopes,
@@ -51,6 +53,9 @@ from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.oau
 from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.oauth.authority import build_delegated_client_credential
 from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.cards.resolver import (
     CardUnavailable,
+)
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.serving import (
+    delegated_serving_resolvers,
 )
 from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.cards.service import (
     CardCommitFailed,
@@ -202,6 +207,9 @@ def _consent_payload(
     grantor_label: str,
     signout_action: str,
     return_to: str,
+    catalog_version: str = "",
+    connected_accounts: list | None = None,
+    seeded_account_scope: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     authorize_request = {
         "client_id": req.client_id,
@@ -216,6 +224,8 @@ def _consent_payload(
         "client": req.client.snapshot() if req.client is not None else {},
     }
     return {
+        "consent_contract": {"version": CONSENT_CONTRACT_VERSION},
+        "catalog_version": catalog_version,
         # `request` is kept for existing renderers. `oauth_request` avoids a
         # common bundle-operation kwarg collision with the framework request.
         "request": authorize_request,
@@ -242,6 +252,11 @@ def _consent_payload(
             }
             for tool in cfg.tools_for_scopes(req.scopes, resource=req.resource)
         ],
+        "named_service_operations": named_service_selection_rows(
+            req.scopes, config=cfg, resource=req.resource,
+        ),
+        "connected_accounts": list(connected_accounts or []),
+        "seeded_account_scope": dict(seeded_account_scope or {}),
     }
 
 
@@ -303,6 +318,9 @@ async def _render_custom_consent_if_configured(
     cfg: OAuthDelegatedClientConfig,
     grantor_subject: str,
     grantor_label: str,
+    catalog_version: str = "",
+    connected_accounts: list | None = None,
+    seeded_account_scope: Mapping[str, Any] | None = None,
 ) -> Response | None:
     endpoint = _custom_consent_endpoint(request, cfg)
     if not endpoint:
@@ -341,6 +359,9 @@ async def _render_custom_consent_if_configured(
         grantor_label=grantor_label,
         signout_action=_logout_action(request),
         return_to=_return_to(request),
+        catalog_version=catalog_version,
+        connected_accounts=connected_accounts,
+        seeded_account_scope=seeded_account_scope,
     )
     try:
         result = await call_bundle_operation(
@@ -367,7 +388,82 @@ async def _render_custom_consent_if_configured(
             status_code=500,
             content={"error": "consent_ui_render_failed", "error_description": "renderer did not return html"},
         )
+    declared = _extract_custom_consent_contract_version(result)
+    if declared != CONSENT_CONTRACT_VERSION:
+        LOGGER.error(
+            "[connection-hub.oauth] consent_ui contract mismatch bundle=%s operation=%s "
+            "declared=%s expected=%s",
+            bundle_id, operation, declared or "<absent>", CONSENT_CONTRACT_VERSION,
+        )
+        return JSONResponse(
+            status_code=500,
+            content={
+                "error": "consent_ui_contract_mismatch",
+                "error_description": (
+                    f"consent renderer {bundle_id}:{operation} declares "
+                    f"{declared or 'no'} contract version; this deployment serves "
+                    f"{CONSENT_CONTRACT_VERSION}. Update the renderer to the current "
+                    "consent view model, or remove `consent_ui` to use the built-in page."
+                ),
+            },
+        )
     return HTMLResponse(html)
+
+
+def _extract_custom_consent_contract_version(result: Any) -> str:
+    if not isinstance(result, Mapping):
+        return ""
+    for key in ("consent_contract_version", "contract_version"):
+        value = result.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    contract = result.get("consent_contract")
+    if isinstance(contract, Mapping):
+        value = contract.get("version")
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return ""
+
+
+def _selected_named_service_operations(
+    form: Any,
+    *,
+    scopes: Iterable[str],
+    cfg: OAuthDelegatedClientConfig,
+    resource: str,
+) -> Any:
+    """The card-level selection a consent submission carries.
+
+    ``"*"`` when every offered operation was chosen, otherwise the exact
+    namespace map keyed by resource. Values outside what the page offered are
+    dropped; an empty result is a deliberate empty selection.
+    """
+    offered = named_service_selection_rows(scopes, config=cfg, resource=resource)
+    if str(form.get("named_service_operations_all") or "").strip():
+        return "*"
+    allowed = {(row["namespace"], row["operation"]) for row in offered}
+    picked: dict[str, list[str]] = {}
+    for raw in form.getlist("named_service_operations"):
+        namespace, _, operation = str(raw or "").partition(":")
+        key = (namespace.strip(), operation.strip())
+        if key not in allowed:
+            continue
+        operations = picked.setdefault(key[0], [])
+        if key[1] not in operations:
+            operations.append(key[1])
+    return {resource or "*": picked} if picked else {}
+
+
+async def _active_catalog_version_for_consent(request: Request) -> str:
+    resolvers = delegated_serving_resolvers(request)
+    if resolvers is None:
+        return ""
+    try:
+        document = await resolvers.catalog.resolve_active()
+    except Exception:
+        LOGGER.warning("[connection-hub.oauth] active catalog unreadable for consent", exc_info=True)
+        return ""
+    return str(getattr(document, "version", "") or "")
 
 
 def _logout_action(request: Request) -> str:
@@ -761,6 +857,13 @@ async def authorize(request: Request) -> Response:
         req.client is not None
         and req.client.registration_kind == CLIENT_REGISTRATION_PRE_REGISTERED
     )
+    # The view model is built before a renderer is chosen: both renderers see
+    # the same facts, and a custom one changes presentation only.
+    connected_accounts = await _connected_accounts_for_consent(subject)
+    seeded_account_scope = await _seed_account_scope_for_consent(
+        request, subject=subject, client_id=req.client_id, resource=req.resource, cfg=cfg,
+    )
+    catalog_version = await _active_catalog_version_for_consent(request)
     custom = await _render_custom_consent_if_configured(
         request,
         req=render_req,
@@ -770,13 +873,12 @@ async def authorize(request: Request) -> Response:
         cfg=cfg,
         grantor_subject=_user_subject(user or {}),
         grantor_label=_user_label(user or {}),
+        catalog_version=catalog_version,
+        connected_accounts=connected_accounts,
+        seeded_account_scope=seeded_account_scope,
     )
     if custom is not None:
         return custom
-    connected_accounts = await _connected_accounts_for_consent(subject)
-    seeded_account_scope = await _seed_account_scope_for_consent(
-        request, subject=subject, client_id=req.client_id, resource=req.resource, cfg=cfg,
-    )
     accounts_needed = _accounts_needed_for_consent(request, render_req.scopes, connected_accounts, cfg=cfg)
     return HTMLResponse(
         render_consent_html(
@@ -795,6 +897,7 @@ async def authorize(request: Request) -> Response:
             connected_accounts=connected_accounts,
             seeded_account_scope=seeded_account_scope,
             accounts_needed=accounts_needed,
+            catalog_version=catalog_version,
         )
     )
 
@@ -1031,6 +1134,43 @@ async def authorize_consent(request: Request) -> Response:
         )
         return RedirectResponse(url, status_code=302)
 
+    declared_contract = str(form.get("consent_contract_version") or "").strip()
+    if declared_contract != CONSENT_CONTRACT_VERSION:
+        LOGGER.error(
+            "[connection-hub.oauth] consent submission contract mismatch client_id=%s "
+            "declared=%s expected=%s",
+            req.client_id, declared_contract or "<absent>", CONSENT_CONTRACT_VERSION,
+        )
+        return JSONResponse(
+            status_code=400,
+            content={
+                "error": "consent_ui_contract_mismatch",
+                "error_description": (
+                    "the consent page did not submit the current consent contract; "
+                    "no authorization code is issued"
+                ),
+            },
+        )
+    expected_catalog_version = str(form.get("expected_catalog_version") or "").strip()
+    active_catalog_version = await _active_catalog_version_for_consent(request)
+    if (
+        expected_catalog_version
+        and active_catalog_version
+        and expected_catalog_version != active_catalog_version
+    ):
+        return JSONResponse(
+            status_code=409,
+            content={
+                "error": "consent_catalog_changed",
+                "error_description": (
+                    "the service catalog changed after this page was shown; "
+                    "restart authorization"
+                ),
+                "expected_catalog_version": expected_catalog_version,
+                "active_catalog_version": active_catalog_version,
+            },
+        )
+
     requested_scope_set = _as_set(req.scopes)
     selected_scope_set = _as_set(form.getlist("platform_grants"))
     selected_scopes = [scope for scope in req.scopes if scope in selected_scope_set]
@@ -1063,6 +1203,9 @@ async def authorize_consent(request: Request) -> Response:
     selected_operations = [t for t in form.getlist("tools") if t in valid_tools]
     resource_cfg = cfg.resource_config(req.resource)
     named_services = dict(resource_cfg.named_services or {}) if resource_cfg is not None else {}
+    named_service_operations = _selected_named_service_operations(
+        form, scopes=selected_scopes, cfg=cfg, resource=req.resource,
+    )
     grantor_authority = _grantor_authority(user or {}, scopes=selected_scopes, inventory=inventory)
     delegation_edges = list(grantor_authority.get("delegation_edges") or [])
     # Per-account claim picks from the consent screen: checkbox values are
@@ -1097,6 +1240,8 @@ async def authorize_consent(request: Request) -> Response:
         grantor_authority=grantor_authority,
         delegation_edges=delegation_edges,
         named_services=named_services,
+        named_service_operations=named_service_operations,
+        catalog_version=active_catalog_version,
         account_scope=account_scope,
         client_metadata=req.client.snapshot() if req.client is not None else {},
     )
@@ -1160,6 +1305,8 @@ async def _issue_tokens(
     grantor_authority=None,
     delegation_edges=None,
     named_services=None,
+    named_service_operations=None,
+    catalog_version="",
     refresh_token=None,
     account_scope=None,
     client_metadata=None,
@@ -1284,6 +1431,8 @@ async def _issue_tokens(
             access_token=access_token,
             refresh_token=str(refresh_token or ""),
             account_scope=account_scope,
+            named_service_operations=named_service_operations,
+            catalog_version=catalog_version,
         )
     except (AutomationAccessUnavailable, CardUnavailable, CardConflict, CardCommitFailed) as exc:
         # The card is the authority a governed call resolves; a token whose card
@@ -1356,6 +1505,8 @@ async def token(request: Request) -> Response:
             grantor_authority=payload.get("grantor_authority") or {},
             delegation_edges=payload.get("delegation_edges") or [],
             named_services=payload.get("named_services") or {},
+            named_service_operations=payload.get("named_service_operations"),
+            catalog_version=payload.get("catalog_version") or "",
             account_scope=payload.get("account_scope") or None,
             client_metadata=payload.get("client_metadata") or {},
         )

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/oauth/http/routes.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/oauth/http/routes.py
@@ -49,7 +49,16 @@ from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.oau
     tools_for_scopes,
 )
 from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.oauth.authority import build_delegated_client_credential
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.cards.resolver import (
+    CardUnavailable,
+)
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.cards.service import (
+    CardCommitFailed,
+    CardConflict,
+)
 from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.oauth.http.deps import (
+    AutomationAccessUnavailable,
+    get_automation_access,
     extract_bearer,
     get_access_token_minter,
     get_authenticate,
@@ -906,15 +915,7 @@ async def _seed_account_scope_for_consent(
     """Pre-check the picker from the client's existing card (re-consent) and
     from a DCR sibling this consent will supersede."""
     try:
-        from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.automation_access import (
-            AutomationAccessService,
-        )
-
-        store = get_grant_store(request)
-        tenant, project = oauth_tenant_project(request)
-        service = AutomationAccessService(
-            redis=store.redis, tenant=tenant, project=project, config=cfg, grant_store=store,
-        )
+        service = get_automation_access(request)
         return await service.oauth_seed_account_scope(
             grantor_subject=subject, client_id=client_id, resource=str(resource or ""),
         )
@@ -1240,10 +1241,7 @@ async def _issue_tokens(
     # KDCube tab) so the connection is visible and revocable. Registry write
     # failures must never fail token issuance.
     try:
-        from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.automation_access import (
-            AutomationAccessService,
-        )
-
+        service = get_automation_access(request)
         metadata_snapshot = dict(client_metadata or {})
         if not metadata_snapshot:
             client_record = await store.get_client_record(client_id) or {}
@@ -1275,13 +1273,6 @@ async def _issue_tokens(
             client_id, registered_name, sorted(metadata_snapshot.keys()),
             str(resource or ""), door_alias, client_label,
         )
-        service = AutomationAccessService(
-            redis=store.redis,
-            tenant=tenant,
-            project=project,
-            config=oauth_delegated_config(request),
-            grant_store=store,
-        )
         await service.record_oauth_grant(
             grantor_subject=sub,
             client_id=client_id,
@@ -1294,8 +1285,31 @@ async def _issue_tokens(
             refresh_token=str(refresh_token or ""),
             account_scope=account_scope,
         )
+    except (AutomationAccessUnavailable, CardUnavailable, CardConflict, CardCommitFailed) as exc:
+        # The card is the authority a governed call resolves; a token whose card
+        # was never committed would be denied as revoked on every use. Delegated
+        # authority is therefore handed over only after the card commits.
+        LOGGER.error(
+            "[connection-hub.oauth] token withheld: delegated card not committed "
+            "client=%s reason=%s",
+            client_id,
+            getattr(exc, "reason", type(exc).__name__),
+        )
+        return _token_error(
+            "temporarily_unavailable",
+            "The delegated access card could not be recorded; retry the request.",
+            status=503,
+        )
     except Exception:
-        LOGGER.exception("[connection-hub.oauth] failed to record delegated grant client=%s", client_id)
+        LOGGER.exception(
+            "[connection-hub.oauth] token withheld: delegated grant not recorded client=%s",
+            client_id,
+        )
+        return _token_error(
+            "temporarily_unavailable",
+            "The delegated access card could not be recorded; retry the request.",
+            status=503,
+        )
     return JSONResponse(
         {
             "access_token": access_token,
@@ -1472,18 +1486,7 @@ async def revoke(request: Request) -> Response:
 
     if card_pointer and grantor_subject:
         try:
-            from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.automation_access import (
-                AutomationAccessService,
-            )
-
-            tenant, project = oauth_tenant_project(request)
-            service = AutomationAccessService(
-                redis=store.redis,
-                tenant=tenant,
-                project=project,
-                config=oauth_delegated_config(request),
-                grant_store=store,
-            )
+            service = get_automation_access(request)
             await service.revoke_access({"user_id": grantor_subject}, access_id=card_pointer)
             LOGGER.info(
                 "[connection-hub.oauth] rfc7009 revocation retired card=%s", card_pointer

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/oauth/http/routes.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/oauth/http/routes.py
@@ -42,6 +42,7 @@ from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.oau
 from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.oauth.config import (
     OAuthDelegatedClientConfig,
     oauth_delegated_config,
+    oauth_delegated_config_from_connections,
 )
 from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.oauth.consent import (
     CONSENT_CONTRACT_VERSION,
@@ -210,6 +211,7 @@ def _consent_payload(
     catalog_version: str = "",
     connected_accounts: list | None = None,
     seeded_account_scope: Mapping[str, Any] | None = None,
+    seeded_named_service_operations: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     authorize_request = {
         "client_id": req.client_id,
@@ -253,10 +255,19 @@ def _consent_payload(
             for tool in cfg.tools_for_scopes(req.scopes, resource=req.resource)
         ],
         "named_service_operations": named_service_selection_rows(
-            req.scopes, config=cfg, resource=req.resource,
+            req.scopes,
+            config=cfg,
+            resource=req.resource,
+            seeded=seeded_named_service_operations,
         ),
         "connected_accounts": list(connected_accounts or []),
         "seeded_account_scope": dict(seeded_account_scope or {}),
+        # What the client's card covers today. A submission replaces it, so a
+        # renderer that cannot see it cannot offer an informed choice.
+        "seeded_named_service_operations": {
+            str(namespace): [str(op) for op in (operations or ())]
+            for namespace, operations in dict(seeded_named_service_operations or {}).items()
+        },
     }
 
 
@@ -321,6 +332,7 @@ async def _render_custom_consent_if_configured(
     catalog_version: str = "",
     connected_accounts: list | None = None,
     seeded_account_scope: Mapping[str, Any] | None = None,
+    seeded_named_service_operations: Mapping[str, Any] | None = None,
 ) -> Response | None:
     endpoint = _custom_consent_endpoint(request, cfg)
     if not endpoint:
@@ -362,6 +374,7 @@ async def _render_custom_consent_if_configured(
         catalog_version=catalog_version,
         connected_accounts=connected_accounts,
         seeded_account_scope=seeded_account_scope,
+        seeded_named_service_operations=seeded_named_service_operations,
     )
     try:
         result = await call_bundle_operation(
@@ -451,19 +464,57 @@ def _selected_named_service_operations(
         operations = picked.setdefault(key[0], [])
         if key[1] not in operations:
             operations.append(key[1])
-    return {resource or "*": picked} if picked else {}
+    if not picked:
+        return {}
+    # Ticking every offered box is the same choice the "select all" control
+    # makes, and the panel already encodes it that way. One user action must
+    # not store two different things depending on which surface took it.
+    chosen = {(namespace, op) for namespace, ops in picked.items() for op in ops}
+    if allowed and chosen >= allowed:
+        return "*"
+    return {resource or "*": picked}
+
+
+async def _active_catalog_document(request: Request) -> Any | None:
+    resolvers = delegated_serving_resolvers(request)
+    if resolvers is None:
+        return None
+    try:
+        return await resolvers.catalog.resolve_active()
+    except Exception:
+        LOGGER.warning("[connection-hub.oauth] active catalog unreadable for consent", exc_info=True)
+        return None
 
 
 async def _active_catalog_version_for_consent(request: Request) -> str:
-    resolvers = delegated_serving_resolvers(request)
-    if resolvers is None:
-        return ""
-    try:
-        document = await resolvers.catalog.resolve_active()
-    except Exception:
-        LOGGER.warning("[connection-hub.oauth] active catalog unreadable for consent", exc_info=True)
-        return ""
+    document = await _active_catalog_document(request)
     return str(getattr(document, "version", "") or "")
+
+
+async def _consent_config(request: Request) -> OAuthDelegatedClientConfig | None:
+    """What the consent page may offer: the registered catalog, the same
+    document the card writer decides against. ``None`` when no catalog can be
+    established — a card cannot be written then either, so offering the
+    descriptor would promise what token exchange refuses."""
+    document = await _active_catalog_document(request)
+    if document is None:
+        return None
+    return oauth_delegated_config_from_connections(
+        getattr(document, "connections", None) or {}
+    )
+
+
+def _catalog_unavailable_response() -> JSONResponse:
+    return JSONResponse(
+        status_code=503,
+        content={
+            "error": "delegated_catalog_unavailable",
+            "error_description": (
+                "The delegated catalog is not established, so this deployment "
+                "cannot say what may be granted. Retry once it is published."
+            ),
+        },
+    )
 
 
 def _logout_action(request: Request) -> str:
@@ -779,7 +830,11 @@ async def register_client(request: Request) -> Response:
 async def authorize(request: Request) -> Response:
     issuer = resolve_issuer(request)
     params = dict(request.query_params)
-    cfg = oauth_delegated_config(request)
+    # The page offers from the registered catalog, the same document the card
+    # writer decides against.
+    cfg = await _consent_config(request)
+    if cfg is None:
+        return _catalog_unavailable_response()
     try:
         resolver = await _dynamic_client_resolver(request, params.get("client_id"))
     except ClientMetadataError as error:
@@ -863,6 +918,9 @@ async def authorize(request: Request) -> Response:
     seeded_account_scope = await _seed_account_scope_for_consent(
         request, subject=subject, client_id=req.client_id, resource=req.resource, cfg=cfg,
     )
+    seeded_named_service_operations = await _seed_named_service_operations_for_consent(
+        request, subject=subject, client_id=req.client_id, resource=req.resource,
+    )
     catalog_version = await _active_catalog_version_for_consent(request)
     custom = await _render_custom_consent_if_configured(
         request,
@@ -876,6 +934,7 @@ async def authorize(request: Request) -> Response:
         catalog_version=catalog_version,
         connected_accounts=connected_accounts,
         seeded_account_scope=seeded_account_scope,
+        seeded_named_service_operations=seeded_named_service_operations,
     )
     if custom is not None:
         return custom
@@ -896,6 +955,7 @@ async def authorize(request: Request) -> Response:
             return_to=_return_to(request),
             connected_accounts=connected_accounts,
             seeded_account_scope=seeded_account_scope,
+            seeded_named_service_operations=seeded_named_service_operations,
             accounts_needed=accounts_needed,
             catalog_version=catalog_version,
         )
@@ -1027,13 +1087,34 @@ async def _seed_account_scope_for_consent(
         return {}
 
 
+async def _seed_named_service_operations_for_consent(
+    request, *, subject: str, client_id: str, resource: str
+) -> dict:
+    """Pre-check the operations picker from the client's existing card.
+
+    Without it a re-consent renders an empty picker while a submission
+    replaces, so leaving the section alone silently drops every operation the
+    card holds.
+    """
+    try:
+        service = get_automation_access(request)
+        return await service.oauth_seed_named_service_operations(
+            grantor_subject=subject, client_id=client_id, resource=str(resource or ""),
+        )
+    except Exception:
+        LOGGER.exception("[connection-hub.oauth] consent named-service seed failed")
+        return {}
+
+
 @router.post("/oauth/authorize/consent", include_in_schema=False)
 @_normalize_grant_store_unavailable
 async def authorize_consent(request: Request) -> Response:
     issuer = resolve_issuer(request)
     form = await request.form()
     params = _consent_authorize_params(request, form)
-    cfg = oauth_delegated_config(request)
+    cfg = await _consent_config(request)
+    if cfg is None:
+        return _catalog_unavailable_response()
     try:
         resolver = await _dynamic_client_resolver(request, params.get("client_id"))
     except ClientMetadataError as error:

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/oauth/store.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/oauth/store.py
@@ -140,6 +140,8 @@ class GrantStore:
         grantor_authority: Optional[Dict[str, Any]] = None,
         delegation_edges: Optional[List[Dict[str, Any]]] = None,
         named_services: Optional[Dict[str, Any]] = None,
+        named_service_operations: Any = None,
+        catalog_version: str = "",
         account_scope: Optional[Dict[str, Any]] = None,
         client_metadata: Optional[Dict[str, Any]] = None,
     ) -> str:
@@ -157,6 +159,11 @@ class GrantStore:
             "grantor_authority": grantor_authority or {},
             "delegation_edges": list(delegation_edges or []),
             "named_services": named_services or {},
+            # The operator's operation choice and the catalog generation it was
+            # made against; carried to token exchange so the card is born with
+            # an explicit selection rather than an absent one.
+            "named_service_operations": named_service_operations,
+            "catalog_version": catalog_version or "",
             # Per-account claim picks made on the consent screen; carried to
             # token exchange so the registry card is born with the binding.
             "account_scope": dict(account_scope or {}),

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/oauth/surface_guard.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/oauth/surface_guard.py
@@ -29,6 +29,22 @@ from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.liv
     LiveGrantCardError,
     resolve_live_grant_card,
 )
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.catalog.authorization import (
+    CAPABILITY_OUTER_OPERATION,
+    CAPABILITY_RESOURCE,
+    CAPABILITY_RESOURCE_CLAIM,
+    ActiveCatalogCapabilities,
+    CapabilityRequest,
+    CardProvenance,
+    authorize_current_capability,
+    catalog_unavailable_denial,
+)
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.catalog.resolver import (
+    CatalogUnavailable,
+)
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.serving import (
+    delegated_serving_resolvers,
+)
 from kdcube_ai_app.apps.chat.sdk.solutions.connections.authority_projection import (
     authority_has_platform_privilege,
 )
@@ -406,6 +422,92 @@ def _any_resource_matches(credential_resources: Iterable[str], request_resource:
     return any(_resource_matches(resource, request_resource) for resource in credential_resources)
 
 
+def _matched_credential_resource(
+    credential_resources: Iterable[str], request_resource: str
+) -> str:
+    """The card selector that admitted this request, for the denial path."""
+    for resource in credential_resources:
+        if _resource_matches(resource, request_resource):
+            return str(resource)
+    return ""
+
+
+async def _active_catalog(request: Request) -> tuple[ActiveCatalogCapabilities | None, str]:
+    """The active catalog, or the reason it could not be established.
+
+    Absent readers are a composition failure, not an absence of requirements:
+    the caller denies rather than proceeding uncontrolled.
+    """
+    resolvers = delegated_serving_resolvers(request)
+    if resolvers is None:
+        return None, "delegated_serving_resolvers_absent"
+    try:
+        document = await resolvers.catalog.resolve_active()
+    except CatalogUnavailable as exc:
+        return None, exc.reason
+    except Exception as exc:  # noqa: BLE001 - resolution failure is unavailability
+        LOGGER.warning(
+            "[connection-hub.oauth.guard] active catalog unreadable: %s", exc, exc_info=True
+        )
+        return None, "catalog_unavailable"
+    return ActiveCatalogCapabilities(document), ""
+
+
+def _card_provenance(grant_record: Mapping[str, Any] | None) -> CardProvenance:
+    record = grant_record if isinstance(grant_record, Mapping) else {}
+    try:
+        revision = int(record.get("card_revision") or 0)
+    except (TypeError, ValueError):
+        revision = 0
+    return CardProvenance(
+        access_id=str(record.get("registry_access_id") or "").strip(),
+        card_revision=revision,
+        catalog_version=str(record.get("catalog_version") or "").strip(),
+    )
+
+
+def _capability_denial_response(payload: Mapping[str, Any]) -> JSONResponse:
+    return JSONResponse(status_code=403, content=dict(payload))
+
+
+def _catalog_unavailable_response(reason: str) -> JSONResponse:
+    return JSONResponse(status_code=503, content=catalog_unavailable_denial(reason))
+
+
+def _capability_denial(
+    *,
+    catalog: ActiveCatalogCapabilities,
+    grant_record: Mapping[str, Any] | None,
+    kind: str,
+    resource: str,
+    request_resource: str,
+    surface: str,
+    claim: str = "",
+    outer_operation: str = "",
+) -> dict[str, Any] | None:
+    return authorize_current_capability(
+        catalog=catalog,
+        provenance=_card_provenance(grant_record),
+        request=CapabilityRequest(
+            kind=kind,
+            resource=resource,
+            request_resource=request_resource,
+            surface=surface,
+            claim=claim,
+            outer_operation=outer_operation,
+        ),
+    )
+
+
+def _rpc_capability_error(rpc_id: Any, payload: Mapping[str, Any]) -> JSONResponse:
+    """A removed capability inside a tool call, with its complete path.
+
+    The path travels as the message body because the caller must be able to see
+    which resource, namespace, and operation were refused.
+    """
+    return _rpc_tool_error(rpc_id, json.dumps(dict(payload), ensure_ascii=False))
+
+
 async def _default_grant_store(request: Request) -> GrantStore:
     override = getattr(request.app.state, "oauth_grant_store", None)
     if override is not None:
@@ -489,6 +591,10 @@ async def _live_grant_record(request: Any, grant_record: Optional[Dict[str, Any]
     attrs = attrs if isinstance(attrs, Mapping) else {}
     tenant, project = oauth_tenant_project(request)
     store = await _default_grant_store(request)
+    # A projection lost to eviction is not a revoked card: the committed
+    # revision restores it. Expired or revoked durable state still denies and
+    # is not re-cached.
+    resolvers = delegated_serving_resolvers(request)
     card = await resolve_live_grant_card(
         store.redis,
         tenant=tenant,
@@ -497,6 +603,7 @@ async def _live_grant_record(request: Any, grant_record: Optional[Dict[str, Any]
         expected_client_id=str(attrs.get("client_id") or ""),
         expected_grantor_subject=str(attrs.get("grantor_subject") or ""),
         expected_delegate_subject=str(credential.get("subject") or ""),
+        card_store=getattr(resolvers, "cards", None),
     )
     if card is None:
         LOGGER.info("[connection-hub.oauth.guard] registry card %s gone — binding treated as revoked", access_id)
@@ -533,9 +640,16 @@ async def _live_grant_record(request: Any, grant_record: Optional[Dict[str, Any]
         for provider, accounts in card.account_scope.items()
     }
     # The named-service boundary tree, narrowed from the descriptor when the
-    # card was written. Cards without it keep the bound snapshot.
-    if card.named_services:
+    # card was written. A card that carries the selection owns the boundary
+    # even when it is empty; only a pre-encoding card keeps the bound snapshot.
+    if not card.named_service_operations.is_unknown:
+        resolved["named_services"] = dict(card.named_services or {})
+    elif card.named_services:
         resolved["named_services"] = dict(card.named_services)
+    # Card provenance travels with the facts so a denial can name the card and
+    # the catalog generation its selection was saved against.
+    resolved["card_revision"] = int(card.card_revision or 0)
+    resolved["catalog_version"] = str(card.catalog_version or "")
     return resolved
 
 
@@ -991,7 +1105,43 @@ async def authorize_delegated_mcp_request(
         )
         return _json_response(403, "forbidden", "delegated credential resource mismatch")
 
-    available_grants = _credential_grants_for_resource(envelope, request_resource)
+    catalog, unavailable = await _active_catalog(request)
+    if catalog is None:
+        LOGGER.warning(
+            "[connection-hub.oauth.mcp_guard] denied reason=catalog_%s resource=%s",
+            unavailable,
+            request_resource,
+        )
+        return _catalog_unavailable_response(unavailable)
+
+    matched_resource = _matched_credential_resource(credential_resources, request_resource)
+    catalog_path = {
+        "catalog": catalog,
+        "grant_record": grant_record,
+        "resource": matched_resource,
+        "request_resource": request_resource,
+        "surface": "mcp",
+    }
+    removed = _capability_denial(kind=CAPABILITY_RESOURCE, **catalog_path)
+    if removed is not None:
+        LOGGER.info(
+            "[connection-hub.oauth.mcp_guard] denied reason=capability_removed path=%s resource=%s",
+            removed["ret"]["requested_capability"],
+            request_resource,
+        )
+        return _capability_denial_response(removed)
+
+    stored_grants = _credential_grants_for_resource(envelope, request_resource)
+    # Stored claims are reduced to what the current resource still permits.
+    available_grants = stored_grants & set(
+        catalog.resource_claims(
+            CapabilityRequest(
+                kind=CAPABILITY_RESOURCE_CLAIM,
+                resource=matched_resource,
+                request_resource=request_resource,
+            )
+        )
+    )
     tool_calls = extract_mcp_tool_calls(body)
     if not tool_calls:
         runtime = delegated_mcp_runtime_projection(request)
@@ -1016,6 +1166,17 @@ async def authorize_delegated_mcp_request(
         tool_policies = dict(policy.tool_policies or {})
 
     for rpc_id, tool_name in tool_calls:
+        removed = _capability_denial(
+            kind=CAPABILITY_OUTER_OPERATION, outer_operation=tool_name, **catalog_path
+        )
+        if removed is not None:
+            LOGGER.info(
+                "[connection-hub.oauth.mcp_guard] denied reason=capability_removed path=%s resource=%s",
+                removed["ret"]["requested_capability"],
+                request_resource,
+            )
+            return _rpc_capability_error(rpc_id, removed)
+
         tool_policy = tool_policies.get(tool_name)
         if tool_policies and tool_policy is None:
             return _rpc_tool_error(rpc_id, f"tool not allowed by endpoint policy: {tool_name}")
@@ -1025,6 +1186,16 @@ async def authorize_delegated_mcp_request(
                 return _rpc_tool_error(rpc_id, f"required role is missing for tool: {tool_name}")
             if tool_policy.permissions and not permissions.issuperset(tool_policy.permissions):
                 return _rpc_tool_error(rpc_id, f"required permission is missing for tool: {tool_name}")
+            for claim in sorted(set(tool_policy.grants or ()) & (stored_grants - available_grants)):
+                removed = _capability_denial(
+                    kind=CAPABILITY_RESOURCE_CLAIM, claim=claim, **catalog_path
+                )
+                LOGGER.info(
+                    "[connection-hub.oauth.mcp_guard] denied reason=capability_removed path=%s resource=%s",
+                    removed["ret"]["requested_capability"],
+                    request_resource,
+                )
+                return _rpc_capability_error(rpc_id, removed)
             if tool_policy.grants and not available_grants.issuperset(tool_policy.grants):
                 return _rpc_tool_error(rpc_id, f"required delegated grant is missing for tool: {tool_name}")
 
@@ -1083,7 +1254,68 @@ async def authorize_delegated_rest_request(
         return denial
 
     request_resource = _request_resource(request)
-    available_grants = _credential_grants_for_resource(envelope, request_resource)
+    operation_name = str(operation or "").strip()
+    catalog, unavailable = await _active_catalog(request)
+    if catalog is None:
+        REST_LOGGER.warning(
+            "[connection-hub.oauth.rest_guard] denied reason=catalog_%s resource=%s operation=%s",
+            unavailable,
+            request_resource,
+            operation_name,
+        )
+        return _catalog_unavailable_response(unavailable)
+
+    matched_resource = _matched_credential_resource(
+        _credential_resources(envelope), request_resource
+    )
+    catalog_path = {
+        "catalog": catalog,
+        "grant_record": grant_record,
+        "resource": matched_resource,
+        "request_resource": request_resource,
+        "surface": "rest",
+    }
+    removed = _capability_denial(kind=CAPABILITY_RESOURCE, **catalog_path)
+    if removed is None and operation_name:
+        removed = _capability_denial(
+            kind=CAPABILITY_OUTER_OPERATION, outer_operation=operation_name, **catalog_path
+        )
+    if removed is not None:
+        REST_LOGGER.info(
+            "[connection-hub.oauth.rest_guard] denied reason=capability_removed path=%s resource=%s",
+            removed["ret"]["requested_capability"],
+            request_resource,
+        )
+        return _capability_denial_response(removed)
+
+    stored_grants = _credential_grants_for_resource(envelope, request_resource)
+    # Stored claims are reduced to what the current resource still permits, so
+    # a claim removed from the catalog cannot satisfy an endpoint policy.
+    claim_ceiling = catalog.resource_claims(
+        CapabilityRequest(
+            kind=CAPABILITY_RESOURCE_CLAIM,
+            resource=matched_resource,
+            request_resource=request_resource,
+        )
+    )
+    available_grants = stored_grants & set(claim_ceiling)
+
+    def _claim_removed(required: Iterable[str]) -> dict[str, Any] | None:
+        """A required claim the card still carries but the catalog dropped."""
+        for claim in sorted(set(required) & (stored_grants - available_grants)):
+            return _capability_denial(
+                kind=CAPABILITY_RESOURCE_CLAIM, claim=claim, **catalog_path
+            )
+        return None
+
+    removed = _claim_removed(policy.grants or ())
+    if removed is not None:
+        REST_LOGGER.info(
+            "[connection-hub.oauth.rest_guard] denied reason=capability_removed path=%s resource=%s",
+            removed["ret"]["requested_capability"],
+            request_resource,
+        )
+        return _capability_denial_response(removed)
     if policy.grants and not available_grants.issuperset(policy.grants):
         REST_LOGGER.info(
             "[connection-hub.oauth.rest_guard] denied reason=missing_grant required=%s available=%s resource=%s operation=%s",
@@ -1098,7 +1330,6 @@ async def authorize_delegated_rest_request(
     if not operation_policies:
         operation_policies = dict(policy.operation_policies or {})
     selected_operation_grants = policy.selected_operation_grants or bool(operation_policies)
-    operation_name = str(operation or "").strip()
     operation_policy = operation_policies.get(operation_name)
     if operation_policies and operation_policy is None:
         REST_LOGGER.info(
@@ -1116,6 +1347,14 @@ async def authorize_delegated_rest_request(
             return _json_response(403, "forbidden", f"required role is missing for operation: {operation_name}")
         if operation_policy.permissions and not permissions.issuperset(operation_policy.permissions):
             return _json_response(403, "forbidden", f"required permission is missing for operation: {operation_name}")
+        removed = _claim_removed(operation_policy.grants or ())
+        if removed is not None:
+            REST_LOGGER.info(
+                "[connection-hub.oauth.rest_guard] denied reason=capability_removed path=%s resource=%s",
+                removed["ret"]["requested_capability"],
+                request_resource,
+            )
+            return _capability_denial_response(removed)
         if operation_policy.grants and not available_grants.issuperset(operation_policy.grants):
             REST_LOGGER.info(
                 "[connection-hub.oauth.rest_guard] denied reason=missing_operation_grant operation=%s required=%s available=%s resource=%s",

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/oauth/surface_guard.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/oauth/surface_guard.py
@@ -640,12 +640,11 @@ async def _live_grant_record(request: Any, grant_record: Optional[Dict[str, Any]
         for provider, accounts in card.account_scope.items()
     }
     # The named-service boundary tree, narrowed from the descriptor when the
-    # card was written. A card that carries the selection owns the boundary
-    # even when it is empty; only a pre-encoding card keeps the bound snapshot.
-    if not card.named_service_operations.is_unknown:
-        resolved["named_services"] = dict(card.named_services or {})
-    elif card.named_services:
-        resolved["named_services"] = dict(card.named_services)
+    # card was written. Always set, including empty: an absent key leaves the
+    # descriptor as the only ceiling, so a card that materialized nothing would
+    # reach everything the deployment configures. A pre-encoding card is bounded
+    # by what it materialized, per the design's pre-migration rule.
+    resolved["named_services"] = dict(card.named_services or {})
     # Card provenance travels with the facts so a denial can name the card and
     # the catalog generation its selection was saved against.
     resolved["card_revision"] = int(card.card_revision or 0)

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/oauth/tests/helpers.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/oauth/tests/helpers.py
@@ -49,6 +49,66 @@ def enable_delegated_client(app: FastAPI, *, issuer: str = "https://connector.ex
     }
 
 
+def _clear_delegated_keys(*, tenant: str, project: str) -> None:
+    """Drop delegated-access keys left by an earlier test in this namespace."""
+    import os
+
+    import redis as sync_redis
+
+    url = os.environ.get("REDIS_URL")
+    if not url:
+        return
+    client = sync_redis.Redis.from_url(url)
+    try:
+        keys = list(client.scan_iter(match=f"{tenant}:{project}:kdcube:delegated-access:*"))
+        if keys:
+            client.delete(*keys)
+    finally:
+        client.close()
+
+
+def bind_delegated_card_persistence(app: FastAPI, *, redis, storage_root) -> None:
+    """Give a mounted test app the delegated-access capability.
+
+    Production binds this per request from the Connection Hub bundle; a test
+    app that mounts the router binds it once. Without it, token issuance
+    withholds the token because the card cannot be committed.
+    """
+    from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.automation_access import (
+        AutomationAccessService,
+    )
+    from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.cards.persistence import (
+        DurableCardPersistence,
+    )
+    from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.cards.store import (
+        BundleStorageDelegatedCardStore,
+    )
+
+    cfg = oauth_delegated_config(app)
+    # Test apps share one tenant/project namespace, so a projection from an
+    # earlier test would otherwise be read as this card's current revision.
+    _clear_delegated_keys(tenant=cfg.tenant, project=cfg.project)
+    persistence = DurableCardPersistence(
+        redis=redis,
+        tenant=cfg.tenant,
+        project=cfg.project,
+        card_store=BundleStorageDelegatedCardStore(storage_root),
+    )
+
+    def _build():
+        store = getattr(app.state, "oauth_grant_store", None)
+        return AutomationAccessService(
+            redis=getattr(store, "redis", None),
+            tenant=cfg.tenant,
+            project=cfg.project,
+            config=cfg,
+            grant_store=store,
+            card_persistence=persistence,
+        )
+
+    app.state.automation_access_factory = _build
+
+
 def mount_test_oauth_adapter(app: FastAPI) -> FastAPI:
     """Mount OAuth adapter routes for tests only.
 

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/oauth/tests/helpers.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/oauth/tests/helpers.py
@@ -49,6 +49,56 @@ def enable_delegated_client(app: FastAPI, *, issuer: str = "https://connector.ex
     }
 
 
+class _FixedCatalogResolver:
+    """Serves one registered catalog generation.
+
+    Publication, caching, and read-through have their own Redis-backed tests;
+    a guard test states the generation it is enforcing against.
+    """
+
+    def __init__(self, document, *, unavailable: str = "") -> None:
+        self._document = document
+        self._unavailable = unavailable
+
+    async def resolve_active(self):
+        if self._unavailable:
+            from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.catalog.resolver import (
+                CatalogUnavailable,
+            )
+
+            raise CatalogUnavailable(self._unavailable)
+        return self._document
+
+    async def resolve_version(self, version: str):
+        return self._document if version == self._document.version else None
+
+
+def bind_delegated_catalog(app, connections, *, unavailable: str = "", cards=None) -> None:
+    """Install the serving resolvers over a fixed catalog generation.
+
+    ``cards`` is the durable card store a cache miss reads through; without one
+    the guard resolves cards from the projection alone.
+    """
+    from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.catalog.models import (
+        CatalogDocument,
+    )
+    from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.serving import (
+        SERVING_RESOLVERS_ATTR,
+        DelegatedServingResolvers,
+    )
+
+    setattr(
+        app.state,
+        SERVING_RESOLVERS_ATTR,
+        DelegatedServingResolvers(
+            catalog=_FixedCatalogResolver(
+                CatalogDocument.build(connections or {}), unavailable=unavailable
+            ),
+            cards=cards,
+        ),
+    )
+
+
 def _clear_delegated_keys(*, tenant: str, project: str) -> None:
     """Drop delegated-access keys left by an earlier test in this namespace."""
     import os

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/oauth/tests/helpers.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/oauth/tests/helpers.py
@@ -47,6 +47,24 @@ def enable_delegated_client(app: FastAPI, *, issuer: str = "https://connector.ex
             },
         ],
     }
+    # A deployment serves what publication registered, and the consent page and
+    # the card writer both read that. Binding the same content puts the fixture
+    # in the state a live deployment is in.
+    bind_delegated_catalog(
+        app, {"delegated_credentials": {"oauth": app.state.oauth_delegated_config}}
+    )
+
+
+
+def publish_delegated_config(app, config: dict) -> None:
+    """Set the deployment's delegable config AND register it as the catalog.
+
+    A consent page offers, and a card write decides, from the registered
+    catalog. A test that only sets props describes a deployment whose edit was
+    never published, which is a different scenario.
+    """
+    app.state.oauth_delegated_config = config
+    bind_delegated_catalog(app, {"delegated_credentials": {"oauth": config}})
 
 
 class _FixedCatalogResolver:

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/oauth/tests/test_authorize.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/oauth/tests/test_authorize.py
@@ -22,7 +22,10 @@ from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.oau
     build_redirect,
     parse_authorize_request,
 )
-from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.oauth.consent import render_consent_html
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.oauth.consent import (
+    CONSENT_CONTRACT_VERSION,
+    render_consent_html,
+)
 from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.oauth.config import oauth_delegated_config
 from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.oauth.store import GrantStore
 from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.oauth.pkce import make_s256_challenge
@@ -320,7 +323,16 @@ def test_authorize_can_render_bundle_hosted_consent(client, monkeypatch):
         assert data["oauth_request"]["client_id"] == "claude"
         assert data["platform_grants"][0]["grant"] == "records:read"
         assert data["tools"][0]["name"] == "records_export"
-        return {"delegated_consent": {"html": "<html><body>Custom consent</body></html>"}}
+        # The renderer sees the whole view model, including the dimensions the
+        # built-in page used to receive on its own.
+        assert data["consent_contract"]["version"] == CONSENT_CONTRACT_VERSION
+        assert "named_service_operations" in data
+        assert "connected_accounts" in data
+        assert "seeded_account_scope" in data
+        return {
+            "consent_contract_version": CONSENT_CONTRACT_VERSION,
+            "delegated_consent": {"html": "<html><body>Custom consent</body></html>"},
+        }
 
     monkeypatch.setattr(oauth_routes, "call_bundle_operation", fake_call_bundle_operation)
 
@@ -333,6 +345,49 @@ def test_authorize_can_render_bundle_hosted_consent(client, monkeypatch):
     assert response.status_code == 200
     assert "Custom consent" in response.text
     assert captured["http_method"] == "POST"
+
+
+def test_a_renderer_that_does_not_state_the_contract_is_not_shown(client, monkeypatch):
+    """A page that never rendered a dimension cannot report a choice about it.
+
+    The custom renderer is presentation only, so it declares which view model it
+    implements; an absent or older version is refused before the user can
+    approve, instead of producing a card whose selection was never asked for.
+    """
+    client.app.state.oauth_delegated_config = {
+        "enabled": True,
+        "issuer": ISSUER,
+        "capabilities": [
+            {
+                "grant": "records:read",
+                "label": "Read records",
+                "delegable_roles": ["kdcube:role:super-admin"],
+            },
+        ],
+        "resources": [{"resource": "*", "grants": ["records:read"]}],
+        "consent_ui": {
+            "host": {
+                "bundle_id": "product@1-0",
+                "route": "public",
+                "operation": "delegated_consent",
+            },
+        },
+    }
+
+    async def stale_renderer(**kwargs):
+        return {"delegated_consent": {"html": "<html><body>Stale consent</body></html>"}}
+
+    monkeypatch.setattr(oauth_routes, "call_bundle_operation", stale_renderer)
+
+    response = client.get(
+        "/oauth/authorize",
+        params=_params(),
+        headers={"Authorization": "Bearer admin-tok"},
+    )
+
+    assert response.status_code == 500
+    assert response.json()["error"] == "consent_ui_contract_mismatch"
+    assert "Stale consent" not in response.text
 
 
 def test_authorize_renders_consent_for_regular_user_when_grant_is_delegable(client):
@@ -428,6 +483,7 @@ def test_consent_approve_issues_code_bound_to_selection(client):
     store = client.app.state.oauth_grant_store
     form = _params()
     form["decision"] = "approve"
+    form["consent_contract_version"] = CONSENT_CONTRACT_VERSION
     form["platform_grants"] = ["records:read"]
     form["tools"] = ["records_export"]
     form["csrf_token"] = _csrf_token(client)
@@ -462,6 +518,7 @@ def test_consent_recovers_missing_authorize_fields_from_same_origin_referrer(cli
     referer = "http://testserver/oauth/authorize?" + up.urlencode(form)
     form.pop("client_id")
     form["decision"] = "approve"
+    form["consent_contract_version"] = CONSENT_CONTRACT_VERSION
     form["platform_grants"] = ["records:read"]
     form["tools"] = ["records_export"]
     form["csrf_token"] = csrf
@@ -486,6 +543,7 @@ def test_consent_recovers_blank_authorize_fields_from_same_origin_referrer(clien
     referer = "http://testserver/oauth/authorize?" + up.urlencode(form)
     form["client_id"] = ""
     form["decision"] = "approve"
+    form["consent_contract_version"] = CONSENT_CONTRACT_VERSION
     form["platform_grants"] = ["records:read"]
     form["tools"] = ["records_export"]
     form["csrf_token"] = csrf
@@ -533,6 +591,7 @@ def test_consent_uses_platform_user_id_as_grantor_when_available(client):
         resource="https://runtime.example.test/api/integrations/bundles/demo/demo/user-memories@2026-06-26/public/mcp/memories",
     )
     form["decision"] = "approve"
+    form["consent_contract_version"] = CONSENT_CONTRACT_VERSION
     form["platform_grants"] = ["memories:read"]
     form["tools"] = ["memory_search"]
     form["csrf_token"] = _csrf_token(client, token="user-tok", params=form)
@@ -569,3 +628,56 @@ def test_consent_deny_redirects_with_error(client):
     q = dict(up.parse_qsl(up.urlsplit(r.headers["location"]).query))
     assert q["error"] == "access_denied"
     assert q["state"] == "st-123"
+
+
+def test_a_submission_without_the_contract_version_issues_no_code(client):
+    """An absent version means the page never rendered the current view model.
+
+    Its silence about the operation selection is not a user's choice, so no
+    authorization code is issued and no card is born.
+    """
+    form = _params()
+    form["decision"] = "approve"
+    form["platform_grants"] = ["records:read"]
+    form["tools"] = ["records_export"]
+    form["csrf_token"] = _csrf_token(client)
+
+    r = client.post(
+        "/oauth/authorize/consent",
+        data=form,
+        headers={"Authorization": "Bearer admin-tok"},
+        follow_redirects=False,
+    )
+
+    assert r.status_code == 400
+    assert r.json()["error"] == "consent_ui_contract_mismatch"
+
+
+def test_the_consent_carries_the_operation_choice_into_the_code(client):
+    """Claims and operations are independent dimensions, so the code carries
+    both: the operator's operation selection travels to token exchange, where
+    the card is born with it."""
+    import json
+
+    store = client.app.state.oauth_grant_store
+    form = _params()
+    form["decision"] = "approve"
+    form["consent_contract_version"] = CONSENT_CONTRACT_VERSION
+    form["platform_grants"] = ["records:read"]
+    form["tools"] = ["records_export"]
+    form["csrf_token"] = _csrf_token(client)
+
+    r = client.post(
+        "/oauth/authorize/consent",
+        data=form,
+        headers={"Authorization": "Bearer admin-tok"},
+        follow_redirects=False,
+    )
+    assert r.status_code == 302
+    code = dict(up.parse_qsl(up.urlsplit(r.headers["location"]).query))["code"]
+    payload = json.loads(store._r.values[store._key("code", code)])
+
+    # Nothing offered, nothing selected: an explicit empty selection, not an
+    # absent one.
+    assert payload["named_service_operations"] == {}
+    assert "catalog_version" in payload

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/oauth/tests/test_authorize.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/oauth/tests/test_authorize.py
@@ -16,7 +16,10 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.oauth.tests.helpers import mount_test_oauth_adapter
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.oauth.tests.helpers import (
+    mount_test_oauth_adapter,
+    publish_delegated_config,
+)
 from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.oauth.flow import (
     AuthorizeError,
     build_redirect,
@@ -24,6 +27,7 @@ from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.oau
 )
 from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.oauth.consent import (
     CONSENT_CONTRACT_VERSION,
+    named_service_selection_rows,
     render_consent_html,
 )
 from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.oauth.config import oauth_delegated_config
@@ -175,7 +179,7 @@ def test_consent_html_shows_platform_account_and_logout():
 def test_consent_html_shows_named_service_namespace_operation_labels():
     app = FastAPI()
     resource = "https://runtime.example.test/public/mcp/named_services"
-    app.state.oauth_delegated_config = {
+    publish_delegated_config(app, {
         "enabled": True,
         "capabilities": [
             {"grant": "named_services:use", "label": "Use named services"},
@@ -213,7 +217,7 @@ def test_consent_html_shows_named_service_namespace_operation_labels():
                 },
             },
         ],
-    }
+    })
     req = parse_authorize_request(
         _params(scope="named_services:use memories:read memories:write", resource=resource),
         supported_scopes=oauth_delegated_config(app).supported_scopes(resource),
@@ -227,6 +231,117 @@ def test_consent_html_shows_named_service_namespace_operation_labels():
     assert "Write memory" in html
     assert "Create or update a memory note." in html
 
+
+
+
+def _seeding_config(resource: str) -> dict:
+    return {
+        "enabled": True,
+        "capabilities": [
+            {"grant": "named_services:use", "label": "Use named services"},
+            {"grant": "memories:read", "label": "Read memories"},
+            {"grant": "memories:write", "label": "Write memories"},
+        ],
+        "resources": [
+            {
+                "resource": resource,
+                "tools": {"named_services_call": {"grants": ["named_services:use"]}},
+                "named_services": {
+                    "namespaces": {
+                        "mem": {
+                            "label": "User memories",
+                            "authority_id": "delegated_client",
+                            "tools": {
+                                "search": {
+                                    "operation": "object.search",
+                                    "label": "Search memories",
+                                    "grants": ["memories:read"],
+                                },
+                                "upsert": {
+                                    "operation": "object.upsert",
+                                    "label": "Write memory",
+                                    "grants": ["memories:write"],
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        ],
+    }
+
+
+def _seeding_request(app, resource: str):
+    return parse_authorize_request(
+        _params(scope="named_services:use memories:read memories:write", resource=resource),
+        supported_scopes=oauth_delegated_config(app).supported_scopes(resource),
+    )
+
+
+def _checkbox(html: str, operation: str) -> str:
+    """The one input tag for this operation, so `checked` can be asserted on it."""
+    marker = f'value="mem:{operation}"'
+    start = html.index(marker)
+    return html[html.rindex("<input", 0, start) : html.index(">", start) + 1]
+
+
+def test_a_first_consent_seeds_nothing():
+    app = FastAPI()
+    resource = "https://runtime.example.test/public/mcp/named_services"
+    publish_delegated_config(app, _seeding_config(resource))
+
+    html = render_consent_html(
+        _seeding_request(app, resource),
+        issuer=ISSUER,
+        config=oauth_delegated_config(app),
+    )
+
+    assert "Nothing is selected by default" in html
+    assert "checked" not in _checkbox(html, "object.search")
+    assert "checked" not in _checkbox(html, "object.upsert")
+
+
+def test_a_re_consent_seeds_what_the_card_holds_and_separates_what_is_new():
+    """A submission REPLACES, so an unseeded picker would drop the grant.
+
+    The operation the card covers comes back checked; the one the catalog
+    added since is offered apart and unchecked, because widening is a decision
+    and not a default.
+    """
+    app = FastAPI()
+    resource = "https://runtime.example.test/public/mcp/named_services"
+    publish_delegated_config(app, _seeding_config(resource))
+
+    html = render_consent_html(
+        _seeding_request(app, resource),
+        issuer=ISSUER,
+        config=oauth_delegated_config(app),
+        seeded_named_service_operations={"mem": ["object.search"]},
+    )
+
+    assert "checked" in _checkbox(html, "object.search")
+    assert "checked" not in _checkbox(html, "object.upsert")
+    assert "Named-service operations this client has now" in html
+    assert "REPLACES" in html
+    assert "Added since this client was last approved" in html
+    assert "Nothing is selected by default" not in html
+
+
+def test_the_view_model_carries_what_the_card_holds():
+    """A custom renderer must be able to tell held from newly offered."""
+    app = FastAPI()
+    resource = "https://runtime.example.test/public/mcp/named_services"
+    publish_delegated_config(app, _seeding_config(resource))
+
+    rows = named_service_selection_rows(
+        ["named_services:use", "memories:read", "memories:write"],
+        config=oauth_delegated_config(app),
+        resource=resource,
+        seeded={"mem": ["object.search"]},
+    )
+
+    held = {row["operation"]: row["held"] for row in rows}
+    assert held == {"object.search": True, "object.upsert": False}
 
 # ----------------------------------- routes -----------------------------------
 
@@ -273,7 +388,7 @@ def test_authorize_rejects_user_without_delegable_grant(client):
 
 def test_authorize_can_render_bundle_hosted_consent(client, monkeypatch):
     captured = {}
-    client.app.state.oauth_delegated_config = {
+    publish_delegated_config(client.app, {
         "enabled": True,
         "issuer": ISSUER,
         "capabilities": [
@@ -309,7 +424,7 @@ def test_authorize_can_render_bundle_hosted_consent(client, monkeypatch):
                 "operation": "delegated_consent",
             },
         },
-    }
+    })
 
     async def fake_call_bundle_operation(**kwargs):
         captured.update(kwargs)
@@ -354,7 +469,7 @@ def test_a_renderer_that_does_not_state_the_contract_is_not_shown(client, monkey
     implements; an absent or older version is refused before the user can
     approve, instead of producing a card whose selection was never asked for.
     """
-    client.app.state.oauth_delegated_config = {
+    publish_delegated_config(client.app, {
         "enabled": True,
         "issuer": ISSUER,
         "capabilities": [
@@ -372,7 +487,7 @@ def test_a_renderer_that_does_not_state_the_contract_is_not_shown(client, monkey
                 "operation": "delegated_consent",
             },
         },
-    }
+    })
 
     async def stale_renderer(**kwargs):
         return {"delegated_consent": {"html": "<html><body>Stale consent</body></html>"}}
@@ -391,7 +506,7 @@ def test_a_renderer_that_does_not_state_the_contract_is_not_shown(client, monkey
 
 
 def test_authorize_renders_consent_for_regular_user_when_grant_is_delegable(client):
-    client.app.state.oauth_delegated_config = {
+    publish_delegated_config(client.app, {
         "enabled": True,
         "issuer": ISSUER,
         "capabilities": [
@@ -412,7 +527,7 @@ def test_authorize_renders_consent_for_regular_user_when_grant_is_delegable(clie
                 },
             },
         ],
-    }
+    })
     r = client.get(
         "/oauth/authorize",
         params=_params(
@@ -563,7 +678,7 @@ def test_consent_recovers_blank_authorize_fields_from_same_origin_referrer(clien
 
 
 def test_consent_uses_platform_user_id_as_grantor_when_available(client):
-    client.app.state.oauth_delegated_config = {
+    publish_delegated_config(client.app, {
         "enabled": True,
         "issuer": ISSUER,
         "capabilities": [
@@ -584,7 +699,7 @@ def test_consent_uses_platform_user_id_as_grantor_when_available(client):
                 },
             },
         ],
-    }
+    })
     store = client.app.state.oauth_grant_store
     form = _params(
         scope="memories:read",

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/oauth/tests/test_client_metadata.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/oauth/tests/test_client_metadata.py
@@ -4,6 +4,8 @@
 from __future__ import annotations
 
 import asyncio
+import os
+import time
 import re
 
 import pytest
@@ -34,6 +36,7 @@ from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.oau
     GrantStore,
 )
 from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.oauth.tests.helpers import (
+    bind_delegated_card_persistence,
     enable_delegated_client,
     mount_test_oauth_adapter,
 )
@@ -273,7 +276,7 @@ async def _mint_access_token(sub, scopes):
     }
 
 
-def _route_client(document):
+def _route_client(document, *, card_storage_root=None):
     app = FastAPI()
     enable_delegated_client(app, issuer=ISSUER)
     app.state.oauth_delegated_config["client_id_metadata_documents"] = {
@@ -291,6 +294,18 @@ def _route_client(document):
     app.state.oauth_authenticate = _authenticate
     app.state.oauth_grant_store = GrantStore(FakeRedis(), tenant="home", project="demo")
     app.state.oauth_mint_access_token = _mint_access_token
+    if card_storage_root is not None:
+        # Token issuance commits a delegated card, so a test that exchanges a
+        # code needs the capability a bundle binds in production.
+        if not os.environ.get("REDIS_URL"):
+            pytest.skip("REDIS_URL is not set; token issuance commits a delegated card")
+        import redis.asyncio as redis_asyncio
+
+        bind_delegated_card_persistence(
+            app,
+            redis=redis_asyncio.from_url(os.environ["REDIS_URL"]),
+            storage_root=card_storage_root,
+        )
     return TestClient(app), calls
 
 
@@ -356,9 +371,52 @@ def test_metadata_client_rejects_mismatched_document_identity():
     assert response.json()["error"] == "invalid_client_metadata"
 
 
-def test_metadata_client_survives_code_refresh_and_revocation_lifecycle():
-    client, _calls = _route_client(_document())
+
+def _seed_live_card(store, refresh_record) -> None:
+    """The live card projection the refresh path reads."""
+    from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.cache_io import (
+        encode_cache_value,
+    )
+    from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.cards.cache import (
+        DelegatedCardRuntimeCache,
+    )
+    from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.cards.model import (
+        CardAuthority,
+        NamedServiceSelection,
+    )
+
+    credential = refresh_record.get("credential") or {}
+    access_id = str(refresh_record["registry_access_id"])
+    resource = str(refresh_record.get("resource") or "") or "*"
+    authority = CardAuthority(
+        access_id=access_id,
+        client_id=str(refresh_record.get("client_id") or ""),
+        grantor_subject=str(refresh_record.get("sub") or ""),
+        delegate_subject=str(credential.get("subject") or ""),
+        source="oauth",
+        card_revision=1,
+        operations=tuple(refresh_record.get("operations") or ()),
+        resource_grants={resource: tuple(refresh_record.get("scopes") or ())},
+        named_service_operations=NamedServiceSelection.unknown(),
+        expires_at=int(time.time()) + 3600,
+    )
+    cache = DelegatedCardRuntimeCache(None, tenant="home", project="demo")
+    store.redis.values[cache.card_key(access_id)] = encode_cache_value(
+        {"kind": "card", "card_revision": 1, "authority": authority.to_dict()}
+    )
+
+
+def test_metadata_client_survives_code_refresh_and_revocation_lifecycle(tmp_path):
+    client, _calls = _route_client(_document(), card_storage_root=tmp_path)
     store = client.app.state.oauth_grant_store
+    # Entered as a context manager so every request runs on the same event
+    # loop: the Redis client the card persistence holds cannot survive a
+    # per-request loop.
+    with client:
+        _run_metadata_client_lifecycle(client, store)
+
+
+def _run_metadata_client_lifecycle(client, store):
     shown = client.get(
         "/oauth/authorize",
         params=_authorize_params(),
@@ -403,6 +461,7 @@ def test_metadata_client_survives_code_refresh_and_revocation_lifecycle():
     assert refresh_record["client_metadata"]["client_name"] == (
         "Example desktop client"
     )
+    _seed_live_card(store, refresh_record)
 
     refreshed = client.post(
         "/oauth/token",

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/oauth/tests/test_client_metadata.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/oauth/tests/test_client_metadata.py
@@ -29,6 +29,9 @@ from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.oau
 from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.oauth.config import (
     OAuthDelegatedClientMetadataDocumentsConfig,
 )
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.oauth.consent import (
+    CONSENT_CONTRACT_VERSION,
+)
 from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.oauth.pkce import (
     make_s256_challenge,
 )
@@ -431,6 +434,7 @@ def _run_metadata_client_lifecycle(client, store):
             **_authorize_params(),
             "csrf_token": match.group(1),
             "decision": "approve",
+            "consent_contract_version": CONSENT_CONTRACT_VERSION,
             "platform_grants": "records:read",
             "tools": "records_export",
         },
@@ -526,6 +530,7 @@ def test_metadata_change_after_display_requires_fresh_consent():
             **_authorize_params(),
             "csrf_token": match.group(1),
             "decision": "approve",
+            "consent_contract_version": CONSENT_CONTRACT_VERSION,
             "platform_grants": "records:read",
         },
         headers={"Authorization": "Bearer admin-tok"},

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/oauth/tests/test_csrf.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/oauth/tests/test_csrf.py
@@ -19,6 +19,9 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.oauth.tests.helpers import mount_test_oauth_adapter
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.oauth.consent import (
+    CONSENT_CONTRACT_VERSION,
+)
 from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.oauth.store import GrantStore
 from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.oauth.pkce import make_s256_challenge
 from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.oauth.tests.test_clients_and_store import FakeRedis
@@ -56,6 +59,7 @@ def _consent_form(csrf=None, decision="approve", **over):
     f["decision"] = decision
     f["platform_grants"] = ["records:read"]
     f["tools"] = ["records_export"]
+    f["consent_contract_version"] = CONSENT_CONTRACT_VERSION
     if csrf is not None:
         f["csrf_token"] = csrf
     return f

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/oauth/tests/test_surface_guard.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/oauth/tests/test_surface_guard.py
@@ -1109,11 +1109,18 @@ def test_named_service_boundary_narrowed_to_nothing_reaches_the_bridge(monkeypat
     assert boundary == {"namespaces": {}}
 
 
-def test_named_service_boundary_falls_back_to_the_snapshot_on_a_legacy_card(monkeypatch):
-    """Cards written before the field keep the bound snapshot."""
+def test_a_card_that_materialized_nothing_is_bounded_by_nothing(monkeypatch):
+    """A pre-encoding card is bounded by what it materialized, not by the
+    binding's embedded snapshot.
+
+    The boundary key was omitted when a card carried neither a selection nor a
+    tree, and an absent key leaves the descriptor as the only ceiling — so a
+    record whose writer never filled the field reached every namespace the
+    deployment configures.
+    """
     boundary = _boundary(monkeypatch, named_services={})
 
-    assert set(boundary["namespaces"]) == {"stale"}
+    assert boundary == {}
 
 
 # -- current-catalog intersection ----------------------------------------------

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/oauth/tests/test_surface_guard.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/oauth/tests/test_surface_guard.py
@@ -20,13 +20,24 @@ from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.oau
 from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.automation_access import (
     ACCESS_SOURCE_OAUTH,
     AutomationAccessRecord,
-    automation_record_key,
+    card_authority_from_record,
 )
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.cache_io import (
+    encode_cache_value,
+)
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.cards.cache import (
+    DelegatedCardRuntimeCache,
+)
+
 from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.cards.model import (
     NamedServiceSelection,
 )
 
 GUARD_RESOURCE = "http://testserver/guard"
+
+
+def _card_key(access_id: str) -> str:
+    return DelegatedCardRuntimeCache(None, tenant="home", project="demo").card_key(access_id)
 
 
 class _GrantStore:
@@ -281,16 +292,19 @@ def _live_card(
 
 
 def _store_live_card(redis: _Redis, card: AutomationAccessRecord) -> None:
-    redis.values[
-        automation_record_key("home", "demo", card.access_id)
-    ] = json.dumps(card.to_dict())
+    authority = card_authority_from_record(card)
+    redis.values[_card_key(card.access_id)] = encode_cache_value(
+        {
+            "kind": "card",
+            "card_revision": authority.card_revision,
+            "authority": authority.to_dict(),
+        }
+    )
 
 
 def test_managed_mcp_guard_fails_closed_when_live_card_is_malformed(monkeypatch):
     redis = _Redis()
-    redis.values[
-        automation_record_key("home", "demo", "oauth-access-1")
-    ] = "{"
+    redis.values[_card_key("oauth-access-1")] = "{"
     client = _client(
         monkeypatch,
         grant_record=_pointer_grant(),

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/oauth/tests/test_surface_guard.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/oauth/tests/test_surface_guard.py
@@ -77,6 +77,30 @@ GUARD_CONNECTIONS = {
 }
 
 
+def _connections_with_admin_wildcard(*, keep_guard_resource: bool = True) -> dict:
+    """The catalog shape the guard suite could not express before.
+
+    A deployment that declares the all-resource administrator row alongside its
+    specific rows. Withdrawing a specific row then leaves a row that matches
+    every URL, which is exactly the state that must still deny.
+    """
+    import copy as _copy
+
+    trimmed = _copy.deepcopy(GUARD_CONNECTIONS)
+    resources = trimmed["delegated_credentials"]["oauth"]["resources"]
+    if not keep_guard_resource:
+        resources.clear()
+    resources.append(
+        {
+            "resource": "*",
+            "label": "All platform and application APIs",
+            "admin_only": True,
+            "grants": ["kdcube:role:super-admin"],
+        }
+    )
+    return trimmed
+
+
 def _connections_without(*, tool: str = "", claim: str = "", resource: bool = True) -> dict:
     import copy as _copy
 
@@ -1354,3 +1378,70 @@ def test_a_removed_capability_denial_reads_no_historical_catalog(monkeypatch):
     assert response.status_code == 403
     assert response.json()["error"]["code"] == "delegated_capability_no_longer_available"
     assert reads == []
+
+
+# -- the administrator all-resource row is a surface, not a catch-all ---------
+
+
+def test_a_withdrawn_resource_is_denied_even_when_the_catalog_keeps_a_wildcard_row(
+    monkeypatch,
+):
+    """The invariant the whole slice exists for: an administrator can take a
+    door away. With a `*` row present, matching by request URL alone would find
+    it, and the bearer would keep authority nobody could revoke through the
+    catalog."""
+    client = _client(
+        monkeypatch,
+        connections=_connections_with_admin_wildcard(keep_guard_resource=False),
+        grant_record={"operations": ["records_export"], "credential": _authority()},
+    )
+
+    response = client.post(
+        "/guard", json=_rpc_tool_call(), headers={"Authorization": "Bearer reader"},
+    )
+
+    assert response.status_code == 403
+    body = response.json()
+    assert body["error"]["code"] == "delegated_capability_no_longer_available"
+    assert body["ret"]["requested_capability"]["kind"] == "resource"
+
+
+def test_an_administrator_card_still_reaches_the_wildcard_row(monkeypatch):
+    """The same row remains a real delegation surface for a card that holds it:
+    `*` answers a selector that is itself `*`."""
+    authority = _authority(scopes=["kdcube:role:super-admin"])
+    authority["attrs"]["resource_grants"] = {"*": ["kdcube:role:super-admin"]}
+    client = _client(
+        monkeypatch,
+        connections=_connections_with_admin_wildcard(keep_guard_resource=False),
+        auth={
+            "mode": "managed",
+            "authority_id": "delegated_client",
+            "tools": {"records_export": {"grants": ["kdcube:role:super-admin"]}},
+            "selected_tool_grants": True,
+        },
+        grant_record={"operations": ["records_export"], "credential": authority},
+    )
+
+    response = client.post(
+        "/guard", json=_rpc_tool_call(), headers={"Authorization": "Bearer reader"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["ok"] is True
+
+
+def test_a_surviving_resource_is_unaffected_by_the_wildcard_row(monkeypatch):
+    """A specific row still answers its own requests when both exist."""
+    client = _client(
+        monkeypatch,
+        connections=_connections_with_admin_wildcard(),
+        grant_record={"operations": ["records_export"], "credential": _authority()},
+    )
+
+    response = client.post(
+        "/guard", json=_rpc_tool_call(), headers={"Authorization": "Bearer reader"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["ok"] is True

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/oauth/tests/test_surface_guard.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/oauth/tests/test_surface_guard.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import json
 import time
 
+import pytest
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 from fastapi.testclient import TestClient
@@ -13,6 +14,9 @@ from starlette.requests import Request as StarletteRequest
 
 from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.oauth import (
     surface_guard,
+)
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.oauth.tests.helpers import (
+    bind_delegated_catalog,
 )
 from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.oauth.store import (
     GrantStoreUnavailable,
@@ -30,10 +34,61 @@ from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.car
 )
 
 from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.cards.model import (
+    CARD_STATE_REVOKED,
     NamedServiceSelection,
+)
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.cards.service import (
+    replace_state,
+)
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.cards.store import (
+    BundleStorageDelegatedCardStore,
+    subject_hash_for,
 )
 
 GUARD_RESOURCE = "http://testserver/guard"
+
+# The catalog generation these tests enforce against. Drift cases trim it.
+GUARD_CONNECTIONS = {
+    "delegated_credentials": {
+        "oauth": {
+            "enabled": True,
+            "resources": [
+                {
+                    "resource": GUARD_RESOURCE,
+                    "grants": [
+                        "records:read",
+                        "records:write",
+                        "memories:read",
+                        "memories:write",
+                    ],
+                    "tools": {
+                        "records_export": {"grants": ["records:read"]},
+                        "records_update": {"grants": ["records:write"]},
+                        "memory_search": {"grants": ["memories:read"]},
+                        "memory_delete": {"grants": ["memories:write"]},
+                    },
+                },
+            ],
+        },
+    },
+}
+
+
+def _connections_without(*, tool: str = "", claim: str = "", resource: bool = True) -> dict:
+    import copy as _copy
+
+    trimmed = _copy.deepcopy(GUARD_CONNECTIONS)
+    resources = trimmed["delegated_credentials"]["oauth"]["resources"]
+    if not resource:
+        resources.clear()
+        return trimmed
+    if tool:
+        resources[0]["tools"].pop(tool, None)
+    if claim:
+        resources[0]["grants"] = [
+            grant for grant in resources[0]["grants"] if grant != claim
+        ]
+    return trimmed
 
 
 def _card_key(access_id: str) -> str:
@@ -147,6 +202,9 @@ def _client(
     return_projection=False,
     return_named_services=False,
     redis=None,
+    connections=None,
+    catalog_unavailable="",
+    cards=None,
 ):
     async def fake_authenticate(token: str):
         if token != "reader":
@@ -166,6 +224,12 @@ def _client(
     app = FastAPI()
     app.state.oauth_grant_store = _GrantStore(grant_record, redis=redis)
     app.state.oauth_delegated_config = {"tenant": "home", "project": "demo"}
+    bind_delegated_catalog(
+        app,
+        GUARD_CONNECTIONS if connections is None else connections,
+        unavailable=catalog_unavailable,
+        cards=cards,
+    )
     auth = auth or {
         "mode": "managed",
         "authority_id": "delegated_client",
@@ -206,6 +270,9 @@ def _rest_client(
     user=None,
     operation="records_export",
     redis=None,
+    connections=None,
+    catalog_unavailable="",
+    cards=None,
 ):
     async def fake_authenticate(token: str):
         if token != "reader":
@@ -225,6 +292,12 @@ def _rest_client(
     app = FastAPI()
     app.state.oauth_grant_store = _GrantStore(grant_record, redis=redis)
     app.state.oauth_delegated_config = {"tenant": "home", "project": "demo"}
+    bind_delegated_catalog(
+        app,
+        GUARD_CONNECTIONS if connections is None else connections,
+        unavailable=catalog_unavailable,
+        cards=cards,
+    )
     auth = auth or {
         "mode": "managed",
         "authority_id": "delegated_client",
@@ -265,6 +338,7 @@ def _live_card(
     resource_grants=None,
     named_service_operations=None,
     named_services=None,
+    expires_at=None,
 ) -> AutomationAccessRecord:
     return AutomationAccessRecord(
         access_id=access_id,
@@ -286,7 +360,7 @@ def _live_card(
             else NamedServiceSelection.unknown()
         ),
         named_services=named_services or {},
-        expires_at=int(time.time()) + 3600,
+        expires_at=int(time.time()) + 3600 if expires_at is None else int(expires_at),
         source=ACCESS_SOURCE_OAUTH,
     )
 
@@ -876,8 +950,24 @@ def test_managed_guard_rejects_missing_resource(monkeypatch):
 
 
 def test_managed_guard_compares_forwarded_public_resource(monkeypatch):
+    # The catalog selector is a pattern, as a deployed descriptor writes it.
+    forwarded_catalog = {
+        "delegated_credentials": {
+            "oauth": {
+                "enabled": True,
+                "resources": [
+                    {
+                        "resource": "*/guard",
+                        "grants": ["records:read"],
+                        "tools": {"records_export": {"grants": ["records:read"]}},
+                    },
+                ],
+            },
+        },
+    }
     client = _client(
         monkeypatch,
+        connections=forwarded_catalog,
         grant_record={
             "operations": ["records_export"],
             "credential": _authority(
@@ -997,3 +1087,217 @@ def test_named_service_boundary_falls_back_to_the_snapshot_on_a_legacy_card(monk
     boundary = _boundary(monkeypatch, named_services={})
 
     assert set(boundary["namespaces"]) == {"stale"}
+
+
+# -- current-catalog intersection ----------------------------------------------
+
+
+def _denial_path(payload):
+    return payload["ret"]["requested_capability"]
+
+
+def test_a_resource_removed_from_the_catalog_denies_before_the_tool_runs(monkeypatch):
+    client = _client(
+        monkeypatch,
+        connections=_connections_without(resource=False),
+        grant_record={"operations": ["records_export"], "credential": _authority()},
+    )
+
+    response = client.post(
+        "/guard", json=_rpc_tool_call(), headers={"Authorization": "Bearer reader"},
+    )
+
+    assert response.status_code == 403
+    payload = response.json()
+    assert payload["error"]["code"] == "delegated_capability_no_longer_available"
+    assert payload["error"]["retryable"] is False
+    assert _denial_path(payload)["kind"] == "resource"
+
+
+def test_a_tool_removed_from_the_catalog_denies_with_its_whole_path(monkeypatch):
+    client = _client(
+        monkeypatch,
+        connections=_connections_without(tool="records_export"),
+        grant_record={"operations": ["records_export"], "credential": _authority()},
+    )
+
+    response = client.post(
+        "/guard", json=_rpc_tool_call(), headers={"Authorization": "Bearer reader"},
+    )
+
+    # A tool call is refused inside the RPC result, carrying the full path.
+    assert response.status_code == 200
+    result = response.json()["result"]
+    assert result["isError"] is True
+    payload = json.loads(result["content"][0]["text"])
+    assert payload["error"]["code"] == "delegated_capability_no_longer_available"
+    path = _denial_path(payload)
+    assert path["kind"] == "outer_operation"
+    assert path["outer_operation"] == "records_export"
+    assert path["resource"] == GUARD_RESOURCE
+    assert path["surface"] == "mcp"
+
+
+def test_a_claim_removed_from_the_catalog_denies_the_rest_operation(monkeypatch):
+    client = _rest_client(
+        monkeypatch,
+        connections=_connections_without(claim="records:read"),
+        auth={
+            "mode": "managed",
+            "authority_id": "delegated_client",
+            "grants": ["records:read"],
+            "operations": {"records_export": {"grants": ["records:read"]}},
+            "selected_operation_grants": True,
+        },
+        grant_record={"operations": ["records_export"], "credential": _authority()},
+    )
+
+    response = client.post("/guard", headers={"Authorization": "Bearer reader"})
+
+    assert response.status_code == 403
+    payload = response.json()
+    assert payload["error"]["code"] == "delegated_capability_no_longer_available"
+    path = _denial_path(payload)
+    assert path["kind"] == "resource_claim"
+    assert path["claim"] == "records:read"
+
+
+def test_a_card_that_still_matches_the_catalog_is_admitted(monkeypatch):
+    client = _client(
+        monkeypatch,
+        grant_record={"operations": ["records_export"], "credential": _authority()},
+    )
+
+    response = client.post(
+        "/guard", json=_rpc_tool_call(), headers={"Authorization": "Bearer reader"},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"ok": True}
+
+
+def test_an_unreadable_catalog_is_retryable_unavailability_not_a_denial(monkeypatch):
+    client = _client(
+        monkeypatch,
+        catalog_unavailable="durable_active_unreadable",
+        grant_record={"operations": ["records_export"], "credential": _authority()},
+    )
+
+    response = client.post(
+        "/guard", json=_rpc_tool_call(), headers={"Authorization": "Bearer reader"},
+    )
+
+    assert response.status_code == 503
+    payload = response.json()
+    assert payload["error"]["code"] == "temporarily_unavailable"
+    assert payload["error"]["retryable"] is True
+    assert payload["ret"]["reason"] == "durable_active_unreadable"
+
+
+def test_uninstalled_serving_resolvers_fail_closed(monkeypatch):
+    """Absent readers are a composition failure, never "no requirement"."""
+    client = _client(
+        monkeypatch,
+        grant_record={"operations": ["records_export"], "credential": _authority()},
+    )
+    delattr(client.app.state, "delegated_serving_resolvers")
+
+    response = client.post(
+        "/guard", json=_rpc_tool_call(), headers={"Authorization": "Bearer reader"},
+    )
+
+    assert response.status_code == 503
+    assert response.json()["ret"]["reason"] == "delegated_serving_resolvers_absent"
+
+
+# -- durable card read-through --------------------------------------------------
+
+
+async def _commit_card(store, card: AutomationAccessRecord, *, revoked: bool = False) -> None:
+    from datetime import datetime, timezone
+
+    authority = card_authority_from_record(card)
+    if revoked:
+        authority = replace_state(authority, CARD_STATE_REVOKED)
+    subject = subject_hash_for(card.grantor_subject)
+    pointer = await store.write_revision(
+        subject_hash=subject, authority=authority, updated_at=datetime.now(timezone.utc)
+    )
+    await store.advance_current(subject_hash=subject, pointer=pointer)
+
+
+def _durable_client(monkeypatch, store, *, redis=None):
+    return _client(
+        monkeypatch,
+        grant_record=_pointer_grant(),
+        redis=redis if redis is not None else _Redis(),
+        cards=store,
+    )
+
+
+@pytest.mark.asyncio
+async def test_an_evicted_projection_is_restored_from_the_committed_revision(
+    monkeypatch, tmp_path
+):
+    """A lost projection is not a revoked card: the durable revision stands."""
+    store = BundleStorageDelegatedCardStore(tmp_path)
+    await _commit_card(store, _live_card())
+    client = _durable_client(monkeypatch, store)
+
+    response = client.post(
+        "/guard", json=_rpc_tool_call(), headers={"Authorization": "Bearer reader"},
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json() == {"ok": True}
+
+
+@pytest.mark.asyncio
+async def test_an_expired_durable_card_denies(monkeypatch, tmp_path):
+    store = BundleStorageDelegatedCardStore(tmp_path)
+    await _commit_card(store, _live_card(expires_at=int(time.time()) - 60))
+    client = _durable_client(monkeypatch, store)
+
+    response = client.post(
+        "/guard", json=_rpc_tool_call(), headers={"Authorization": "Bearer reader"},
+    )
+
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_a_revoked_durable_card_denies(monkeypatch, tmp_path):
+    store = BundleStorageDelegatedCardStore(tmp_path)
+    await _commit_card(store, _live_card(), revoked=True)
+    client = _durable_client(monkeypatch, store)
+
+    response = client.post(
+        "/guard", json=_rpc_tool_call(), headers={"Authorization": "Bearer reader"},
+    )
+
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_unreadable_durable_state_is_unavailability_not_a_denial(
+    monkeypatch, tmp_path
+):
+    store = BundleStorageDelegatedCardStore(tmp_path)
+    card = _live_card()
+    await _commit_card(store, card)
+    # The pointer names a revision that is gone: corruption, not absence.
+    subject = subject_hash_for(card.grantor_subject)
+    current = await store.read_current(subject_hash=subject, access_id=card.access_id)
+    store.revision_path(
+        subject_hash=subject,
+        access_id=card.access_id,
+        revision_name=current.revision_name,
+    ).unlink()
+    client = _durable_client(monkeypatch, store)
+
+    response = client.post(
+        "/guard", json=_rpc_tool_call(), headers={"Authorization": "Bearer reader"},
+    )
+
+    assert response.status_code == 503
+    assert response.json()["error"] == "temporarily_unavailable"

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/oauth/tests/test_surface_guard.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/oauth/tests/test_surface_guard.py
@@ -22,6 +22,9 @@ from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.aut
     AutomationAccessRecord,
     automation_record_key,
 )
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.cards.model import (
+    NamedServiceSelection,
+)
 
 GUARD_RESOURCE = "http://testserver/guard"
 
@@ -266,7 +269,11 @@ def _live_card(
             if resource_grants is not None
             else {GUARD_RESOURCE: ("records:read",)}
         ),
-        named_service_operations=named_service_operations or {},
+        named_service_operations=(
+            NamedServiceSelection.exact(named_service_operations)
+            if named_service_operations
+            else NamedServiceSelection.unknown()
+        ),
         named_services=named_services or {},
         expires_at=int(time.time()) + 3600,
         source=ACCESS_SOURCE_OAUTH,

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/oauth/tests/test_surface_guard.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/oauth/tests/test_surface_guard.py
@@ -44,6 +44,9 @@ from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.car
     BundleStorageDelegatedCardStore,
     subject_hash_for,
 )
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.serving import (
+    SERVING_RESOLVERS_ATTR,
+)
 
 GUARD_RESOURCE = "http://testserver/guard"
 
@@ -1301,3 +1304,53 @@ async def test_unreadable_durable_state_is_unavailability_not_a_denial(
 
     assert response.status_code == 503
     assert response.json()["error"] == "temporarily_unavailable"
+
+
+def test_a_capability_the_catalog_still_offers_keeps_the_consent_path(monkeypatch):
+    """A card that never held a capability is not a withdrawn capability.
+
+    Collapsing the two would answer "no longer available" to someone who only
+    has to grant it, and consent is not offered for a withdrawn capability.
+    """
+    client = _client(
+        monkeypatch,
+        grant_record={"operations": [], "credential": _authority()},
+    )
+
+    response = client.post(
+        "/guard", json=_rpc_tool_call(), headers={"Authorization": "Bearer reader"},
+    )
+
+    assert response.status_code == 200
+    result = response.json()["result"]
+    assert result["isError"] is True
+    text = result["content"][0]["text"]
+    assert "not consented" in text
+    assert "delegated_capability_no_longer_available" not in text
+
+
+def test_a_removed_capability_denial_reads_no_historical_catalog(monkeypatch):
+    """Governed execution intersects with the active catalog and nothing else."""
+    client = _client(
+        monkeypatch,
+        connections=_connections_without(resource=False),
+        grant_record={"operations": ["records_export"], "credential": _authority()},
+    )
+    resolvers = getattr(client.app.state, SERVING_RESOLVERS_ATTR)
+    catalog = resolvers.catalog
+    reads: list[str] = []
+    original = catalog.resolve_version
+
+    async def _counted(version: str):
+        reads.append(version)
+        return await original(version)
+
+    catalog.resolve_version = _counted
+
+    response = client.post(
+        "/guard", json=_rpc_tool_call(), headers={"Authorization": "Bearer reader"},
+    )
+
+    assert response.status_code == 403
+    assert response.json()["error"]["code"] == "delegated_capability_no_longer_available"
+    assert reads == []

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/oauth/tests/test_token.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/oauth/tests/test_token.py
@@ -9,12 +9,17 @@ unit tests independent of the bundle-session authority.
 from __future__ import annotations
 
 import json
+import os
+import time
 
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.oauth.tests.helpers import mount_test_oauth_adapter
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.oauth.tests.helpers import (
+    bind_delegated_card_persistence,
+    mount_test_oauth_adapter,
+)
 from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.oauth.authority import (
     DELEGATED_CLIENT_CREDENTIAL_KIND,
 )
@@ -26,8 +31,21 @@ from kdcube_ai_app.apps.chat.sdk.solutions.connections.authority_registry import
 from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.oauth.pkce import make_s256_challenge
 from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.oauth.tests.test_clients_and_store import FakeRedis
 from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.oauth.tests.helpers import enable_delegated_client
-from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.automation_access import (
-    automation_record_key,
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.cache_io import (
+    encode_cache_value,
+)
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.cards.cache import (
+    DelegatedCardRuntimeCache,
+)
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.cards.model import (
+    CardAuthority,
+    NamedServiceSelection,
+)
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.cards.persistence import (
+    DurableCardPersistence,
+)
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.cards.service import (
+    CardCommitFailed,
 )
 
 VERIFIER = "code-verifier-" + "z" * 60
@@ -38,15 +56,69 @@ async def _fake_minter(sub, scopes):
     return {"access_token": f"kst1.mock.{sub}", "expires_in": 3600}
 
 
+
+def _card_key(access_id: str) -> str:
+    return DelegatedCardRuntimeCache(None, tenant="home", project="demo").card_key(access_id)
+
+
+def _seed_live_card(
+    store,
+    refresh_record,
+    *,
+    operations=("records_export",),
+    resource_grants=None,
+) -> str:
+    """Establish the live card projection the refresh path reads.
+
+    The precondition here is a live card, not a persistence layer, so the test
+    states it directly.
+    """
+    credential = refresh_record.get("credential") or {}
+    access_id = str(refresh_record["registry_access_id"])
+    resource = str(refresh_record.get("resource") or "") or "*"
+    authority = CardAuthority(
+        access_id=access_id,
+        client_id=str(refresh_record.get("client_id") or ""),
+        grantor_subject=str(refresh_record.get("sub") or ""),
+        delegate_subject=str(credential.get("subject") or ""),
+        source="oauth",
+        card_revision=1,
+        operations=tuple(operations),
+        resource_grants=(
+            resource_grants if resource_grants is not None else {resource: ("records:read",)}
+        ),
+        named_service_operations=NamedServiceSelection.unknown(),
+        expires_at=int(time.time()) + 3600,
+    )
+    store.redis.values[_card_key(access_id)] = encode_cache_value(
+        {
+            "kind": "card",
+            "card_revision": authority.card_revision,
+            "authority": authority.to_dict(),
+        }
+    )
+    return access_id
+
+
 @pytest.fixture
-def ctx():
+def ctx(tmp_path):
+    if not os.environ.get("REDIS_URL"):
+        pytest.skip("REDIS_URL is not set; token issuance commits a delegated card")
+    import redis.asyncio as redis_asyncio
+
     app = FastAPI()
     enable_delegated_client(app)
     mount_test_oauth_adapter(app)
     store = GrantStore(FakeRedis(), tenant="home", project="demo")
     app.state.oauth_grant_store = store
     app.state.oauth_mint_access_token = _fake_minter
-    return TestClient(app), store
+    redis = redis_asyncio.from_url(os.environ["REDIS_URL"])
+    bind_delegated_card_persistence(app, redis=redis, storage_root=tmp_path)
+    # Entered as a context manager so every request in a test runs on the same
+    # event loop: the Redis client the card persistence holds cannot survive a
+    # per-request loop.
+    with TestClient(app) as client:
+        yield client, store
 
 
 async def _seed_code(store, *, redirect_uri="http://127.0.0.1:9000/callback", client_id="claude"):
@@ -121,6 +193,39 @@ async def test_authorization_code_exchange_succeeds(ctx):
 
 
 @pytest.mark.asyncio
+async def test_token_is_withheld_when_the_card_does_not_commit(ctx, monkeypatch):
+    client, store = ctx
+    code = await _seed_code(store)
+
+    async def failing_persist(self, *args, **kwargs):
+        raise CardCommitFailed("durable_commit_failed")
+
+    monkeypatch.setattr(DurableCardPersistence, "persist", failing_persist)
+
+    r = client.post("/oauth/token", data={
+        "grant_type": "authorization_code",
+        "code": code,
+        "redirect_uri": "http://127.0.0.1:9000/callback",
+        "client_id": "claude",
+        "code_verifier": VERIFIER,
+    })
+
+    assert r.status_code == 503
+    assert r.json()["error"] == "temporarily_unavailable"
+    # The code was consumed before the card commit was attempted, so the client
+    # re-consents rather than retrying this exchange.
+    replay = client.post("/oauth/token", data={
+        "grant_type": "authorization_code",
+        "code": code,
+        "redirect_uri": "http://127.0.0.1:9000/callback",
+        "client_id": "claude",
+        "code_verifier": VERIFIER,
+    })
+    assert replay.status_code == 400
+    assert replay.json()["error"] == "invalid_grant"
+
+
+@pytest.mark.asyncio
 async def test_exchange_fails_on_bad_verifier(ctx):
     client, store = ctx
     code = await _seed_code(store)
@@ -189,6 +294,7 @@ async def test_refresh_token_rotates_and_issues_new_access(ctx):
         "code_verifier": VERIFIER,
     }).json()
     rt = first["refresh_token"]
+    _seed_live_card(store, await store.validate_refresh_token(rt))
 
     r = client.post("/oauth/token", data={
         "grant_type": "refresh_token", "refresh_token": rt, "client_id": "claude",
@@ -221,11 +327,7 @@ async def test_refresh_token_keeps_old_token_when_live_card_lookup_is_unavailabl
     }).json()
     refresh_token = first["refresh_token"]
     refresh_record = await store.validate_refresh_token(refresh_token)
-    card_key = automation_record_key(
-        "home",
-        "demo",
-        refresh_record["registry_access_id"],
-    )
+    card_key = _card_key(_seed_live_card(store, refresh_record))
     original_get = store.redis.get
 
     async def failing_card_get(key):
@@ -259,12 +361,7 @@ async def test_refresh_token_rejects_malformed_live_card_without_rotation(ctx):
     }).json()
     refresh_token = first["refresh_token"]
     refresh_record = await store.validate_refresh_token(refresh_token)
-    card_key = automation_record_key(
-        "home",
-        "demo",
-        refresh_record["registry_access_id"],
-    )
-    store.redis.values[card_key] = "{"
+    store.redis.values[_card_key(refresh_record["registry_access_id"])] = "{"
 
     response = client.post("/oauth/token", data={
         "grant_type": "refresh_token",
@@ -290,17 +387,10 @@ async def test_refresh_token_applies_empty_live_grant_narrowing(ctx):
     }).json()
     refresh_token = first["refresh_token"]
     refresh_record = await store.validate_refresh_token(refresh_token)
-    card_key = automation_record_key(
-        "home",
-        "demo",
-        refresh_record["registry_access_id"],
+    resource = str(refresh_record.get("resource") or "") or "*"
+    _seed_live_card(
+        store, refresh_record, operations=(), resource_grants={resource: ()}
     )
-    card = json.loads(store.redis.values[card_key])
-    card["operations"] = []
-    card["resource_grants"] = {
-        resource: [] for resource in card["resource_grants"]
-    }
-    store.redis.values[card_key] = json.dumps(card)
 
     response = client.post("/oauth/token", data={
         "grant_type": "refresh_token",

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/serving.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/serving.py
@@ -1,0 +1,178 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Elena Viter
+
+"""Readers of current delegated authority, composed for a serving process.
+
+A governed request resolves current authority from two shared sources: the
+registered catalog and durable card history. The process that enforces them
+does not own them, so the platform composes the readers once and request paths
+consume them. Enforcement code never learns which bundle publishes the catalog
+or how its storage is addressed.
+
+Resolution order for a consumer is request state, then app state. Absent
+readers are not "no requirement": the caller must fail closed.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.cache_settings import (
+    DelegatedCacheSettings,
+)
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.cards.store import (
+    BundleStorageDelegatedCardStore,
+)
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.catalog.resolver import (
+    DelegatedCatalogResolver,
+)
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.catalog.runtime_cache import (
+    DelegatedCatalogRuntimeCache,
+)
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.catalog.store import (
+    BundleStorageDelegatedCatalogStore,
+)
+
+LOGGER = logging.getLogger("connection_hub.delegated_serving")
+
+SERVING_RESOLVERS_ATTR = "delegated_serving_resolvers"
+
+
+@dataclass(frozen=True)
+class DelegatedServingResolvers:
+    """Read-only resolution of current delegated authority."""
+
+    catalog: DelegatedCatalogResolver
+    cards: BundleStorageDelegatedCardStore
+
+
+def connection_hub_app_id() -> str:
+    """The bundle that publishes delegated catalog and card history."""
+    from kdcube_ai_app.apps.chat.sdk.solutions.connections.authentication_surface import (
+        connection_hub_app_id as resolve,
+    )
+
+    return resolve()
+
+
+async def build_delegated_serving_resolvers(
+    *,
+    redis: Any,
+    tenant: str,
+    project: str,
+    bundle_id: str = "",
+) -> DelegatedServingResolvers | None:
+    """Compose the readers over the publishing bundle's shared storage.
+
+    Returns ``None`` when Redis or that storage cannot be addressed, so the
+    caller installs nothing rather than a half-built reader.
+    """
+    if redis is None:
+        return None
+    app_id = str(bundle_id or "").strip() or connection_hub_app_id()
+    scope_tenant = str(tenant or "").strip()
+    scope_project = str(project or "").strip()
+    if not app_id or not scope_tenant or not scope_project:
+        return None
+
+    from kdcube_ai_app.infra.plugin.bundle_storage import bundle_storage_dir
+
+    try:
+        storage_root = bundle_storage_dir(
+            bundle_id=app_id, tenant=scope_tenant, project=scope_project, ensure=False
+        )
+    except Exception:
+        LOGGER.warning(
+            "[connection-hub.delegated-serving] storage root unavailable bundle=%s", app_id,
+            exc_info=True,
+        )
+        return None
+
+    settings = await _cache_settings(tenant=scope_tenant, project=scope_project, bundle_id=app_id)
+    cache = DelegatedCatalogRuntimeCache(redis, tenant=scope_tenant, project=scope_project)
+    return DelegatedServingResolvers(
+        catalog=DelegatedCatalogResolver(
+            cache=cache,
+            store=BundleStorageDelegatedCatalogStore(storage_root),
+            settings=settings,
+        ),
+        cards=BundleStorageDelegatedCardStore(storage_root),
+    )
+
+
+async def _cache_settings(*, tenant: str, project: str, bundle_id: str) -> DelegatedCacheSettings:
+    """Residency settings from the publishing bundle's descriptor.
+
+    These are cache lifetimes, not authority, so an unreadable descriptor falls
+    back to the defaults instead of refusing to serve.
+    """
+    try:
+        from kdcube_ai_app.infra.plugin.bundle_store import get_bundle_props_from_authority
+
+        props = await get_bundle_props_from_authority(
+            tenant=tenant, project=project, bundle_id=bundle_id
+        )
+        connections = (props or {}).get("connections") if isinstance(props, dict) else None
+        return DelegatedCacheSettings.from_connections(connections or {})
+    except Exception:
+        LOGGER.warning(
+            "[connection-hub.delegated-serving] descriptor residency unavailable bundle=%s;"
+            " using defaults",
+            bundle_id,
+            exc_info=True,
+        )
+        return DelegatedCacheSettings()
+
+
+async def install_delegated_serving_resolvers(
+    app: Any,
+    *,
+    redis: Any,
+    tenant: str,
+    project: str,
+) -> bool:
+    """Bind the readers onto an application for its whole lifetime.
+
+    One process serves one tenant/project, so the readers have no per-request
+    input and are composed once at startup.
+    """
+    resolvers = await build_delegated_serving_resolvers(
+        redis=redis, tenant=tenant, project=project
+    )
+    state = getattr(app, "state", None)
+    if resolvers is None or state is None:
+        LOGGER.warning(
+            "[connection-hub.delegated-serving] readers not installed tenant=%s project=%s",
+            tenant,
+            project,
+        )
+        return False
+    setattr(state, SERVING_RESOLVERS_ATTR, resolvers)
+    LOGGER.info(
+        "[connection-hub.delegated-serving] readers installed tenant=%s project=%s bundle=%s",
+        tenant,
+        project,
+        connection_hub_app_id(),
+    )
+    return True
+
+
+def delegated_serving_resolvers(request: Any) -> DelegatedServingResolvers | None:
+    """Request-scoped readers first, then the application's own."""
+    for holder in (getattr(request, "state", None), getattr(getattr(request, "app", None), "state", None)):
+        resolvers = getattr(holder, SERVING_RESOLVERS_ATTR, None) if holder is not None else None
+        if isinstance(resolvers, DelegatedServingResolvers):
+            return resolvers
+    return None
+
+
+__all__ = [
+    "SERVING_RESOLVERS_ATTR",
+    "DelegatedServingResolvers",
+    "build_delegated_serving_resolvers",
+    "connection_hub_app_id",
+    "delegated_serving_resolvers",
+    "install_delegated_serving_resolvers",
+]

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/tests/test_automation_access.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/tests/test_automation_access.py
@@ -6,10 +6,18 @@
 from __future__ import annotations
 
 import json
+import os
+import uuid
 from types import SimpleNamespace
 
 import pytest
 
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.cards.persistence import (
+    DurableCardPersistence,
+)
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.cards.store import (
+    BundleStorageDelegatedCardStore,
+)
 from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.catalog.resolver import (
     CatalogUnavailable,
 )
@@ -75,6 +83,51 @@ class _Authority:
         self.logged_out.append(session_id)
         return True
 
+
+
+async def stored_card(
+    service: AutomationAccessService, access_id: str, *, grantor: str = "platform-user-1"
+) -> dict:
+    """The committed card, read through the persistence port."""
+    record = await service._load_record(access_id, grantor_subject=grantor)
+    assert record is not None, f"card {access_id} is not committed"
+    return record.to_dict()
+
+
+async def only_stored_card(
+    service: AutomationAccessService, *, grantor: str = "platform-user-1"
+) -> dict:
+    """The single committed card for a grantor."""
+    records = await service._list_active_records(grantor)
+    assert len(records) == 1, f"expected one card, found {len(records)}"
+    return records[0].to_dict()
+
+
+REDIS_URL = os.environ.get("REDIS_URL") or ""
+
+pytestmark = pytest.mark.skipif(
+    not REDIS_URL,
+    reason="REDIS_URL is not set; delegated-card persistence needs a real Redis",
+)
+
+
+@pytest.fixture
+async def card_persistence(tmp_path):
+    """Production card persistence: durable revisions plus a Redis projection."""
+    import redis.asyncio as redis_asyncio
+
+    client = redis_asyncio.from_url(REDIS_URL)
+    try:
+        await client.ping()
+    except Exception as exc:  # pragma: no cover - environment guard
+        pytest.skip(f"Redis at REDIS_URL is unreachable: {exc}")
+    yield DurableCardPersistence(
+        redis=client,
+        tenant=f"t-{uuid.uuid4().hex[:8]}",
+        project=f"p-{uuid.uuid4().hex[:8]}",
+        card_store=BundleStorageDelegatedCardStore(tmp_path),
+    )
+    await client.aclose()
 
 TEST_CATALOG_VERSION = "delegated_catalog_2026-08-11-10-30-00-123_d4e5f6a7b8c9"
 
@@ -269,12 +322,13 @@ def _named_services_config():
 
 
 @pytest.mark.asyncio
-async def test_automation_access_create_list_and_revoke():
+async def test_automation_access_create_list_and_revoke(card_persistence):
     redis = _Redis()
     store = _Store()
     authority = _Authority()
     service = AutomationAccessService(
         catalog_resolver=_CatalogResolver(),
+        card_persistence=card_persistence,
         redis=redis,
         tenant="demo-tenant",
         project="demo-project",
@@ -317,8 +371,7 @@ async def test_automation_access_create_list_and_revoke():
     assert [item["grant"] for item in listed["grant_options"]] == ["records:read"]
     assert listed["resources"][0]["operations"][0]["name"] == "records_export"
 
-    raw_record = next(iter(redis.values.values()))
-    assert json.loads(raw_record)["session_id"] == "session-1"
+    assert (await stored_card(service, created["access"]["access_id"]))["session_id"] == "session-1"
 
     revoked = await service.revoke_access(user, access_id=created["access"]["access_id"])
     assert revoked == {
@@ -339,7 +392,7 @@ async def test_automation_access_create_list_and_revoke():
 
 
 @pytest.mark.asyncio
-async def test_resource_options_project_exact_named_service_and_provider_catalogs():
+async def test_resource_options_project_exact_named_service_and_provider_catalogs(card_persistence):
     mail_requirement = {
         "provider_id": "google",
         "connector_app_id": "gmail",
@@ -373,6 +426,7 @@ async def test_resource_options_project_exact_named_service_and_provider_catalog
     store = _Store()
     service = AutomationAccessService(
         catalog_resolver=_CatalogResolver(),
+        card_persistence=card_persistence,
         redis=_Redis(),
         tenant="demo-tenant",
         project="demo-project",
@@ -422,10 +476,11 @@ async def test_resource_options_project_exact_named_service_and_provider_catalog
 
 
 @pytest.mark.asyncio
-async def test_automation_access_persists_only_selected_named_service_operations():
+async def test_automation_access_persists_only_selected_named_service_operations(card_persistence):
     store = _Store()
     service = AutomationAccessService(
         catalog_resolver=_CatalogResolver(),
+        card_persistence=card_persistence,
         redis=_Redis(),
         tenant="demo-tenant",
         project="demo-project",
@@ -464,9 +519,10 @@ async def test_automation_access_persists_only_selected_named_service_operations
 
 
 @pytest.mark.asyncio
-async def test_automation_access_rejects_named_service_operation_without_its_grants():
+async def test_automation_access_rejects_named_service_operation_without_its_grants(card_persistence):
     service = AutomationAccessService(
         catalog_resolver=_CatalogResolver(),
+        card_persistence=card_persistence,
         redis=_Redis(),
         tenant="demo-tenant",
         project="demo-project",
@@ -502,9 +558,10 @@ async def test_automation_access_rejects_named_service_operation_without_its_gra
 
 
 @pytest.mark.asyncio
-async def test_automation_access_rejects_non_delegable_grant():
+async def test_automation_access_rejects_non_delegable_grant(card_persistence):
     service = AutomationAccessService(
         catalog_resolver=_CatalogResolver(),
+        card_persistence=card_persistence,
         redis=_Redis(),
         tenant="demo-tenant",
         project="demo-project",
@@ -529,9 +586,10 @@ async def test_automation_access_rejects_non_delegable_grant():
 
 
 @pytest.mark.asyncio
-async def test_automation_access_requires_configured_resource_when_catalog_exists():
+async def test_automation_access_requires_configured_resource_when_catalog_exists(card_persistence):
     service = AutomationAccessService(
         catalog_resolver=_CatalogResolver(),
+        card_persistence=card_persistence,
         redis=_Redis(),
         tenant="demo-tenant",
         project="demo-project",
@@ -567,9 +625,10 @@ async def test_automation_access_requires_configured_resource_when_catalog_exist
 
 
 @pytest.mark.asyncio
-async def test_automation_access_all_resources_is_admin_only():
+async def test_automation_access_all_resources_is_admin_only(card_persistence):
     service = AutomationAccessService(
         catalog_resolver=_CatalogResolver(),
+        card_persistence=card_persistence,
         redis=_Redis(),
         tenant="demo-tenant",
         project="demo-project",
@@ -619,9 +678,10 @@ async def test_automation_access_all_resources_is_admin_only():
 
 
 @pytest.mark.asyncio
-async def test_automation_access_can_select_multiple_resources():
+async def test_automation_access_can_select_multiple_resources(card_persistence):
     service = AutomationAccessService(
         catalog_resolver=_CatalogResolver(),
+        card_persistence=card_persistence,
         redis=_Redis(),
         tenant="demo-tenant",
         project="demo-project",
@@ -670,7 +730,7 @@ class _OAuthStore(_Store):
 
 
 @pytest.mark.asyncio
-async def test_oauth_grant_registers_lists_and_revokes():
+async def test_oauth_grant_registers_lists_and_revokes(card_persistence):
     """An external client connecting via OAuth becomes a visible, revocable grant."""
     redis = _Redis()
     store = _OAuthStore()
@@ -681,6 +741,7 @@ async def test_oauth_grant_registers_lists_and_revokes():
     }
     service = AutomationAccessService(
         catalog_resolver=_CatalogResolver(),
+        card_persistence=card_persistence,
         redis=redis,
         tenant="demo-tenant",
         project="demo-project",
@@ -810,9 +871,10 @@ async def test_live_sessions_receive_delegated_access_changes():
     assert [e["action"] for e in relay.emitted] == ["granted", "revoked"]
 
 
-def _agent_service():
+def _agent_service(card_persistence):
     return AutomationAccessService(
         catalog_resolver=_CatalogResolver(),
+        card_persistence=card_persistence,
         redis=_Redis(),
         tenant="demo-tenant",
         project="demo-project",
@@ -828,8 +890,8 @@ _AGENT_USER = {"user_id": "platform-user-1", "roles": ["kdcube:role:registered"]
 
 
 @pytest.mark.asyncio
-async def test_create_access_with_agent_client_id_is_deterministic_and_stores_token():
-    service = _agent_service()
+async def test_create_access_with_agent_client_id_is_deterministic_and_stores_token(card_persistence):
+    service = _agent_service(card_persistence)
     created = await service.create_access(
         _AGENT_USER,
         label="lg-react (memories)",
@@ -856,15 +918,15 @@ async def test_create_access_with_agent_client_id_is_deterministic_and_stores_to
 
 
 @pytest.mark.asyncio
-async def test_reconsent_updates_one_record_and_preserves_created_at():
-    service = _agent_service()
+async def test_reconsent_updates_one_record_and_preserves_created_at(card_persistence):
+    service = _agent_service(card_persistence)
     first = await service.create_access(
         _AGENT_USER, label="lg-react", client_id=_AGENT_CLIENT,
         resource_grants={"https://example.test/mcp": ["records:read"]},
     )
     listed = await service.list_access(_AGENT_USER)
     assert len(listed["items"]) == 1
-    created_at = json.loads(next(iter(service._redis.values.values())))["created_at"]
+    created_at = (await only_stored_card(service))["created_at"]
 
     again = await service.create_access(
         _AGENT_USER, label="lg-react (relabeled)", client_id=_AGENT_CLIENT,
@@ -873,12 +935,12 @@ async def test_reconsent_updates_one_record_and_preserves_created_at():
     # Same deterministic access_id -> re-consent updates the SAME record, not a pile-up.
     assert again["access"]["access_id"] == first["access"]["access_id"]
     assert len((await service.list_access(_AGENT_USER))["items"]) == 1
-    assert json.loads(next(iter(service._redis.values.values())))["created_at"] == created_at
+    assert (await only_stored_card(service))["created_at"] == created_at
 
 
 @pytest.mark.asyncio
-async def test_agent_access_token_none_when_no_grant_or_scope_mismatch():
-    service = _agent_service()
+async def test_agent_access_token_none_when_no_grant_or_scope_mismatch(card_persistence):
+    service = _agent_service(card_persistence)
     await service.create_access(
         _AGENT_USER, label="lg-react", client_id=_AGENT_CLIENT,
         resource_grants={"https://example.test/mcp": ["records:read"]},
@@ -897,10 +959,10 @@ async def test_agent_access_token_none_when_no_grant_or_scope_mismatch():
 
 
 @pytest.mark.asyncio
-async def test_agent_regrant_MERGES_claims_never_replaces():
+async def test_agent_regrant_MERGES_claims_never_replaces(card_persistence):
     # Sequential one-click grants on the SAME resource must accumulate:
     # granting write after read keeps read (a replace would silently revoke it).
-    service = _agent_service()
+    service = _agent_service(card_persistence)
     writer = {**_AGENT_USER, "permissions": ["records:write"]}
     await service.create_access(
         writer, label="a", client_id=_AGENT_CLIENT,
@@ -919,10 +981,10 @@ async def test_agent_regrant_MERGES_claims_never_replaces():
 
 
 @pytest.mark.asyncio
-async def test_agent_regrant_with_merge_existing_false_REPLACES_the_record():
+async def test_agent_regrant_with_merge_existing_false_REPLACES_the_record(card_persistence):
     # The EDIT semantics: the user unchecked a claim; the submitted set becomes
     # the record exactly — the merge default would have kept the removed claim.
-    service = _agent_service()
+    service = _agent_service(card_persistence)
     writer = {**_AGENT_USER, "permissions": ["records:write"]}
     await service.create_access(
         writer, label="a", client_id=_AGENT_CLIENT,
@@ -941,7 +1003,7 @@ async def test_agent_regrant_with_merge_existing_false_REPLACES_the_record():
     assert len((await service.list_access(writer))["items"]) == 1
 
 
-def _named_services_agent_service():
+def _named_services_agent_service(card_persistence):
     from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.oauth.config import (
         oauth_delegated_config,
     )
@@ -987,6 +1049,7 @@ def _named_services_agent_service():
     )
     return AutomationAccessService(
         catalog_resolver=_CatalogResolver(),
+        card_persistence=card_persistence,
         redis=_Redis(), tenant="demo-tenant", project="demo-project",
         config=oauth_delegated_config(SimpleNamespace(state=state)),
         grant_store=_Store(), authority=_Authority(), minter=_minter,
@@ -994,12 +1057,12 @@ def _named_services_agent_service():
 
 
 @pytest.mark.asyncio
-async def test_agent_namespace_grant_state_governs_and_grants():
+async def test_agent_namespace_grant_state_governs_and_grants(card_persistence):
     # The NATIVE named-service gate's answer: which resource publishes the
     # namespace, the operation's required claims, and whether THIS agent holds
     # them — pending before the grant, granted after, ungoverned namespaces
     # impose no gate.
-    service = _named_services_agent_service()
+    service = _named_services_agent_service(card_persistence)
     ns_resource = "*/kdcube-services@1-0/public/mcp/named_services*"
 
     pending = await service.agent_namespace_grant_state(
@@ -1038,8 +1101,8 @@ async def test_agent_namespace_grant_state_governs_and_grants():
 
 
 @pytest.mark.asyncio
-async def test_manual_automation_keeps_random_client_and_no_stored_token():
-    service = _agent_service()
+async def test_manual_automation_keeps_random_client_and_no_stored_token(card_persistence):
+    service = _agent_service(card_persistence)
     created = await service.create_access(
         _AGENT_USER, label="Nightly", resource_grants={"https://example.test/mcp": ["records:read"]},
     )
@@ -1047,11 +1110,11 @@ async def test_manual_automation_keeps_random_client_and_no_stored_token():
     # token returned to the caller but NOT persisted in the record for reuse.
     assert created["access"]["client_id"].startswith("automation:")
     assert created["access"]["source"] == "manual"
-    assert json.loads(next(iter(service._redis.values.values()))).get("access_token", "") == ""
+    assert (await only_stored_card(service)).get("access_token", "") == ""
 
 
 @pytest.mark.asyncio
-async def test_external_client_card_extends_and_refresh_registration_merges():
+async def test_external_client_card_extends_and_refresh_registration_merges(card_persistence):
     # The card is the authority (the guard resolves it live): a hub-side
     # extension merges claims into an EXTERNAL client's existing card, an
     # unknown client is never created here, and the refresh-time
@@ -1061,7 +1124,7 @@ async def test_external_client_card_extends_and_refresh_registration_merges():
         oauth_access_id,
     )
 
-    service = _agent_service()
+    service = _agent_service(card_persistence)
     resource = "https://example.test/mcp"
 
     # Extension before any consent: nothing to extend.
@@ -1097,11 +1160,11 @@ async def test_external_client_card_extends_and_refresh_registration_merges():
 
 
 @pytest.mark.asyncio
-async def test_external_client_edit_replaces_and_narrows():
+async def test_external_client_edit_replaces_and_narrows(card_persistence):
     # The pointer/card design: editing an external client's card REPLACES its
     # resource grants exactly (narrowing allowed, read+write -> read). The
     # guard resolves the card live, so it applies on the client's next call.
-    service = _agent_service()
+    service = _agent_service(card_persistence)
     resource = "https://example.test/mcp"
 
     await service.record_oauth_grant(
@@ -1125,11 +1188,11 @@ async def test_external_client_edit_replaces_and_narrows():
 
 
 @pytest.mark.asyncio
-async def test_agent_grant_carries_account_scope_and_merges():
+async def test_agent_grant_carries_account_scope_and_merges(card_persistence):
     # The agent card carries a per-account claim binding
     # {provider: {account_id: [claims]}}; a re-grant MERGES (union) claims per
     # account, replace overwrites — "read+write on one, read-only on another".
-    service = _agent_service()
+    service = _agent_service(card_persistence)
     resource = "https://example.test/mcp"
 
     created = await service.create_access(
@@ -1159,8 +1222,8 @@ async def test_agent_grant_carries_account_scope_and_merges():
 
 
 @pytest.mark.asyncio
-async def test_agent_replace_distinguishes_omitted_scope_from_explicit_clear():
-    service = _agent_service()
+async def test_agent_replace_distinguishes_omitted_scope_from_explicit_clear(card_persistence):
+    service = _agent_service(card_persistence)
     resource = "https://example.test/mcp"
     await service.create_access(
         _AGENT_USER,
@@ -1193,10 +1256,10 @@ async def test_agent_replace_distinguishes_omitted_scope_from_explicit_clear():
 
 
 @pytest.mark.asyncio
-async def test_agent_grant_account_scope_accepts_legacy_list_form():
+async def test_agent_grant_account_scope_accepts_legacy_list_form(card_persistence):
     # Backward compat: the old {provider: [account_ids]} form migrates to
     # {account_id: ["*"]} (bound to those accounts, any claim) — no breakage.
-    service = _agent_service()
+    service = _agent_service(card_persistence)
     resource = "https://example.test/mcp"
     created = await service.create_access(
         _AGENT_USER, label="a", client_id=_AGENT_CLIENT,
@@ -1237,10 +1300,10 @@ def test_credential_view_without_delegated_credential_has_no_account_restriction
 
 
 @pytest.mark.asyncio
-async def test_external_client_edit_account_scope_merge_and_replace():
+async def test_external_client_edit_account_scope_merge_and_replace(card_persistence):
     # Gap #1 closed: an external client's card account binding is editable
     # (merge extends, replace narrows), same as its claims.
-    service = _agent_service()
+    service = _agent_service(card_persistence)
     resource = "https://example.test/mcp"
     await service.record_oauth_grant(
         grantor_subject="platform-user-1", client_id="claude",
@@ -1280,9 +1343,9 @@ async def test_external_client_edit_account_scope_merge_and_replace():
 
 
 @pytest.mark.asyncio
-async def test_agent_grant_state_exposes_account_scope_for_native_gate():
+async def test_agent_grant_state_exposes_account_scope_for_native_gate(card_persistence):
     # Gap #3 source: the native gate reads account_scope off AGENT_GRANT_CHECK.
-    service = _named_services_agent_service()
+    service = _named_services_agent_service(card_persistence)
     door = "*/kdcube-services@1-0/public/mcp/named_services*"
     await service.create_access(
         _AGENT_USER, label="a", client_id=_AGENT_CLIENT,
@@ -1298,12 +1361,12 @@ async def test_agent_grant_state_exposes_account_scope_for_native_gate():
 
 
 @pytest.mark.asyncio
-async def test_agent_binding_carries_the_card_pointer_for_live_resolution():
+async def test_agent_binding_carries_the_card_pointer_for_live_resolution(card_persistence):
     # Gap #2 fix: an agent bearer's binding is a POINTER onto its card
     # (registry_access_id = the card access_id), so the guard resolves the card
     # live and an edit (claims OR account_scope) applies to the reused agent
     # bearer on its next call — not only after a re-mint, matching OAuth.
-    service = _agent_service()
+    service = _agent_service(card_persistence)
     resource = "https://example.test/mcp"
     result = await service.create_access(
         _AGENT_USER, label="a", client_id=_AGENT_CLIENT,
@@ -1313,18 +1376,18 @@ async def test_agent_binding_carries_the_card_pointer_for_live_resolution():
     access_id = result["access"]["access_id"]
     assert access_id  # deterministic agent card id
     # The last bind carries the pointer to that exact card.
-    assert store_bound_pointer(service) == access_id
+    assert store_bound_pointer(card_persistence, service) == access_id
 
 
-def store_bound_pointer(service):
-    # The _agent_service()'s store is a fresh _Store; its last bind records
+def store_bound_pointer(card_persistence, service):
+    # The _agent_service(card_persistence)'s store is a fresh _Store; its last bind records
     # registry_access_id when the pointer was passed.
     bound = getattr(service._store, "bound", [])
     return bound[-1].get("registry_access_id") if bound else None
 
 
 @pytest.mark.asyncio
-async def test_disconnecting_an_account_clears_its_agent_bindings():
+async def test_disconnecting_an_account_clears_its_agent_bindings(card_persistence):
     """Disconnecting a connected account must drop it from every grant that
     binds it. Account ids are deterministic, so a binding left behind would
     silently revive - re-granting access nobody ticked - if the same account
@@ -1332,6 +1395,7 @@ async def test_disconnecting_an_account_clears_its_agent_bindings():
     redis = _Redis()
     service = AutomationAccessService(
         catalog_resolver=_CatalogResolver(),
+        card_persistence=card_persistence,
         redis=redis,
         tenant="demo-tenant",
         project="demo-project",
@@ -1358,7 +1422,7 @@ async def test_disconnecting_an_account_clears_its_agent_bindings():
     )
     assert result["pruned"] == 1 and access_id in result["grants"]
 
-    record = json.loads(redis.values[service._record_key(access_id)])
+    record = await stored_card(service, access_id)
     scope = record["account_scope"]
     # The disconnected account is gone; its provider survives with the sibling.
     assert "google_aaa" not in scope.get("google", {})
@@ -1371,7 +1435,7 @@ async def test_disconnecting_an_account_clears_its_agent_bindings():
     await service.prune_account_from_grants(
         grantor_subject="platform-user-1", provider_id="google", account_id="google_bbb",
     )
-    record = json.loads(redis.values[service._record_key(access_id)])
+    record = await stored_card(service, access_id)
     assert "google" not in record["account_scope"]
 
     # An account nobody bound is a no-op.
@@ -1382,7 +1446,7 @@ async def test_disconnecting_an_account_clears_its_agent_bindings():
 
 
 @pytest.mark.asyncio
-async def test_automation_access_update_replaces_grants_in_place_and_keeps_identity():
+async def test_automation_access_update_replaces_grants_in_place_and_keeps_identity(card_persistence):
     """Edit a manual automation IN PLACE: the grant set is replaced, the card
     (access_id/client_id) and its client-side token are kept, and no re-mint or
     re-bind happens — the guard resolves the card live, so the new scope applies
@@ -1392,6 +1456,7 @@ async def test_automation_access_update_replaces_grants_in_place_and_keeps_ident
     authority = _Authority()
     service = AutomationAccessService(
         catalog_resolver=_CatalogResolver(),
+        card_persistence=card_persistence,
         redis=redis, tenant="demo-tenant", project="demo-project",
         config=_config(), grant_store=store, authority=authority, minter=_minter,
     )
@@ -1425,13 +1490,14 @@ async def test_automation_access_update_replaces_grants_in_place_and_keeps_ident
     assert len(store.bound) == bound_before                 # NO re-mint / re-bind
 
     # The live card the guard resolves now carries the new grant.
-    raw_record = next(iter(redis.values.values()))
-    assert json.loads(raw_record)["resource_grants"] == {"https://example.test/mcp": ["records:write"]}
+    assert (await stored_card(service, access_id))["resource_grants"] == {
+        "https://example.test/mcp": ["records:write"]
+    }
 
 
 @pytest.mark.asyncio
-async def test_automation_access_update_explicit_empty_scope_clears_binding():
-    service = _agent_service()
+async def test_automation_access_update_explicit_empty_scope_clears_binding(card_persistence):
+    service = _agent_service(card_persistence)
     user = {
         "user_id": "platform-user-1",
         "roles": ["kdcube:role:super-admin"],
@@ -1456,12 +1522,13 @@ async def test_automation_access_update_explicit_empty_scope_clears_binding():
 
 
 @pytest.mark.asyncio
-async def test_automation_access_update_guards_ownership_existence_and_empty():
+async def test_automation_access_update_guards_ownership_existence_and_empty(card_persistence):
     redis = _Redis()
     store = _Store()
     authority = _Authority()
     service = AutomationAccessService(
         catalog_resolver=_CatalogResolver(),
+        card_persistence=card_persistence,
         redis=redis, tenant="demo-tenant", project="demo-project",
         config=_config(), grant_store=store, authority=authority, minter=_minter,
     )
@@ -1477,22 +1544,25 @@ async def test_automation_access_update_guards_ownership_existence_and_empty():
     assert missing["ok"] is False and missing["error"] == "delegated_access_not_found"
 
     intruder = {"user_id": "intruder", "roles": ["kdcube:role:registered"], "permissions": []}
+    # Loads are grantor-scoped, so another user's card is simply not visible.
+    # The response no longer distinguishes "exists but yours" from "absent".
     not_owned = await service.update_access(
         intruder, access_id=access_id, resource_grants={"https://example.test/mcp": ["records:read"]},
     )
-    assert not_owned["ok"] is False and not_owned["error"] == "delegated_access_not_owned"
+    assert not_owned["ok"] is False and not_owned["error"] == "delegated_access_not_found"
 
     empty = await service.update_access(owner, access_id=access_id, resource_grants={})
     assert empty["ok"] is False and empty["error"] == "delegated_access_requires_resource_grants"
 
 
 @pytest.mark.asyncio
-async def test_automation_access_update_replaces_named_service_operations_without_rebinding():
+async def test_automation_access_update_replaces_named_service_operations_without_rebinding(card_persistence):
     """Editing the namespace selection rewrites the card only; no binding is
     written."""
     store = _Store()
     service = AutomationAccessService(
         catalog_resolver=_CatalogResolver(),
+        card_persistence=card_persistence,
         redis=_Redis(), tenant="demo-tenant", project="demo-project",
         config=_named_services_config(), grant_store=store, authority=_Authority(),
         minter=_minter, named_service_discovery=_NamedServiceDiscovery({}),
@@ -1506,6 +1576,7 @@ async def test_automation_access_update_replaces_named_service_operations_withou
         named_service_operations={resource: {"slack": ["object.search"]}},
     )
     assert created["ok"] is True
+    access_id = created["access"]["access_id"]
     bound_before = len(store.bound)
 
     widened = await service.update_access(
@@ -1522,9 +1593,7 @@ async def test_automation_access_update_replaces_named_service_operations_withou
 
     # The tree the guard copies onto the request is recomputed from the
     # descriptor and now carries the added operation.
-    card = json.loads(next(
-        raw for key, raw in service._redis.values.items() if "automation" in key
-    ))
+    card = await stored_card(service, access_id)
     tools = card["named_services"]["namespaces"]["slack"]["tools"]
     assert set(tools["call"]["operations"]) == {"object.search", "object.action"}
 
@@ -1536,17 +1605,16 @@ async def test_automation_access_update_replaces_named_service_operations_withou
 
     assert cleared["access"]["named_service_operations"] == {resource: {}}
     assert len(store.bound) == bound_before
-    card = json.loads(next(
-        raw for key, raw in service._redis.values.items() if "automation" in key
-    ))
+    card = await stored_card(service, access_id)
     assert card["named_services"]["namespaces"] == {}
 
 
 @pytest.mark.asyncio
-async def test_automation_access_update_rejects_an_operation_its_grants_do_not_cover():
+async def test_automation_access_update_rejects_an_operation_its_grants_do_not_cover(card_persistence):
     """The selection is validated at save time."""
     service = AutomationAccessService(
         catalog_resolver=_CatalogResolver(),
+        card_persistence=card_persistence,
         redis=_Redis(), tenant="demo-tenant", project="demo-project",
         config=_named_services_config(), grant_store=_Store(), authority=_Authority(),
         minter=_minter, named_service_discovery=_NamedServiceDiscovery({}),
@@ -1571,11 +1639,12 @@ async def test_automation_access_update_rejects_an_operation_its_grants_do_not_c
 
 
 @pytest.mark.asyncio
-async def test_automation_access_update_omitting_the_narrowing_keeps_it():
+async def test_automation_access_update_omitting_the_narrowing_keeps_it(card_persistence):
     """Absent vs empty, same rule as account_scope: omitting the narrowing keeps
     the record's, an explicit {} widens to the full policy."""
     service = AutomationAccessService(
         catalog_resolver=_CatalogResolver(),
+        card_persistence=card_persistence,
         redis=_Redis(), tenant="demo-tenant", project="demo-project",
         config=_named_services_config(), grant_store=_Store(), authority=_Authority(),
         minter=_minter, named_service_discovery=_NamedServiceDiscovery({}),
@@ -1589,8 +1658,8 @@ async def test_automation_access_update_omitting_the_narrowing_keeps_it():
     )
     access_id = created["access"]["access_id"]
 
-    def _card():
-        raw = json.loads(service._redis.values[service._record_key(access_id)])
+    async def _card():
+        raw = await stored_card(service, access_id)
         namespaces = raw["named_services"]["namespaces"]
         return raw.get("named_service_operations"), sorted(
             namespaces.get("slack", {}).get("tools", {}).get("call", {}).get("operations", {})
@@ -1600,23 +1669,24 @@ async def test_automation_access_update_omitting_the_narrowing_keeps_it():
         user, access_id=access_id, resource_grants={resource: grants}, label="Renamed",
     )
     assert renamed["ok"] is True
-    assert _card() == ({resource: {"slack": ["object.search"]}}, ["object.search"])
+    assert await _card() == ({resource: {"slack": ["object.search"]}}, ["object.search"])
 
     await service.update_access(
         user, access_id=access_id, resource_grants={resource: grants},
         named_service_operations={},
     )
-    selection, operations = _card()
+    selection, operations = await _card()
     assert selection == {}
     assert operations == []
 
 
 @pytest.mark.asyncio
-async def test_agent_grant_replace_without_the_narrowing_keeps_it():
+async def test_agent_grant_replace_without_the_narrowing_keeps_it(card_persistence):
     """A replace edit that submits no narrowing (a rename) must not widen the
     agent's boundary."""
     service = AutomationAccessService(
         catalog_resolver=_CatalogResolver(),
+        card_persistence=card_persistence,
         redis=_Redis(), tenant="demo-tenant", project="demo-project",
         config=_named_services_config(), grant_store=_Store(), authority=_Authority(),
         minter=_minter, named_service_discovery=_NamedServiceDiscovery({}),
@@ -1641,11 +1711,12 @@ async def test_agent_grant_replace_without_the_narrowing_keeps_it():
 
 
 @pytest.mark.asyncio
-async def test_automation_access_update_empty_narrowing_clears_every_resource():
+async def test_automation_access_update_empty_narrowing_clears_every_resource(card_persistence):
     """An explicit {} is the clear, and it reaches resources the caller did not
     name — the widget therefore omits the field when it has no selection."""
     service = AutomationAccessService(
         catalog_resolver=_CatalogResolver(),
+        card_persistence=card_persistence,
         redis=_Redis(), tenant="demo-tenant", project="demo-project",
         config=_named_services_config(), grant_store=_Store(), authority=_Authority(),
         minter=_minter, named_service_discovery=_NamedServiceDiscovery({}),
@@ -1656,24 +1727,24 @@ async def test_automation_access_update_empty_narrowing_clears_every_resource():
     created = await service.create_access(user, label="all ops", resource_grants={resource: grants})
     access_id = created["access"]["access_id"]
 
-    def _namespaces():
-        raw = json.loads(service._redis.values[service._record_key(access_id)])
+    async def _namespaces():
+        raw = await stored_card(service, access_id)
         return sorted(raw["named_services"]["namespaces"])
 
     # No narrowing asked for: the full descriptor policy, which the bridge
     # still gates per operation against the card's grants.
-    assert _namespaces() == ["mail", "slack"]
+    assert await _namespaces() == ["mail", "slack"]
 
     await service.update_access(
         user, access_id=access_id, resource_grants={resource: grants}, label="Renamed",
     )
-    assert _namespaces() == ["mail", "slack"]        # omitted -> preserved
+    assert await _namespaces() == ["mail", "slack"]        # omitted -> preserved
 
     await service.update_access(
         user, access_id=access_id, resource_grants={resource: grants},
         named_service_operations={},
     )
-    assert _namespaces() == []               # explicit {} -> cleared
+    assert await _namespaces() == []               # explicit {} -> cleared
 
 
 def test_a_catalog_tool_whose_claim_was_never_declared_is_reported():

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/tests/test_automation_access.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/tests/test_automation_access.py
@@ -10,6 +10,9 @@ from types import SimpleNamespace
 
 import pytest
 
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.catalog.resolver import (
+    CatalogUnavailable,
+)
 from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.automation_access import (
     AutomationAccessService,
 )
@@ -71,6 +74,22 @@ class _Authority:
     async def logout(self, *, session_id: str):
         self.logged_out.append(session_id)
         return True
+
+
+TEST_CATALOG_VERSION = "delegated_catalog_2026-08-11-10-30-00-123_d4e5f6a7b8c9"
+
+
+class _CatalogResolver:
+    """Resolves a fixed active catalog version; `unavailable` fails closed."""
+
+    def __init__(self, version: str = TEST_CATALOG_VERSION, unavailable: bool = False) -> None:
+        self.version = version
+        self.unavailable = unavailable
+
+    async def resolve_active(self):
+        if self.unavailable:
+            raise CatalogUnavailable("active_catalog_not_registered")
+        return SimpleNamespace(version=self.version)
 
 
 class _NamedServiceDiscovery:
@@ -255,6 +274,7 @@ async def test_automation_access_create_list_and_revoke():
     store = _Store()
     authority = _Authority()
     service = AutomationAccessService(
+        catalog_resolver=_CatalogResolver(),
         redis=redis,
         tenant="demo-tenant",
         project="demo-project",
@@ -352,6 +372,7 @@ async def test_resource_options_project_exact_named_service_and_provider_catalog
     )
     store = _Store()
     service = AutomationAccessService(
+        catalog_resolver=_CatalogResolver(),
         redis=_Redis(),
         tenant="demo-tenant",
         project="demo-project",
@@ -404,6 +425,7 @@ async def test_resource_options_project_exact_named_service_and_provider_catalog
 async def test_automation_access_persists_only_selected_named_service_operations():
     store = _Store()
     service = AutomationAccessService(
+        catalog_resolver=_CatalogResolver(),
         redis=_Redis(),
         tenant="demo-tenant",
         project="demo-project",
@@ -444,6 +466,7 @@ async def test_automation_access_persists_only_selected_named_service_operations
 @pytest.mark.asyncio
 async def test_automation_access_rejects_named_service_operation_without_its_grants():
     service = AutomationAccessService(
+        catalog_resolver=_CatalogResolver(),
         redis=_Redis(),
         tenant="demo-tenant",
         project="demo-project",
@@ -481,6 +504,7 @@ async def test_automation_access_rejects_named_service_operation_without_its_gra
 @pytest.mark.asyncio
 async def test_automation_access_rejects_non_delegable_grant():
     service = AutomationAccessService(
+        catalog_resolver=_CatalogResolver(),
         redis=_Redis(),
         tenant="demo-tenant",
         project="demo-project",
@@ -507,6 +531,7 @@ async def test_automation_access_rejects_non_delegable_grant():
 @pytest.mark.asyncio
 async def test_automation_access_requires_configured_resource_when_catalog_exists():
     service = AutomationAccessService(
+        catalog_resolver=_CatalogResolver(),
         redis=_Redis(),
         tenant="demo-tenant",
         project="demo-project",
@@ -544,6 +569,7 @@ async def test_automation_access_requires_configured_resource_when_catalog_exist
 @pytest.mark.asyncio
 async def test_automation_access_all_resources_is_admin_only():
     service = AutomationAccessService(
+        catalog_resolver=_CatalogResolver(),
         redis=_Redis(),
         tenant="demo-tenant",
         project="demo-project",
@@ -595,6 +621,7 @@ async def test_automation_access_all_resources_is_admin_only():
 @pytest.mark.asyncio
 async def test_automation_access_can_select_multiple_resources():
     service = AutomationAccessService(
+        catalog_resolver=_CatalogResolver(),
         redis=_Redis(),
         tenant="demo-tenant",
         project="demo-project",
@@ -653,6 +680,7 @@ async def test_oauth_grant_registers_lists_and_revokes():
         "permissions": [],
     }
     service = AutomationAccessService(
+        catalog_resolver=_CatalogResolver(),
         redis=redis,
         tenant="demo-tenant",
         project="demo-project",
@@ -784,6 +812,7 @@ async def test_live_sessions_receive_delegated_access_changes():
 
 def _agent_service():
     return AutomationAccessService(
+        catalog_resolver=_CatalogResolver(),
         redis=_Redis(),
         tenant="demo-tenant",
         project="demo-project",
@@ -957,6 +986,7 @@ def _named_services_agent_service():
         }
     )
     return AutomationAccessService(
+        catalog_resolver=_CatalogResolver(),
         redis=_Redis(), tenant="demo-tenant", project="demo-project",
         config=oauth_delegated_config(SimpleNamespace(state=state)),
         grant_store=_Store(), authority=_Authority(), minter=_minter,
@@ -1301,6 +1331,7 @@ async def test_disconnecting_an_account_clears_its_agent_bindings():
     were reconnected later."""
     redis = _Redis()
     service = AutomationAccessService(
+        catalog_resolver=_CatalogResolver(),
         redis=redis,
         tenant="demo-tenant",
         project="demo-project",
@@ -1360,6 +1391,7 @@ async def test_automation_access_update_replaces_grants_in_place_and_keeps_ident
     store = _Store()
     authority = _Authority()
     service = AutomationAccessService(
+        catalog_resolver=_CatalogResolver(),
         redis=redis, tenant="demo-tenant", project="demo-project",
         config=_config(), grant_store=store, authority=authority, minter=_minter,
     )
@@ -1429,6 +1461,7 @@ async def test_automation_access_update_guards_ownership_existence_and_empty():
     store = _Store()
     authority = _Authority()
     service = AutomationAccessService(
+        catalog_resolver=_CatalogResolver(),
         redis=redis, tenant="demo-tenant", project="demo-project",
         config=_config(), grant_store=store, authority=authority, minter=_minter,
     )
@@ -1459,6 +1492,7 @@ async def test_automation_access_update_replaces_named_service_operations_withou
     written."""
     store = _Store()
     service = AutomationAccessService(
+        catalog_resolver=_CatalogResolver(),
         redis=_Redis(), tenant="demo-tenant", project="demo-project",
         config=_named_services_config(), grant_store=store, authority=_Authority(),
         minter=_minter, named_service_discovery=_NamedServiceDiscovery({}),
@@ -1512,6 +1546,7 @@ async def test_automation_access_update_replaces_named_service_operations_withou
 async def test_automation_access_update_rejects_an_operation_its_grants_do_not_cover():
     """The selection is validated at save time."""
     service = AutomationAccessService(
+        catalog_resolver=_CatalogResolver(),
         redis=_Redis(), tenant="demo-tenant", project="demo-project",
         config=_named_services_config(), grant_store=_Store(), authority=_Authority(),
         minter=_minter, named_service_discovery=_NamedServiceDiscovery({}),
@@ -1540,6 +1575,7 @@ async def test_automation_access_update_omitting_the_narrowing_keeps_it():
     """Absent vs empty, same rule as account_scope: omitting the narrowing keeps
     the record's, an explicit {} widens to the full policy."""
     service = AutomationAccessService(
+        catalog_resolver=_CatalogResolver(),
         redis=_Redis(), tenant="demo-tenant", project="demo-project",
         config=_named_services_config(), grant_store=_Store(), authority=_Authority(),
         minter=_minter, named_service_discovery=_NamedServiceDiscovery({}),
@@ -1580,6 +1616,7 @@ async def test_agent_grant_replace_without_the_narrowing_keeps_it():
     """A replace edit that submits no narrowing (a rename) must not widen the
     agent's boundary."""
     service = AutomationAccessService(
+        catalog_resolver=_CatalogResolver(),
         redis=_Redis(), tenant="demo-tenant", project="demo-project",
         config=_named_services_config(), grant_store=_Store(), authority=_Authority(),
         minter=_minter, named_service_discovery=_NamedServiceDiscovery({}),
@@ -1608,6 +1645,7 @@ async def test_automation_access_update_empty_narrowing_clears_every_resource():
     """An explicit {} is the clear, and it reaches resources the caller did not
     name — the widget therefore omits the field when it has no selection."""
     service = AutomationAccessService(
+        catalog_resolver=_CatalogResolver(),
         redis=_Redis(), tenant="demo-tenant", project="demo-project",
         config=_named_services_config(), grant_store=_Store(), authority=_Authority(),
         minter=_minter, named_service_discovery=_NamedServiceDiscovery({}),

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/tests/test_automation_access.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/tests/test_automation_access.py
@@ -24,6 +24,7 @@ from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.cat
 )
 from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.automation_access import (
     AutomationAccessService,
+    agent_grant_access_id,
 )
 from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.oauth.config import (
     oauth_delegated_config,
@@ -1147,6 +1148,152 @@ async def test_agent_namespace_grant_state_governs_and_grants(card_persistence):
 
 
 @pytest.mark.asyncio
+async def test_the_native_gate_reads_the_boundary_not_the_intent(card_persistence):
+    """A wildcard card is bounded by what it expanded to, on the native path too.
+
+    The gate used to answer from the stored SELECTION and handled only `none`
+    and `exact`, so a wildcard fell through to a claims-only decision and
+    collected operations added after the card was issued — while the
+    named-services door, reading the materialized boundary, refused them. One
+    question, two answers. Both now read the boundary.
+    """
+    service = _named_services_agent_service(card_persistence)
+    ns_resource = "*/kdcube-services@1-0/public/mcp/named_services*"
+    claims = ["mail:read", "named_services:use"]
+
+    created = await service.create_access(
+        _AGENT_USER, label="agent", client_id=_AGENT_CLIENT,
+        resource_grants={ns_resource: claims},
+    )
+    assert created["ok"] is True
+    assert created["access"]["named_service_operations"] == "*"
+
+    granted = await service.agent_namespace_grant_state(
+        grantor_subject="platform-user-1", client_id=_AGENT_CLIENT,
+        namespace="mail", operation="object.search",
+    )
+    assert granted["granted"] is True
+
+    # The card's boundary is the expansion of the generation it was saved
+    # against. An operation the deployment adds later is outside it, and the
+    # claims the card already holds must not be enough on their own.
+    record = await service._load_record(
+        agent_grant_access_id("platform-user-1", _AGENT_CLIENT, [ns_resource]),
+        grantor_subject="platform-user-1",
+    )
+    namespaces = record.named_services["namespaces"]
+    namespaces["mail"]["tools"].pop("search")
+
+    await service._persist_record(record, expected_revision=record.card_revision)
+
+    after = await service.agent_namespace_grant_state(
+        grantor_subject="platform-user-1", client_id=_AGENT_CLIENT,
+        namespace="mail", operation="object.search",
+    )
+    assert after["governed"] is True
+    assert after["granted"] is False
+
+
+@pytest.mark.asyncio
+async def test_a_boundary_refusal_says_the_card_refused_not_the_claims(card_persistence):
+    """The two refusals are different questions and need different answers.
+
+    Live run 2026-08-19: the gate refused an operation added after the card was
+    issued — correctly — but reported it as `missing=[memories:read,
+    named_services:use]`, claims the card already held. The caller raised a
+    consent demand for them, the demand deduplicated against the existing
+    grant, and the agent told the user to wait for a permission they had
+    already given. The design's denial table separates the two: a capability
+    the catalog offers but the card lacks may follow the consent path; the
+    caller has to be able to tell which case it is.
+    """
+    service = _named_services_agent_service(card_persistence)
+    ns_resource = "*/kdcube-services@1-0/public/mcp/named_services*"
+    assert (await service.create_access(
+        _AGENT_USER, label="agent", client_id=_AGENT_CLIENT,
+        resource_grants={ns_resource: ["mail:read", "named_services:use"]},
+    ))["ok"] is True
+
+    record = await service._load_record(
+        agent_grant_access_id("platform-user-1", _AGENT_CLIENT, [ns_resource]),
+        grantor_subject="platform-user-1",
+    )
+    record.named_services["namespaces"]["mail"]["tools"].pop("search")
+    await service._persist_record(record, expected_revision=record.card_revision)
+
+    state = await service.agent_namespace_grant_state(
+        grantor_subject="platform-user-1", client_id=_AGENT_CLIENT,
+        namespace="mail", operation="object.search",
+    )
+
+    assert state["granted"] is False
+    # The claims are held, so nothing about them is missing.
+    assert state["missing_claims"] == []
+    denial = state["not_granted"]
+    assert denial["error"]["code"] == "delegated_capability_not_granted"
+    assert denial["error"]["retryable"] is False
+    path = denial["ret"]["requested_capability"]
+    assert path["namespace"] == "mail" and path["operation"] == "object.search"
+    # A remedy exists and its owner is the grantor.
+    assert denial["ret"]["recovery"] == {
+        "action": "grant_capability_in_delegated_access",
+        "retry_same_request": False,
+        "request_user_consent": True,
+    }
+    assert denial["ret"]["access_id"] == record.access_id
+
+
+@pytest.mark.asyncio
+async def test_a_claim_refusal_names_only_the_claims_the_card_lacks(card_persistence):
+    """A demand that re-asks for held claims deduplicates away and teaches the
+    caller nothing, so the missing set is the difference, not the requirement."""
+    service = _named_services_agent_service(card_persistence)
+    ns_resource = "*/kdcube-services@1-0/public/mcp/named_services*"
+    assert (await service.create_access(
+        _AGENT_USER, label="agent", client_id=_AGENT_CLIENT,
+        resource_grants={ns_resource: ["named_services:use"]},
+    ))["ok"] is True
+
+    state = await service.agent_namespace_grant_state(
+        grantor_subject="platform-user-1", client_id=_AGENT_CLIENT,
+        namespace="mail", operation="object.search",
+    )
+
+    assert state["granted"] is False
+    assert state["not_granted"] is None
+    assert state["claims"] == ["mail:read", "named_services:use"]
+    assert state["missing_claims"] == ["mail:read"]
+
+
+@pytest.mark.asyncio
+async def test_a_removal_denial_tells_the_caller_consent_will_not_help(card_persistence):
+    """The mirror flag. The design's retry meaning for a withdrawn capability is
+    "do not blindly retry and do not request more user consent"; the live run
+    measured an agent advising a revoke-and-re-grant instead."""
+    service = _named_services_agent_service(card_persistence)
+    ns_resource = "*/kdcube-services@1-0/public/mcp/named_services*"
+    assert (await service.create_access(
+        _AGENT_USER, label="agent", client_id=_AGENT_CLIENT,
+        resource_grants={ns_resource: ["mail:read", "named_services:use"]},
+    ))["ok"] is True
+
+    trimmed = copy.deepcopy(service._catalog_resolver.connections)
+    trimmed["delegated_credentials"]["oauth"]["resources"][0]["named_services"][
+        "namespaces"]["mail"]["tools"].pop("search")
+    service._catalog_resolver.connections = trimmed
+
+    state = await service.agent_namespace_grant_state(
+        grantor_subject="platform-user-1", client_id=_AGENT_CLIENT,
+        namespace="mail", operation="object.search",
+    )
+
+    recovery = state["removed"]["ret"]["recovery"]
+    assert recovery["request_user_consent"] is False
+    assert recovery["retry_same_request"] is False
+    assert "no longer offers" in state["removed"]["error"]["message"]
+
+
+@pytest.mark.asyncio
 async def test_the_native_gate_refuses_an_operation_the_catalog_dropped(card_persistence):
     """The card holds it; the deployment no longer offers it. Consent cannot
     restore that, so the answer is a removal, not a pending grant."""
@@ -2033,10 +2180,15 @@ async def test_automation_access_update_empty_narrowing_clears_every_resource(ca
     # still gates per operation against the card's grants.
     assert await _namespaces() == ["mail", "slack"]
 
+    # Omitted -> the wildcard is frozen into what it already meant, so it can
+    # no longer be re-pinned to a later catalog. Only namespaces this card's
+    # claims authorize survive, because an exact selection may name nothing
+    # else; `mail` needs `mail:read`, which this card never held, so it was
+    # unusable before and is unusable now.
     await service.update_access(
         user, access_id=access_id, resource_grants={resource: grants}, label="Renamed",
     )
-    assert await _namespaces() == ["mail", "slack"]        # omitted -> preserved
+    assert await _namespaces() == ["slack"]
 
     await service.update_access(
         user, access_id=access_id, resource_grants={resource: grants},

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/tests/test_automation_access.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/tests/test_automation_access.py
@@ -145,15 +145,33 @@ class _CatalogResolver:
         version: str = TEST_CATALOG_VERSION,
         unavailable: bool = False,
         connections: dict | None = None,
+        versions: dict[str, dict] | None = None,
     ) -> None:
         self.version = version
         self.unavailable = unavailable
         self.connections = connections or {}
+        # Registered historical generations, for drift comparison.
+        self.versions = dict(versions or {})
 
     async def resolve_active(self):
         if self.unavailable:
             raise CatalogUnavailable("active_catalog_not_registered")
         return SimpleNamespace(version=self.version, connections=self.connections)
+
+    async def resolve_version(self, version: str):
+        if self.unavailable:
+            raise CatalogUnavailable("cache_unavailable")
+        if version == self.version:
+            return SimpleNamespace(version=self.version, connections=self.connections)
+        if version in self.versions:
+            return SimpleNamespace(version=version, connections=self.versions[version])
+        return None
+
+    def advance(self, *, version: str, connections: dict) -> None:
+        """Publish a new generation, keeping the previous one resolvable."""
+        self.versions[self.version] = self.connections
+        self.version = version
+        self.connections = connections
 
 
 class _NamedServiceDiscovery:
@@ -183,55 +201,62 @@ async def _minter(_grantor_subject, _scopes, **kwargs):
     }
 
 
-def _config():
-    state = SimpleNamespace(
-        oauth_delegated_config={
-            "enabled": True,
-            "tenant": "demo-tenant",
-            "project": "demo-project",
-            "capabilities": [
-                {
-                    "grant": "kdcube:role:super-admin",
-                    "label": "Use all platform and application APIs",
-                    "delegable_roles": ["kdcube:role:super-admin"],
-                },
-                {
-                    "grant": "records:read",
-                    "label": "Read records",
-                    "delegable_roles": ["kdcube:role:registered"],
-                },
-                {
-                    "grant": "records:write",
-                    "label": "Write records",
-                    "delegable_permissions": ["records:write"],
-                },
-            ],
-            "resources": [
-                {
-                    "resource": "*",
-                    "label": "All platform and application APIs",
-                    "admin_only": True,
-                    "grants": ["kdcube:role:super-admin"],
-                },
-                {
-                    "resource": "https://example.test/mcp",
-                    "label": "Example MCP",
-                    "identity_scope": "grantor",
-                    "tools": {
-                        "records_export": {
-                            "label": "Export records",
-                            "grants": ["records:read"],
-                        },
-                        "records_upsert": {
-                            "label": "Upsert records",
-                            "grants": ["records:write"],
-                        },
+PLAIN_OAUTH = {
+        "enabled": True,
+        "tenant": "demo-tenant",
+        "project": "demo-project",
+        "capabilities": [
+            {
+                "grant": "kdcube:role:super-admin",
+                "label": "Use all platform and application APIs",
+                "delegable_roles": ["kdcube:role:super-admin"],
+            },
+            {
+                "grant": "records:read",
+                "label": "Read records",
+                "delegable_roles": ["kdcube:role:registered"],
+            },
+            {
+                "grant": "records:write",
+                "label": "Write records",
+                "delegable_permissions": ["records:write"],
+            },
+        ],
+        "resources": [
+            {
+                "resource": "*",
+                "label": "All platform and application APIs",
+                "admin_only": True,
+                "grants": ["kdcube:role:super-admin"],
+            },
+            {
+                "resource": "https://example.test/mcp",
+                "label": "Example MCP",
+                "identity_scope": "grantor",
+                "tools": {
+                    "records_export": {
+                        "label": "Export records",
+                        "grants": ["records:read"],
+                    },
+                    "records_upsert": {
+                        "label": "Upsert records",
+                        "grants": ["records:write"],
                     },
                 },
-            ],
-        }
+            },
+        ],
+}
+
+
+def _config():
+    return oauth_delegated_config(
+        SimpleNamespace(state=SimpleNamespace(oauth_delegated_config=PLAIN_OAUTH))
     )
-    return oauth_delegated_config(SimpleNamespace(state=state))
+
+
+def _connections() -> dict:
+    """The registered catalog body matching `_config`."""
+    return {"delegated_credentials": {"oauth": PLAIN_OAUTH}}
 
 
 NAMED_SERVICES_OAUTH = {
@@ -345,7 +370,7 @@ async def test_automation_access_create_list_and_revoke(card_persistence):
     store = _Store()
     authority = _Authority()
     service = AutomationAccessService(
-        catalog_resolver=_CatalogResolver(),
+        catalog_resolver=_CatalogResolver(connections=_connections()),
         card_persistence=card_persistence,
         redis=redis,
         tenant="demo-tenant",
@@ -443,7 +468,7 @@ async def test_resource_options_project_exact_named_service_and_provider_catalog
     )
     store = _Store()
     service = AutomationAccessService(
-        catalog_resolver=_CatalogResolver(),
+        catalog_resolver=_CatalogResolver(connections=_named_services_connections()),
         card_persistence=card_persistence,
         redis=_Redis(),
         tenant="demo-tenant",
@@ -497,7 +522,7 @@ async def test_resource_options_project_exact_named_service_and_provider_catalog
 async def test_automation_access_persists_only_selected_named_service_operations(card_persistence):
     store = _Store()
     service = AutomationAccessService(
-        catalog_resolver=_CatalogResolver(),
+        catalog_resolver=_CatalogResolver(connections=_named_services_connections()),
         card_persistence=card_persistence,
         redis=_Redis(),
         tenant="demo-tenant",
@@ -539,7 +564,7 @@ async def test_automation_access_persists_only_selected_named_service_operations
 @pytest.mark.asyncio
 async def test_automation_access_rejects_named_service_operation_without_its_grants(card_persistence):
     service = AutomationAccessService(
-        catalog_resolver=_CatalogResolver(),
+        catalog_resolver=_CatalogResolver(connections=_named_services_connections()),
         card_persistence=card_persistence,
         redis=_Redis(),
         tenant="demo-tenant",
@@ -578,7 +603,7 @@ async def test_automation_access_rejects_named_service_operation_without_its_gra
 @pytest.mark.asyncio
 async def test_automation_access_rejects_non_delegable_grant(card_persistence):
     service = AutomationAccessService(
-        catalog_resolver=_CatalogResolver(),
+        catalog_resolver=_CatalogResolver(connections=_connections()),
         card_persistence=card_persistence,
         redis=_Redis(),
         tenant="demo-tenant",
@@ -606,7 +631,7 @@ async def test_automation_access_rejects_non_delegable_grant(card_persistence):
 @pytest.mark.asyncio
 async def test_automation_access_requires_configured_resource_when_catalog_exists(card_persistence):
     service = AutomationAccessService(
-        catalog_resolver=_CatalogResolver(),
+        catalog_resolver=_CatalogResolver(connections=_connections()),
         card_persistence=card_persistence,
         redis=_Redis(),
         tenant="demo-tenant",
@@ -645,7 +670,7 @@ async def test_automation_access_requires_configured_resource_when_catalog_exist
 @pytest.mark.asyncio
 async def test_automation_access_all_resources_is_admin_only(card_persistence):
     service = AutomationAccessService(
-        catalog_resolver=_CatalogResolver(),
+        catalog_resolver=_CatalogResolver(connections=_connections()),
         card_persistence=card_persistence,
         redis=_Redis(),
         tenant="demo-tenant",
@@ -698,7 +723,7 @@ async def test_automation_access_all_resources_is_admin_only(card_persistence):
 @pytest.mark.asyncio
 async def test_automation_access_can_select_multiple_resources(card_persistence):
     service = AutomationAccessService(
-        catalog_resolver=_CatalogResolver(),
+        catalog_resolver=_CatalogResolver(connections=_connections()),
         card_persistence=card_persistence,
         redis=_Redis(),
         tenant="demo-tenant",
@@ -758,7 +783,7 @@ async def test_oauth_grant_registers_lists_and_revokes(card_persistence):
         "permissions": [],
     }
     service = AutomationAccessService(
-        catalog_resolver=_CatalogResolver(),
+        catalog_resolver=_CatalogResolver(connections=_connections()),
         card_persistence=card_persistence,
         redis=redis,
         tenant="demo-tenant",
@@ -891,7 +916,7 @@ async def test_live_sessions_receive_delegated_access_changes():
 
 def _agent_service(card_persistence):
     return AutomationAccessService(
-        catalog_resolver=_CatalogResolver(),
+        catalog_resolver=_CatalogResolver(connections=_connections()),
         card_persistence=card_persistence,
         redis=_Redis(),
         tenant="demo-tenant",
@@ -1172,6 +1197,182 @@ async def test_the_native_gate_refuses_a_namespace_the_catalog_dropped(card_pers
 
     assert state["governed"] is True and state["granted"] is False
     assert state["removed"]["ret"]["requested_capability"]["namespace"] == "mail"
+
+
+@pytest.mark.asyncio
+async def test_save_refuses_when_the_card_moved_under_the_editor(card_persistence):
+    service = _named_services_agent_service(card_persistence)
+    ns_resource = "*/kdcube-services@1-0/public/mcp/named_services*"
+    created = await service.create_access(
+        _AGENT_USER, label="manual",
+        resource_grants={ns_resource: ["named_services:use", "mail:read"]},
+    )
+    access_id = created["access"]["access_id"]
+
+    conflict = await service.update_access(
+        _AGENT_USER, access_id=access_id,
+        resource_grants={ns_resource: ["named_services:use"]},
+        expected_card_revision=int(created["access"]["card_revision"]) + 5,
+    )
+
+    assert conflict["ok"] is False
+    assert conflict["error"] == "delegated_access_precondition_failed"
+    assert conflict["status"] == 409
+    assert conflict["mismatched"]["card_revision"]["actual"] == created["access"]["card_revision"]
+    # The refreshed projection is what the editor reloads.
+    assert conflict["access"]["access_id"] == access_id
+    assert conflict["access"]["catalog_drift"]["status"] == "current"
+
+
+@pytest.mark.asyncio
+async def test_save_refuses_when_the_catalog_moved_under_the_editor(card_persistence):
+    service = _named_services_agent_service(card_persistence)
+    resolver = service._catalog_resolver
+    ns_resource = "*/kdcube-services@1-0/public/mcp/named_services*"
+    created = await service.create_access(
+        _AGENT_USER, label="manual",
+        resource_grants={ns_resource: ["named_services:use", "mail:read"]},
+    )
+
+    conflict = await service.update_access(
+        _AGENT_USER, access_id=created["access"]["access_id"],
+        resource_grants={ns_resource: ["named_services:use"]},
+        expected_catalog_version="delegated_catalog_2026-01-01-00-00-00-000_000000000000",
+    )
+
+    assert conflict["status"] == 409
+    assert conflict["mismatched"]["catalog_version"]["actual"] == resolver.version
+
+
+@pytest.mark.asyncio
+async def test_save_matching_the_expectations_proceeds(card_persistence):
+    service = _named_services_agent_service(card_persistence)
+    ns_resource = "*/kdcube-services@1-0/public/mcp/named_services*"
+    created = await service.create_access(
+        _AGENT_USER, label="manual",
+        resource_grants={ns_resource: ["named_services:use", "mail:read"]},
+    )
+
+    saved = await service.update_access(
+        _AGENT_USER, access_id=created["access"]["access_id"],
+        resource_grants={ns_resource: ["named_services:use", "mail:read"]},
+        label="Renamed",
+        expected_card_revision=int(created["access"]["card_revision"]),
+        expected_catalog_version=service._catalog_resolver.version,
+    )
+
+    assert saved["ok"] is True
+    assert saved["access"]["label"] == "Renamed"
+    assert saved["access"]["catalog_drift"]["status"] == "current"
+    assert saved["pruned"] == {"resources": [], "claims": [], "named_service_operations": []}
+
+
+@pytest.mark.asyncio
+async def test_save_prunes_a_withdrawn_operation_instead_of_refusing(card_persistence):
+    """The picker cannot render a withdrawn row, so Save removes it."""
+    service = _named_services_agent_service(card_persistence)
+    resolver = service._catalog_resolver
+    ns_resource = "*/kdcube-services@1-0/public/mcp/named_services*"
+    created = await service.create_access(
+        _AGENT_USER, label="manual",
+        resource_grants={ns_resource: ["named_services:use", "mail:read", "mail:send"]},
+        named_service_operations={ns_resource: {"mail": ["object.search", "object.action"]}},
+    )
+    assert created["ok"] is True
+
+    trimmed = copy.deepcopy(resolver.connections)
+    namespaces = trimmed["delegated_credentials"]["oauth"]["resources"][0]["named_services"]["namespaces"]
+    namespaces["mail"]["tools"].pop("action")
+    resolver.advance(version="delegated_catalog_2026-08-14-11-00-00-000_aaaaaaaaaaaa", connections=trimmed)
+
+    saved = await service.update_access(
+        _AGENT_USER, access_id=created["access"]["access_id"],
+        resource_grants={ns_resource: ["named_services:use", "mail:read", "mail:send"]},
+        named_service_operations={ns_resource: {"mail": ["object.search", "object.action"]}},
+    )
+
+    assert saved["ok"] is True
+    assert saved["pruned"]["named_service_operations"] == [
+        {"resource": ns_resource, "namespace": "mail", "operation": "object.action"}
+    ]
+    assert saved["access"]["named_service_operations"] == {ns_resource: {"mail": ["object.search"]}}
+    assert saved["access"]["catalog_drift"]["status"] == "current"
+
+
+@pytest.mark.asyncio
+async def test_save_revokes_a_card_pruning_leaves_without_authority(card_persistence):
+    service = _named_services_agent_service(card_persistence)
+    resolver = service._catalog_resolver
+    ns_resource = "*/kdcube-services@1-0/public/mcp/named_services*"
+    created = await service.create_access(
+        _AGENT_USER, label="manual",
+        resource_grants={ns_resource: ["named_services:use", "mail:read"]},
+    )
+    access_id = created["access"]["access_id"]
+
+    emptied = copy.deepcopy(resolver.connections)
+    emptied["delegated_credentials"]["oauth"]["resources"] = []
+    resolver.advance(version="delegated_catalog_2026-08-14-12-00-00-000_bbbbbbbbbbbb", connections=emptied)
+
+    saved = await service.update_access(
+        _AGENT_USER, access_id=access_id,
+        resource_grants={ns_resource: ["named_services:use", "mail:read"]},
+    )
+
+    assert saved["ok"] is True and saved["revoked"] is True
+    assert saved["pruned"]["resources"] == [ns_resource]
+    assert await service._load_record(access_id, grantor_subject="platform-user-1") is None
+
+
+@pytest.mark.asyncio
+async def test_listing_reports_drift_against_the_card_baseline(card_persistence):
+    """Listing explains a card against the generation it was saved under."""
+    service = _named_services_agent_service(card_persistence)
+    resolver = service._catalog_resolver
+    ns_resource = "*/kdcube-services@1-0/public/mcp/named_services*"
+    created = await service.create_access(
+        _AGENT_USER, label="agent", client_id=_AGENT_CLIENT,
+        resource_grants={ns_resource: ["mail:read", "named_services:use"]},
+    )
+    assert created["ok"] is True
+
+    listed = await service.list_access(_AGENT_USER)
+    assert listed["items"][0]["catalog_drift"]["status"] == "current"
+
+    trimmed = copy.deepcopy(resolver.connections)
+    namespaces = trimmed["delegated_credentials"]["oauth"]["resources"][0]["named_services"]["namespaces"]
+    namespaces["mail"]["tools"].pop("search")
+    resolver.advance(version="delegated_catalog_2026-08-14-10-00-00-000_ffffffffffff", connections=trimmed)
+
+    listed = await service.list_access(_AGENT_USER)
+    drift = listed["items"][0]["catalog_drift"]
+
+    assert drift["status"] == "changed"
+    assert drift["saved_version"] == TEST_CATALOG_VERSION
+    assert drift["current_version"] != TEST_CATALOG_VERSION
+    removed = drift["removed"]["named_service_operations"]
+    assert [row["operation"] for row in removed] == ["object.search"]
+    assert removed[0]["was_selected"] is True
+    assert removed[0]["effect"] == "denied_immediately"
+
+
+@pytest.mark.asyncio
+async def test_listing_disables_editing_when_the_comparison_cannot_be_made(card_persistence):
+    service = _named_services_agent_service(card_persistence)
+    ns_resource = "*/kdcube-services@1-0/public/mcp/named_services*"
+    assert (await service.create_access(
+        _AGENT_USER, label="agent", client_id=_AGENT_CLIENT,
+        resource_grants={ns_resource: ["mail:read", "named_services:use"]},
+    ))["ok"] is True
+    service._catalog_resolver.unavailable = True
+
+    listed = await service.list_access(_AGENT_USER)
+
+    assert listed["ok"] is True                      # the card is not hidden
+    assert listed["items"][0]["catalog_drift"] == {
+        "status": "unavailable",
+        "reason": "active_catalog_not_registered",
+    }
 
 
 @pytest.mark.asyncio
@@ -1491,7 +1692,7 @@ async def test_disconnecting_an_account_clears_its_agent_bindings(card_persisten
     were reconnected later."""
     redis = _Redis()
     service = AutomationAccessService(
-        catalog_resolver=_CatalogResolver(),
+        catalog_resolver=_CatalogResolver(connections=_connections()),
         card_persistence=card_persistence,
         redis=redis,
         tenant="demo-tenant",
@@ -1552,7 +1753,7 @@ async def test_automation_access_update_replaces_grants_in_place_and_keeps_ident
     store = _Store()
     authority = _Authority()
     service = AutomationAccessService(
-        catalog_resolver=_CatalogResolver(),
+        catalog_resolver=_CatalogResolver(connections=_connections()),
         card_persistence=card_persistence,
         redis=redis, tenant="demo-tenant", project="demo-project",
         config=_config(), grant_store=store, authority=authority, minter=_minter,
@@ -1624,7 +1825,7 @@ async def test_automation_access_update_guards_ownership_existence_and_empty(car
     store = _Store()
     authority = _Authority()
     service = AutomationAccessService(
-        catalog_resolver=_CatalogResolver(),
+        catalog_resolver=_CatalogResolver(connections=_connections()),
         card_persistence=card_persistence,
         redis=redis, tenant="demo-tenant", project="demo-project",
         config=_config(), grant_store=store, authority=authority, minter=_minter,
@@ -1658,7 +1859,7 @@ async def test_automation_access_update_replaces_named_service_operations_withou
     written."""
     store = _Store()
     service = AutomationAccessService(
-        catalog_resolver=_CatalogResolver(),
+        catalog_resolver=_CatalogResolver(connections=_named_services_connections()),
         card_persistence=card_persistence,
         redis=_Redis(), tenant="demo-tenant", project="demo-project",
         config=_named_services_config(), grant_store=store, authority=_Authority(),
@@ -1710,7 +1911,7 @@ async def test_automation_access_update_replaces_named_service_operations_withou
 async def test_automation_access_update_rejects_an_operation_its_grants_do_not_cover(card_persistence):
     """The selection is validated at save time."""
     service = AutomationAccessService(
-        catalog_resolver=_CatalogResolver(),
+        catalog_resolver=_CatalogResolver(connections=_named_services_connections()),
         card_persistence=card_persistence,
         redis=_Redis(), tenant="demo-tenant", project="demo-project",
         config=_named_services_config(), grant_store=_Store(), authority=_Authority(),
@@ -1740,7 +1941,7 @@ async def test_automation_access_update_omitting_the_narrowing_keeps_it(card_per
     """Absent vs empty, same rule as account_scope: omitting the narrowing keeps
     the record's, an explicit {} widens to the full policy."""
     service = AutomationAccessService(
-        catalog_resolver=_CatalogResolver(),
+        catalog_resolver=_CatalogResolver(connections=_named_services_connections()),
         card_persistence=card_persistence,
         redis=_Redis(), tenant="demo-tenant", project="demo-project",
         config=_named_services_config(), grant_store=_Store(), authority=_Authority(),
@@ -1782,7 +1983,7 @@ async def test_agent_grant_replace_without_the_narrowing_keeps_it(card_persisten
     """A replace edit that submits no narrowing (a rename) must not widen the
     agent's boundary."""
     service = AutomationAccessService(
-        catalog_resolver=_CatalogResolver(),
+        catalog_resolver=_CatalogResolver(connections=_named_services_connections()),
         card_persistence=card_persistence,
         redis=_Redis(), tenant="demo-tenant", project="demo-project",
         config=_named_services_config(), grant_store=_Store(), authority=_Authority(),
@@ -1812,7 +2013,7 @@ async def test_automation_access_update_empty_narrowing_clears_every_resource(ca
     """An explicit {} is the clear, and it reaches resources the caller did not
     name — the widget therefore omits the field when it has no selection."""
     service = AutomationAccessService(
-        catalog_resolver=_CatalogResolver(),
+        catalog_resolver=_CatalogResolver(connections=_named_services_connections()),
         card_persistence=card_persistence,
         redis=_Redis(), tenant="demo-tenant", project="demo-project",
         config=_named_services_config(), grant_store=_Store(), authority=_Authority(),

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/tests/test_automation_access.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/tests/test_automation_access.py
@@ -512,6 +512,7 @@ async def test_resource_options_project_exact_named_service_and_provider_catalog
                 "slack:write",
             ]
         },
+        named_service_operations="*",
     )
     assert created["ok"] is True
     persisted_policy = store.bound[0]["named_services"]
@@ -1123,6 +1124,7 @@ async def test_agent_namespace_grant_state_governs_and_grants(card_persistence):
     created = await service.create_access(
         _AGENT_USER, label="agent", client_id=_AGENT_CLIENT,
         resource_grants={ns_resource: pending["claims"]},
+        named_service_operations={ns_resource: {"mail": ["object.search"]}},
     )
     assert created["ok"] is True
 
@@ -1164,6 +1166,7 @@ async def test_the_native_gate_reads_the_boundary_not_the_intent(card_persistenc
     created = await service.create_access(
         _AGENT_USER, label="agent", client_id=_AGENT_CLIENT,
         resource_grants={ns_resource: claims},
+        named_service_operations="*",
     )
     assert created["ok"] is True
     assert created["access"]["named_service_operations"] == "*"
@@ -1212,6 +1215,7 @@ async def test_a_boundary_refusal_says_the_card_refused_not_the_claims(card_pers
     assert (await service.create_access(
         _AGENT_USER, label="agent", client_id=_AGENT_CLIENT,
         resource_grants={ns_resource: ["mail:read", "named_services:use"]},
+        named_service_operations="*",
     ))["ok"] is True
 
     record = await service._load_record(
@@ -1331,6 +1335,7 @@ async def test_the_native_gate_refuses_a_namespace_the_catalog_dropped(card_pers
     assert (await service.create_access(
         _AGENT_USER, label="agent", client_id=_AGENT_CLIENT,
         resource_grants={ns_resource: ["mail:read", "named_services:use"]},
+        named_service_operations="*",
     ))["ok"] is True
 
     trimmed = copy.deepcopy(service._catalog_resolver.connections)
@@ -1480,6 +1485,7 @@ async def test_listing_reports_drift_against_the_card_baseline(card_persistence)
     created = await service.create_access(
         _AGENT_USER, label="agent", client_id=_AGENT_CLIENT,
         resource_grants={ns_resource: ["mail:read", "named_services:use"]},
+        named_service_operations="*",
     )
     assert created["ok"] is True
 
@@ -2169,15 +2175,18 @@ async def test_automation_access_update_empty_narrowing_clears_every_resource(ca
     user = {"user_id": "platform-user-1", "roles": ["kdcube:role:registered"], "permissions": []}
     resource = "https://example.test/mcp/named-services"
     grants = ["named_services:use", "slack:read"]
-    created = await service.create_access(user, label="all ops", resource_grants={resource: grants})
+    created = await service.create_access(
+        user, label="all ops", resource_grants={resource: grants},
+        named_service_operations="*",
+    )
     access_id = created["access"]["access_id"]
 
     async def _namespaces():
         raw = await stored_card(service, access_id)
         return sorted(raw["named_services"]["namespaces"])
 
-    # No narrowing asked for: the full descriptor policy, which the bridge
-    # still gates per operation against the card's grants.
+    # Every operation the catalog offered, which the bridge still gates per
+    # operation against the card's grants.
     assert await _namespaces() == ["mail", "slack"]
 
     # Omitted -> the wildcard is frozen into what it already meant, so it can
@@ -2232,3 +2241,246 @@ def test_a_catalog_tool_whose_claim_was_never_declared_is_reported():
 
 def test_a_coherent_catalog_reports_nothing():
     assert _config().ungrantable_resource_tools() == ()
+
+
+async def test_consent_seeds_the_account_binding_from_the_clients_own_card(card_persistence):
+    """The pre-check a re-consent screen shows comes from durable storage.
+
+    The client's own card is one of two seed sources; the other is a superseded
+    DCR sibling. Reading the card through anything but the durable store finds
+    nothing, and the screen silently drops the binding it should pre-check.
+    """
+    service = AutomationAccessService(
+        catalog_resolver=_CatalogResolver(connections=_connections()),
+        card_persistence=card_persistence,
+        redis=_Redis(),
+        tenant="demo-tenant",
+        project="demo-project",
+        config=_config(),
+        grant_store=_OAuthStore(),
+        authority=_Authority(),
+        minter=_minter,
+    )
+    record = await service.record_oauth_grant(
+        grantor_subject="platform-user-1",
+        client_id="claude",
+        client_label="Claude",
+        scopes=["records:read"],
+        resource="https://example.test/mcp",
+        access_token="kst1.oauth.token",
+        refresh_token="refresh-1",
+        account_scope={"slack": {"acct-1": ["chat:write"]}},
+    )
+    assert record is not None
+    assert record.account_scope == {"slack": {"acct-1": ("chat:write",)}}
+
+    seeded = await service.oauth_seed_account_scope(
+        grantor_subject="platform-user-1",
+        client_id="claude",
+        resource="https://example.test/mcp",
+    )
+    assert seeded == {"slack": {"acct-1": ["chat:write"]}}
+
+
+async def test_a_card_keyed_by_a_concrete_url_resolves_to_its_catalog_row(card_persistence):
+    """An OAuth card names the URL the client asked for; the catalog names a
+    pattern. The row is matched, not compared, so the card stays editable and
+    the listing tells a surface which row governs it."""
+    pattern = "https://example.test/mcp/named-services*"
+    concrete = "https://example.test/mcp/named-services/instance-7"
+    oauth = copy.deepcopy(NAMED_SERVICES_OAUTH)
+    for row in oauth["resources"]:
+        if row["resource"] == "https://example.test/mcp/named-services":
+            row["resource"] = pattern
+    connections = {"delegated_credentials": {"oauth": oauth}}
+    config = oauth_delegated_config(
+        SimpleNamespace(state=SimpleNamespace(oauth_delegated_config=oauth))
+    )
+    service = AutomationAccessService(
+        catalog_resolver=_CatalogResolver(connections=connections),
+        card_persistence=card_persistence,
+        redis=_Redis(),
+        tenant="demo-tenant",
+        project="demo-project",
+        config=config,
+        grant_store=_OAuthStore(),
+        authority=_Authority(),
+        minter=_minter,
+    )
+    user = {"sub": "platform-user-1", "roles": ["kdcube:role:registered"], "permissions": []}
+    record = await service.record_oauth_grant(
+        grantor_subject="platform-user-1",
+        client_id="dcr-claude",
+        client_label="Claude",
+        scopes=["named_services:use", "mail:read"],
+        resource=concrete,
+        access_token="kst1.oauth.token",
+        refresh_token="refresh-1",
+    )
+    assert record is not None
+
+    listed = await service.list_access(user)
+    item = next(row for row in listed["items"] if row["access_id"] == record.access_id)
+    # The surface is told which row governs the card, so it never compares.
+    assert item["catalog_row_by_resource"] == {concrete: pattern}
+
+    # And the same key is editable: unknown_resources would mean the save path
+    # judged the card by string equality too.
+    updated = await service.update_access(
+        user,
+        access_id=record.access_id,
+        resource_grants={concrete: ["named_services:use", "mail:read"]},
+        named_service_operations={concrete: {"mail": ["object.search"]}},
+    )
+    assert updated.get("ok") is True, updated
+    assert updated["access"]["named_service_operations"] == {
+        concrete: {"mail": ["object.search"]}
+    }
+    # The boundary comes from the row's subtree but the grants and the
+    # selection are read under the card's key, so the tree is not empty.
+    stored = await only_stored_card(service)
+    assert stored["named_services"], stored["named_services"]
+
+
+async def test_a_revoked_card_can_be_granted_again(card_persistence):
+    """Revoke does not poison a deterministic access_id.
+
+    `oauth_access_id` and `agent_grant_access_id` are derived from
+    (grantor, client, resource), so the same client reconnecting reuses the id.
+    The revoked revision keeps the counter; the new consent continues it.
+    """
+    service = AutomationAccessService(
+        catalog_resolver=_CatalogResolver(connections=_connections()),
+        card_persistence=card_persistence,
+        redis=_Redis(), tenant="demo-tenant", project="demo-project",
+        config=_config(), grant_store=_OAuthStore(),
+        authority=_Authority(), minter=_minter,
+    )
+    user = {"sub": "platform-user-1", "roles": ["kdcube:role:registered"], "permissions": []}
+    first = await service.record_oauth_grant(
+        grantor_subject="platform-user-1", client_id="dcr-claude", client_label="Claude",
+        scopes=["records:read"], resource="https://example.test/mcp",
+        access_token="kst1.a", refresh_token="r-a",
+    )
+    assert first is not None and first.card_revision == 1
+
+    revoked = await service.revoke_access(user, access_id=first.access_id)
+    assert revoked.get("ok") is True, revoked
+    assert (await service.list_access(user))["items"] == []
+
+    again = await service.record_oauth_grant(
+        grantor_subject="platform-user-1", client_id="dcr-claude", client_label="Claude",
+        scopes=["records:read"], resource="https://example.test/mcp",
+        access_token="kst1.b", refresh_token="r-b",
+    )
+    assert again is not None, "reconnect after revoke produced no card"
+    assert again.access_id == first.access_id
+    # The counter continues past the revoked revision rather than restarting.
+    assert again.card_revision > first.card_revision
+    assert len((await service.list_access(user))["items"]) == 1
+
+
+async def test_the_catalog_is_offered_through_what_the_grantor_may_delegate(card_persistence):
+    """A claim outside the grantor's delegable set is not offered anywhere.
+
+    Offering it produces a form whose save cannot succeed, and the picker
+    auto-ticks an operation's claims, so dropping a claim from one list while
+    its operation survives in another moves the wall rather than removing it.
+    """
+    oauth = copy.deepcopy(NAMED_SERVICES_OAUTH)
+    for capability in oauth["capabilities"]:
+        if capability["grant"] == "mail:send":
+            capability["delegable_roles"] = ["kdcube:role:super-admin"]
+    service = AutomationAccessService(
+        catalog_resolver=_CatalogResolver(
+            connections={"delegated_credentials": {"oauth": oauth}}
+        ),
+        card_persistence=card_persistence,
+        redis=_Redis(), tenant="demo-tenant", project="demo-project",
+        config=oauth_delegated_config(
+            SimpleNamespace(state=SimpleNamespace(oauth_delegated_config=oauth))
+        ),
+        grant_store=_OAuthStore(), authority=_Authority(), minter=_minter,
+    )
+    admin = {"sub": "u-admin", "roles": ["kdcube:role:super-admin"], "permissions": []}
+    plain = {"sub": "u-plain", "roles": ["kdcube:role:registered"], "permissions": []}
+
+    def claims(options):
+        return {grant for option in options for grant in option.get("grants") or []}
+
+    def operations(options):
+        out = set()
+        for option in options:
+            for namespace in option.get("named_services") or []:
+                for tool_name, tool in (namespace.get("tools") or {}).items():
+                    ops = tool.get("operations")
+                    if isinstance(ops, dict) and ops:
+                        out.update(f"{namespace['namespace']}:{op}" for op in ops)
+                    else:
+                        out.add(f"{namespace['namespace']}:{tool.get('operation') or tool_name}")
+        return out
+
+    wide = await service.resource_options(admin)
+    narrow = await service.resource_options(plain)
+
+    # The restricted claim is offered to the grantor who may delegate it.
+    assert "mail:send" in claims(wide)
+    plain_claims = claims(narrow)
+    assert "mail:send" not in plain_claims, plain_claims
+    assert "mail:read" in plain_claims
+
+    # And the operation that costs it disappears with it, instead of staying
+    # tickable against a claim the form no longer offers.
+    assert "mail:object.action" in operations(wide)
+    assert "mail:object.action" not in operations(narrow)
+    assert "mail:object.search" in operations(narrow)
+
+    # A save of what is still offered succeeds; the removed claim is refused
+    # with the reason that actually applies.
+    refused = await service.create_access(
+        plain,
+        label="Nope",
+        resource_grants={"https://example.test/mcp/named-services": ["mail:send"]},
+    )
+    assert refused["ok"] is False
+    assert refused["error"] == "delegated_access_grants_not_delegable"
+    assert "not yours to delegate" in refused["message"]
+    assert "capabilities" in refused["message"]
+
+
+async def test_mixed_identity_scopes_are_refused_with_their_reason(card_persistence):
+    """One card issues one credential, so its doors share one identity scope."""
+    oauth = copy.deepcopy(NAMED_SERVICES_OAUTH)
+    oauth["resources"] = list(oauth["resources"]) + [{
+        "resource": "https://example.test/mcp/family",
+        "label": "Family-scoped door",
+        "identity_scope": "grantor_identity_family",
+        "tools": {"family_call": {"label": "Call", "grants": ["named_services:use"]}},
+    }]
+    service = AutomationAccessService(
+        catalog_resolver=_CatalogResolver(
+            connections={"delegated_credentials": {"oauth": oauth}}
+        ),
+        card_persistence=card_persistence,
+        redis=_Redis(), tenant="demo-tenant", project="demo-project",
+        config=oauth_delegated_config(
+            SimpleNamespace(state=SimpleNamespace(oauth_delegated_config=oauth))
+        ),
+        grant_store=_OAuthStore(), authority=_Authority(), minter=_minter,
+    )
+    user = {"sub": "platform-user-1", "roles": ["kdcube:role:registered"], "permissions": []}
+    refused = await service.create_access(
+        user,
+        label="Mixed",
+        resource_grants={
+            "https://example.test/mcp/named-services": ["named_services:use"],
+            "https://example.test/mcp/family": ["named_services:use"],
+        },
+        named_service_operations={},
+    )
+    assert refused["ok"] is False
+    assert refused["error"] == "delegated_access_resources_have_conflicting_identity_scopes"
+    # The refusal names the conflict rather than only its code.
+    assert refused["identity_scopes"] == ["grantor", "grantor_identity_family"]
+    assert "identity_scope" in refused["message"]
+    assert "separate cards" in refused["message"]

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/tests/test_automation_access.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/tests/test_automation_access.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import copy
 import json
 import os
 import uuid
@@ -133,16 +134,26 @@ TEST_CATALOG_VERSION = "delegated_catalog_2026-08-11-10-30-00-123_d4e5f6a7b8c9"
 
 
 class _CatalogResolver:
-    """Resolves a fixed active catalog version; `unavailable` fails closed."""
+    """Resolves a fixed active catalog generation; `unavailable` fails closed.
 
-    def __init__(self, version: str = TEST_CATALOG_VERSION, unavailable: bool = False) -> None:
+    ``connections`` is the catalog body a governed decision reads; tests that
+    only need a version to stamp leave it empty.
+    """
+
+    def __init__(
+        self,
+        version: str = TEST_CATALOG_VERSION,
+        unavailable: bool = False,
+        connections: dict | None = None,
+    ) -> None:
         self.version = version
         self.unavailable = unavailable
+        self.connections = connections or {}
 
     async def resolve_active(self):
         if self.unavailable:
             raise CatalogUnavailable("active_catalog_not_registered")
-        return SimpleNamespace(version=self.version)
+        return SimpleNamespace(version=self.version, connections=self.connections)
 
 
 class _NamedServiceDiscovery:
@@ -223,102 +234,109 @@ def _config():
     return oauth_delegated_config(SimpleNamespace(state=state))
 
 
+NAMED_SERVICES_OAUTH = {
+        "enabled": True,
+        "tenant": "demo-tenant",
+        "project": "demo-project",
+        "capabilities": [
+            {
+                "grant": grant,
+                "label": grant,
+                "delegable_roles": ["kdcube:role:registered"],
+            }
+            for grant in (
+                "named_services:use",
+                "mail:read",
+                "mail:send",
+                "slack:read",
+                "slack:write",
+            )
+        ],
+        "resources": [
+            {
+                "resource": "https://example.test/mcp/named-services",
+                "label": "Named services MCP",
+                "tools": {
+                    "named_services_call": {
+                        "label": "Named service call",
+                        "grants": ["named_services:use"],
+                    }
+                },
+                "named_services": {
+                    "namespaces": {
+                        "mail": {
+                            "label": "Mail",
+                            "description": "Connected mail accounts.",
+                            "authority_id": "delegated_client",
+                            "tools": {
+                                "search": {
+                                    "operation": "object.search",
+                                    "label": "Search mail",
+                                    "grants": ["mail:read"],
+                                },
+                                "action": {
+                                    "operation": "object.action",
+                                    "label": "Mail action",
+                                    "operations": {
+                                        "object.action": {
+                                            "label": "Mail action",
+                                            "grants": ["mail:read", "mail:send"],
+                                        }
+                                    },
+                                },
+                            },
+                        },
+                        "slack": {
+                            "label": "Slack",
+                            "description": "Connected Slack workspaces.",
+                            "authority_id": "delegated_client",
+                            "tools": {
+                                "search": {
+                                    "operation": "object.search",
+                                    "label": "Search Slack",
+                                    "grants": ["slack:read"],
+                                },
+                                "action": {
+                                    "operation": "object.action",
+                                    "label": "Slack action",
+                                    "operations": {
+                                        "object.action": {
+                                            "label": "Slack action",
+                                            "grants": ["slack:read", "slack:write"],
+                                        }
+                                    },
+                                },
+                                "call": {
+                                    "label": "Generic Slack call",
+                                    "operations": {
+                                        "object.search": {
+                                            "label": "Search Slack",
+                                            "grants": ["slack:read"],
+                                        },
+                                        "object.action": {
+                                            "label": "Slack action",
+                                            "grants": ["slack:read", "slack:write"],
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                    }
+                },
+            }
+        ],
+}
+
+
 def _named_services_config():
-    state = SimpleNamespace(
-        oauth_delegated_config={
-            "enabled": True,
-            "tenant": "demo-tenant",
-            "project": "demo-project",
-            "capabilities": [
-                {
-                    "grant": grant,
-                    "label": grant,
-                    "delegable_roles": ["kdcube:role:registered"],
-                }
-                for grant in (
-                    "named_services:use",
-                    "mail:read",
-                    "mail:send",
-                    "slack:read",
-                    "slack:write",
-                )
-            ],
-            "resources": [
-                {
-                    "resource": "https://example.test/mcp/named-services",
-                    "label": "Named services MCP",
-                    "tools": {
-                        "named_services_call": {
-                            "label": "Named service call",
-                            "grants": ["named_services:use"],
-                        }
-                    },
-                    "named_services": {
-                        "namespaces": {
-                            "mail": {
-                                "label": "Mail",
-                                "description": "Connected mail accounts.",
-                                "authority_id": "delegated_client",
-                                "tools": {
-                                    "search": {
-                                        "operation": "object.search",
-                                        "label": "Search mail",
-                                        "grants": ["mail:read"],
-                                    },
-                                    "action": {
-                                        "operation": "object.action",
-                                        "label": "Mail action",
-                                        "operations": {
-                                            "object.action": {
-                                                "label": "Mail action",
-                                                "grants": ["mail:read", "mail:send"],
-                                            }
-                                        },
-                                    },
-                                },
-                            },
-                            "slack": {
-                                "label": "Slack",
-                                "description": "Connected Slack workspaces.",
-                                "authority_id": "delegated_client",
-                                "tools": {
-                                    "search": {
-                                        "operation": "object.search",
-                                        "label": "Search Slack",
-                                        "grants": ["slack:read"],
-                                    },
-                                    "action": {
-                                        "operation": "object.action",
-                                        "label": "Slack action",
-                                        "operations": {
-                                            "object.action": {
-                                                "label": "Slack action",
-                                                "grants": ["slack:read", "slack:write"],
-                                            }
-                                        },
-                                    },
-                                    "call": {
-                                        "label": "Generic Slack call",
-                                        "operations": {
-                                            "object.search": {
-                                                "label": "Search Slack",
-                                                "grants": ["slack:read"],
-                                            },
-                                            "object.action": {
-                                                "label": "Slack action",
-                                                "grants": ["slack:read", "slack:write"],
-                                            },
-                                        },
-                                    },
-                                },
-                            },
-                        }
-                    },
-                }
-            ],
-        }
+    return oauth_delegated_config(
+        SimpleNamespace(state=SimpleNamespace(oauth_delegated_config=NAMED_SERVICES_OAUTH))
     )
-    return oauth_delegated_config(SimpleNamespace(state=state))
+
+
+def _named_services_connections() -> dict:
+    """The registered catalog body matching `_named_services_config`."""
+    return {"delegated_credentials": {"oauth": NAMED_SERVICES_OAUTH}}
 
 
 @pytest.mark.asyncio
@@ -1047,8 +1065,11 @@ def _named_services_agent_service(card_persistence):
             ],
         }
     )
+    # The native gate reads the registered catalog, so the fixture publishes the
+    # same block it configures.
+    connections = {"delegated_credentials": {"oauth": state.oauth_delegated_config}}
     return AutomationAccessService(
-        catalog_resolver=_CatalogResolver(),
+        catalog_resolver=_CatalogResolver(connections=connections),
         card_persistence=card_persistence,
         redis=_Redis(), tenant="demo-tenant", project="demo-project",
         config=oauth_delegated_config(SimpleNamespace(state=state)),
@@ -1098,6 +1119,82 @@ async def test_agent_namespace_grant_state_governs_and_grants(card_persistence):
         grantor_subject="platform-user-1", client_id=_AGENT_CLIENT,
         namespace="calendar", operation="object.search",
     )) == {"governed": False}
+
+
+@pytest.mark.asyncio
+async def test_the_native_gate_refuses_an_operation_the_catalog_dropped(card_persistence):
+    """The card holds it; the deployment no longer offers it. Consent cannot
+    restore that, so the answer is a removal, not a pending grant."""
+    service = _named_services_agent_service(card_persistence)
+    ns_resource = "*/kdcube-services@1-0/public/mcp/named_services*"
+    claims = ["mail:read", "named_services:use"]
+    assert (await service.create_access(
+        _AGENT_USER, label="agent", client_id=_AGENT_CLIENT,
+        resource_grants={ns_resource: claims},
+    ))["ok"] is True
+
+    trimmed = copy.deepcopy(service._catalog_resolver.connections)
+    namespaces = trimmed["delegated_credentials"]["oauth"]["resources"][0]["named_services"]["namespaces"]
+    namespaces["mail"]["tools"].pop("search")
+    service._catalog_resolver.connections = trimmed
+
+    state = await service.agent_namespace_grant_state(
+        grantor_subject="platform-user-1", client_id=_AGENT_CLIENT,
+        namespace="mail", operation="object.search",
+    )
+
+    assert state["governed"] is True and state["granted"] is False
+    removed = state["removed"]
+    assert removed["error"]["code"] == "delegated_capability_no_longer_available"
+    path = removed["ret"]["requested_capability"]
+    assert path["namespace"] == "mail" and path["operation"] == "object.search"
+    assert path["surface"] == "named_service"
+    assert removed["ret"]["card_revision"] >= 1
+
+
+@pytest.mark.asyncio
+async def test_the_native_gate_refuses_a_namespace_the_catalog_dropped(card_persistence):
+    service = _named_services_agent_service(card_persistence)
+    ns_resource = "*/kdcube-services@1-0/public/mcp/named_services*"
+    assert (await service.create_access(
+        _AGENT_USER, label="agent", client_id=_AGENT_CLIENT,
+        resource_grants={ns_resource: ["mail:read", "named_services:use"]},
+    ))["ok"] is True
+
+    trimmed = copy.deepcopy(service._catalog_resolver.connections)
+    trimmed["delegated_credentials"]["oauth"]["resources"][0]["named_services"]["namespaces"].pop("mail")
+    service._catalog_resolver.connections = trimmed
+
+    state = await service.agent_namespace_grant_state(
+        grantor_subject="platform-user-1", client_id=_AGENT_CLIENT,
+        namespace="mail", operation="object.search",
+    )
+
+    assert state["governed"] is True and state["granted"] is False
+    assert state["removed"]["ret"]["requested_capability"]["namespace"] == "mail"
+
+
+@pytest.mark.asyncio
+async def test_a_namespace_no_card_ever_held_stays_ungoverned(card_persistence):
+    """Nothing was delegated here, so there is nothing to refuse."""
+    service = _named_services_agent_service(card_persistence)
+
+    assert (await service.agent_namespace_grant_state(
+        grantor_subject="platform-user-1", client_id=_AGENT_CLIENT,
+        namespace="calendar", operation="object.search",
+    )) == {"governed": False}
+
+
+@pytest.mark.asyncio
+async def test_the_native_gate_fails_closed_when_the_catalog_is_unavailable(card_persistence):
+    service = _named_services_agent_service(card_persistence)
+    service._catalog_resolver.unavailable = True
+
+    with pytest.raises(CatalogUnavailable):
+        await service.agent_namespace_grant_state(
+            grantor_subject="platform-user-1", client_id=_AGENT_CLIENT,
+            namespace="mail", operation="object.search",
+        )
 
 
 @pytest.mark.asyncio

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/tests/test_automation_access.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/tests/test_automation_access.py
@@ -2484,3 +2484,53 @@ async def test_mixed_identity_scopes_are_refused_with_their_reason(card_persiste
     assert refused["identity_scopes"] == ["grantor", "grantor_identity_family"]
     assert "identity_scope" in refused["message"]
     assert "separate cards" in refused["message"]
+
+
+async def test_a_save_decides_against_the_catalog_not_the_descriptor(card_persistence):
+    """Effective props are an input to publication, not to a card write.
+
+    The descriptor here offers a door the registered catalog does not, which is
+    the window between editing props and `on_app_deploy`. A create that read
+    props would write a card the catalog cannot serve: it commits cleanly and
+    every call fails closed.
+    """
+    ahead = copy.deepcopy(NAMED_SERVICES_OAUTH)
+    ahead["resources"] = list(ahead["resources"]) + [{
+        "resource": "https://example.test/mcp/unpublished",
+        "label": "Added to props, not yet published",
+        "tools": {"call": {"label": "Call", "grants": ["named_services:use"]}},
+    }]
+    service = AutomationAccessService(
+        # The catalog is the one WITHOUT the new door.
+        catalog_resolver=_CatalogResolver(connections=_named_services_connections()),
+        card_persistence=card_persistence,
+        redis=_Redis(), tenant="demo-tenant", project="demo-project",
+        # The descriptor is ahead of it.
+        config=oauth_delegated_config(
+            SimpleNamespace(state=SimpleNamespace(oauth_delegated_config=ahead))
+        ),
+        grant_store=_OAuthStore(), authority=_Authority(), minter=_minter,
+    )
+    user = {"sub": "platform-user-1", "roles": ["kdcube:role:registered"], "permissions": []}
+
+    refused = await service.create_access(
+        user,
+        label="Unpublished door",
+        resource_grants={"https://example.test/mcp/unpublished": ["named_services:use"]},
+        named_service_operations={},
+    )
+    assert refused["ok"] is False
+    assert refused["error"] == "delegated_access_unknown_resources", refused
+
+    # The form must not offer it either, or the refusal is a surprise.
+    offered = {row["resource"] for row in await service.resource_options(user)}
+    assert "https://example.test/mcp/unpublished" not in offered, offered
+
+    # A door the catalog does publish still saves.
+    ok = await service.create_access(
+        user,
+        label="Published door",
+        resource_grants={"https://example.test/mcp/named-services": ["named_services:use"]},
+        named_service_operations={},
+    )
+    assert ok["ok"] is True, ok

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/tests/test_cache_settings.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/tests/test_cache_settings.py
@@ -1,0 +1,99 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Elena Viter
+
+import pathlib
+
+import pytest
+import yaml
+
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.cache_settings import (
+    DEFAULT_ACTIVE_CACHE_SECONDS,
+    DEFAULT_REVOKED_TOMBSTONE_SECONDS,
+    DEFAULT_UPDATING_MARKER_SECONDS,
+    DEFAULT_VERSION_CACHE_SECONDS,
+    DelegatedCacheSettings,
+)
+
+def _ai_app_root() -> pathlib.Path:
+    for parent in pathlib.Path(__file__).resolve().parents:
+        if (parent / "deployment/bundles.yaml").is_file():
+            return parent
+    raise AssertionError("ai-app root with deployment/bundles.yaml not found")
+
+
+_AI_APP_ROOT = _ai_app_root()
+_REFERENCE_DESCRIPTOR = (
+    _AI_APP_ROOT
+    / "src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/examples/bundles"
+    / "connection-hub@1-0/config/bundles.template.yaml"
+)
+_DEPLOYED_DESCRIPTOR = _AI_APP_ROOT / "deployment/bundles.yaml"
+
+
+def test_defaults_apply_when_the_block_is_absent():
+    settings = DelegatedCacheSettings.from_connections({})
+    assert settings.catalog.active_cache_seconds == DEFAULT_ACTIVE_CACHE_SECONDS
+    assert settings.catalog.version_cache_seconds == DEFAULT_VERSION_CACHE_SECONDS
+    assert settings.cards.updating_marker_seconds == DEFAULT_UPDATING_MARKER_SECONDS
+    assert settings.cards.revoked_tombstone_seconds == DEFAULT_REVOKED_TOMBSTONE_SECONDS
+
+
+def test_declared_values_are_read():
+    settings = DelegatedCacheSettings.from_connections(
+        {
+            "delegated_credentials": {
+                "catalog": {"active_cache_seconds": 60, "version_cache_seconds": 120},
+                "cards": {"updating_marker_seconds": 5, "revoked_tombstone_seconds": 30},
+            }
+        }
+    )
+    assert settings.catalog.active_cache_seconds == 60
+    assert settings.catalog.version_cache_seconds == 120
+    assert settings.cards.updating_marker_seconds == 5
+    assert settings.cards.revoked_tombstone_seconds == 30
+
+
+@pytest.mark.parametrize("bad", [0, -1, "", None, "abc", {}])
+def test_unusable_values_fall_back_to_the_default(bad):
+    settings = DelegatedCacheSettings.from_connections(
+        {"delegated_credentials": {"catalog": {"active_cache_seconds": bad}}}
+    )
+    assert settings.catalog.active_cache_seconds == DEFAULT_ACTIVE_CACHE_SECONDS
+
+
+def test_residency_is_bounded():
+    settings = DelegatedCacheSettings.from_connections(
+        {"delegated_credentials": {"catalog": {"version_cache_seconds": 10 ** 9}}}
+    )
+    assert settings.catalog.version_cache_seconds == 24 * 3600
+
+
+def _descriptor_connections(path: pathlib.Path) -> dict:
+    document = yaml.safe_load(path.read_text(encoding="utf-8"))
+    found: list[dict] = []
+
+    def walk(node):
+        if isinstance(node, dict):
+            candidate = node.get("connections")
+            if isinstance(candidate, dict) and "delegated_credentials" in candidate:
+                found.append(candidate)
+            for value in node.values():
+                walk(value)
+        elif isinstance(node, list):
+            for item in node:
+                walk(item)
+
+    walk(document)
+    assert found, f"no connections block with delegated_credentials in {path}"
+    return found[0]
+
+
+def test_reference_and_deployed_descriptors_declare_the_same_residency():
+    reference = DelegatedCacheSettings.from_connections(
+        _descriptor_connections(_REFERENCE_DESCRIPTOR)
+    )
+    deployed = DelegatedCacheSettings.from_connections(
+        _descriptor_connections(_DEPLOYED_DESCRIPTOR)
+    )
+    assert reference == deployed
+    assert reference == DelegatedCacheSettings()

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/tests/test_card_records.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/tests/test_card_records.py
@@ -1,0 +1,228 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Elena Viter
+
+import hashlib
+from datetime import datetime, timezone
+
+import pytest
+
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.cards.model import (
+    CARD_STATE_ACTIVE,
+    CARD_STATE_REVOKED,
+    CardAuthority,
+    CardCredentialHandles,
+    CardRecordError,
+    NamedServiceSelection,
+    card_revision_name,
+)
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.cards.store import (
+    BundleStorageDelegatedCardStore,
+    CardStorageError,
+)
+
+RESOURCE = "https://example.test/mcp/named-services"
+SUBJECT_HASH = hashlib.sha256(b"platform-user-1").hexdigest()
+
+EXACT = {RESOURCE: {"slack": ["object.search"]}}
+
+
+def _authority(**overrides) -> CardAuthority:
+    base = dict(
+        access_id="aut_abc123",
+        client_id="automation:abc",
+        grantor_subject="platform-user-1",
+        delegate_subject="integration:automation:abc",
+        source="manual",
+        label="CI bot",
+        card_revision=1,
+        catalog_version="delegated_catalog_2026-08-11-10-30-00-123_d4e5f6a7b8c9",
+        resource_grants={RESOURCE: ("named_services:use", "slack:read")},
+        named_service_operations=NamedServiceSelection.exact(EXACT),
+        operations=("named_services_schema",),
+        created_at=1_780_000_000,
+        expires_at=1_780_003_600,
+    )
+    base.update(overrides)
+    return CardAuthority(**base)
+
+
+# -- three-state named-service selection (#224) -------------------------------
+
+
+def test_absent_field_is_unknown_and_explicit_empty_is_none():
+    absent = NamedServiceSelection.from_stored(None, present=False)
+    empty = NamedServiceSelection.from_stored({}, present=True)
+
+    assert absent.is_unknown
+    assert empty.is_none
+    assert absent != empty
+
+
+def test_wildcard_and_exact_states_parse():
+    assert NamedServiceSelection.from_stored("*", present=True).is_all
+    exact = NamedServiceSelection.from_stored(EXACT, present=True)
+    assert exact.is_exact
+    assert exact.operations == {RESOURCE: {"slack": ("object.search",)}}
+
+
+def test_exact_with_no_surviving_entry_is_none_not_exact():
+    assert NamedServiceSelection.exact({}).is_none
+    assert NamedServiceSelection.exact({"   ": {}}).is_none
+
+
+def test_every_written_state_round_trips():
+    for selection in (
+        NamedServiceSelection.all(),
+        NamedServiceSelection.none(),
+        NamedServiceSelection.exact(EXACT),
+    ):
+        stored = selection.to_stored()
+        assert NamedServiceSelection.from_stored(stored, present=True) == selection
+
+
+def test_unknown_writes_nothing():
+    assert NamedServiceSelection.unknown().to_stored() is None
+
+
+def test_namespace_keys_are_normalized():
+    selection = NamedServiceSelection.exact({RESOURCE: {"Slack:": ["object.search"]}})
+    assert selection.operations == {RESOURCE: {"slack": ("object.search",)}}
+
+
+def test_a_non_wildcard_string_is_rejected():
+    with pytest.raises(CardRecordError) as exc:
+        NamedServiceSelection.from_stored("all", present=True)
+    assert exc.value.reason == "named_service_operations_invalid"
+
+
+# -- card authority -----------------------------------------------------------
+
+
+def test_explicit_empty_survives_serialization_but_unknown_does_not_appear():
+    empty = _authority(named_service_operations=NamedServiceSelection.none()).to_dict()
+    unknown = _authority(named_service_operations=NamedServiceSelection.unknown()).to_dict()
+
+    assert empty["named_service_operations"] == {}
+    assert "named_service_operations" not in unknown
+
+
+@pytest.mark.parametrize(
+    "selection",
+    [
+        NamedServiceSelection.all(),
+        NamedServiceSelection.none(),
+        NamedServiceSelection.exact(EXACT),
+        NamedServiceSelection.unknown(),
+    ],
+)
+def test_authority_round_trips_every_selection_state(selection):
+    authority = _authority(named_service_operations=selection)
+    assert CardAuthority.from_mapping(authority.to_dict()) == authority
+
+
+def test_content_hash_is_stable_and_selection_sensitive():
+    authority = _authority()
+    assert authority.content_hash() == _authority().content_hash()
+    assert (
+        _authority(named_service_operations=NamedServiceSelection.none()).content_hash()
+        != _authority(named_service_operations=NamedServiceSelection.unknown()).content_hash()
+    )
+
+
+def test_unknown_state_value_is_rejected():
+    payload = _authority().to_dict()
+    payload["state"] = "suspended"
+    with pytest.raises(CardRecordError) as exc:
+        CardAuthority.from_mapping(payload)
+    assert exc.value.reason == "state_invalid"
+
+
+def test_credential_handles_are_separate_from_authority():
+    assert "access_token" not in _authority().to_dict()
+    assert "refresh_token" not in _authority().to_dict()
+    assert "session_id" not in _authority().to_dict()
+    assert CardCredentialHandles(access_id="aut_abc123").empty is True
+
+
+def test_revision_name_is_sortable_and_verifiable():
+    moment = datetime(2026, 8, 11, 15, 4, 19, 881_000, tzinfo=timezone.utc)
+    name = card_revision_name(card_revision=2, content_hash="b9d06ee7124a" + "0" * 52, updated_at=moment)
+    assert name == "card_revision_2026-08-11-15-04-19-881_00000002_b9d06ee7124a.json"
+
+
+# -- durable card store -------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_card_store_commit_and_read_back(tmp_path):
+    store = BundleStorageDelegatedCardStore(tmp_path)
+    authority = _authority()
+    moment = datetime.now(timezone.utc)
+
+    assert await store.read_current_authority(subject_hash=SUBJECT_HASH, access_id=authority.access_id) is None
+
+    pointer = await store.write_revision(
+        subject_hash=SUBJECT_HASH, authority=authority, updated_at=moment
+    )
+    await store.advance_current(subject_hash=SUBJECT_HASH, pointer=pointer)
+
+    loaded = await store.read_current_authority(
+        subject_hash=SUBJECT_HASH, access_id=authority.access_id
+    )
+    assert loaded is not None
+    loaded_pointer, loaded_authority = loaded
+    assert loaded_authority == authority
+    assert loaded_pointer.card_revision == 1
+    assert loaded_pointer.state == CARD_STATE_ACTIVE
+    assert await store.list_card_ids(subject_hash=SUBJECT_HASH) == [authority.access_id]
+
+
+@pytest.mark.asyncio
+async def test_revisions_are_immutable_and_accumulate(tmp_path):
+    store = BundleStorageDelegatedCardStore(tmp_path)
+    first = _authority()
+    second = _authority(card_revision=2, state=CARD_STATE_REVOKED)
+
+    for authority in (first, second):
+        pointer = await store.write_revision(
+            subject_hash=SUBJECT_HASH, authority=authority, updated_at=datetime.now(timezone.utc)
+        )
+        await store.advance_current(subject_hash=SUBJECT_HASH, pointer=pointer)
+
+    names = await store.list_revision_names(subject_hash=SUBJECT_HASH, access_id=first.access_id)
+    assert len(names) == 2
+    assert names == sorted(names)
+    _, current = await store.read_current_authority(
+        subject_hash=SUBJECT_HASH, access_id=first.access_id
+    )
+    assert current.state == CARD_STATE_REVOKED
+
+
+@pytest.mark.asyncio
+async def test_pointer_naming_a_missing_revision_is_corruption_not_absence(tmp_path):
+    store = BundleStorageDelegatedCardStore(tmp_path)
+    authority = _authority()
+    pointer = await store.write_revision(
+        subject_hash=SUBJECT_HASH, authority=authority, updated_at=datetime.now(timezone.utc)
+    )
+    await store.advance_current(subject_hash=SUBJECT_HASH, pointer=pointer)
+    store.revision_path(
+        subject_hash=SUBJECT_HASH,
+        access_id=authority.access_id,
+        revision_name=pointer.revision_name,
+    ).unlink()
+
+    with pytest.raises(CardStorageError) as exc:
+        await store.read_current_authority(subject_hash=SUBJECT_HASH, access_id=authority.access_id)
+    assert exc.value.reason == "current_revision_missing"
+
+
+@pytest.mark.asyncio
+async def test_store_rejects_unsafe_path_segments(tmp_path):
+    store = BundleStorageDelegatedCardStore(tmp_path)
+    with pytest.raises(CardStorageError) as exc:
+        await store.read_current(subject_hash="not-a-hash", access_id="aut_abc123")
+    assert exc.value.reason == "subject_hash_invalid"
+    with pytest.raises(CardStorageError) as exc:
+        await store.read_current(subject_hash=SUBJECT_HASH, access_id="../../escape")
+    assert exc.value.reason == "access_id_invalid"

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/tests/test_card_records.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/tests/test_card_records.py
@@ -46,7 +46,7 @@ def _authority(**overrides) -> CardAuthority:
     return CardAuthority(**base)
 
 
-# -- three-state named-service selection (#224) -------------------------------
+# -- three-state named-service selection --------------------------------------
 
 
 def test_absent_field_is_unknown_and_explicit_empty_is_none():

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/tests/test_card_records.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/tests/test_card_records.py
@@ -226,3 +226,85 @@ async def test_store_rejects_unsafe_path_segments(tmp_path):
     with pytest.raises(CardStorageError) as exc:
         await store.read_current(subject_hash=SUBJECT_HASH, access_id="../../escape")
     assert exc.value.reason == "access_id_invalid"
+
+
+# -- record <-> authority/handles conversion -----------------------------------
+
+
+def _record_with_secrets():
+    from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.automation_access import (
+        AutomationAccessRecord,
+    )
+
+    return AutomationAccessRecord(
+        access_id="aut_abc123",
+        label="CI bot",
+        client_id="automation:abc",
+        grantor_subject="platform-user-1",
+        delegate_subject="integration:automation:abc",
+        operations=("named_services_schema",),
+        resource_grants={RESOURCE: ("slack:read",)},
+        named_service_operations=NamedServiceSelection.exact(EXACT),
+        named_services={"namespaces": {"slack": {}}},
+        identity_scope="grantor",
+        catalog_version="delegated_catalog_2026-08-11-10-30-00-123_d4e5f6a7b8c9",
+        card_revision=7,
+        session_id="sess-secret",
+        created_at=1_780_000_000,
+        expires_at=1_780_003_600,
+        last_four="9abc",
+        source="manual",
+        refresh_token="rt-secret",
+        access_token="at-secret",
+        last_issued_at=1_780_000_000,
+    )
+
+
+def test_authority_carries_no_credential_material():
+    from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.automation_access import (
+        card_authority_from_record,
+        card_handles_from_record,
+    )
+
+    record = _record_with_secrets()
+    authority = card_authority_from_record(record)
+    handles = card_handles_from_record(record)
+
+    serialized = str(authority.to_dict())
+    for secret in ("rt-secret", "at-secret", "sess-secret"):
+        assert secret not in serialized
+
+    assert handles.access_token == "at-secret"
+    assert handles.refresh_token == "rt-secret"
+    assert handles.session_id == "sess-secret"
+
+
+def test_record_round_trips_through_the_split():
+    from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.automation_access import (
+        card_authority_from_record,
+        card_handles_from_record,
+        record_from_card,
+    )
+
+    record = _record_with_secrets()
+    rebuilt = record_from_card(
+        card_authority_from_record(record), card_handles_from_record(record)
+    )
+    assert rebuilt == record
+
+
+def test_recombining_without_handles_yields_no_secrets():
+    from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.automation_access import (
+        card_authority_from_record,
+        record_from_card,
+    )
+
+    record = _record_with_secrets()
+    restored = record_from_card(card_authority_from_record(record))
+
+    assert restored.access_token == ""
+    assert restored.refresh_token == ""
+    assert restored.session_id == ""
+    assert restored.resource_grants == record.resource_grants
+    assert restored.named_service_operations == record.named_service_operations
+    assert restored.card_revision == 7

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/tests/test_card_service.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/tests/test_card_service.py
@@ -299,6 +299,23 @@ async def test_an_expired_card_is_not_indexed_or_served(service, cache, store):
 
 
 @pytest.mark.asyncio
+async def test_read_through_does_not_re_cache_expired_authority(
+    service, cache, store, redis_client
+):
+    """Recovery restores authority, never resurrects it."""
+    await service.commit(
+        _authority(expires_at=NOW - 1), subject_hash=SUBJECT_HASH, expected_revision=0, now=NOW
+    )
+    await redis_client.delete(cache.card_key(ACCESS_ID))
+
+    resolver = DelegatedCardResolver(cache=cache, store=store)
+    assert await resolver.resolve(
+        subject_hash=SUBJECT_HASH, access_id=ACCESS_ID, now=NOW
+    ) is None
+    assert await redis_client.exists(cache.card_key(ACCESS_ID)) == 0
+
+
+@pytest.mark.asyncio
 async def test_a_damaged_projection_is_repaired_from_durable_state(service, store, cache, redis_client):
     """Unusable cache data must not read as a revoked card."""
     await service.commit(_authority(), subject_hash=SUBJECT_HASH, expected_revision=0, now=NOW)

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/tests/test_card_service.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/tests/test_card_service.py
@@ -1,0 +1,298 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Elena Viter
+
+"""Card mutation protocol against real Redis and durable storage."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import os
+import uuid
+
+import pytest
+
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.cards.cache import (
+    DelegatedCardRuntimeCache,
+)
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.cards.model import (
+    CARD_STATE_ACTIVE,
+    CARD_STATE_REVOKED,
+    CardAuthority,
+    CardCurrentPointer,
+    NamedServiceSelection,
+)
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.cards.resolver import (
+    CardUnavailable,
+    DelegatedCardResolver,
+)
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.cards.service import (
+    CardCommitFailed,
+    CardConflict,
+    DelegatedCardService,
+)
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.cards.store import (
+    BundleStorageDelegatedCardStore,
+)
+
+SUBJECT_HASH = hashlib.sha256(b"platform-user-1").hexdigest()
+ACCESS_ID = "aut_abc123"
+NOW = 1_780_000_000
+
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("REDIS_URL"),
+    reason="REDIS_URL is not set; card mutation tests are skipped",
+)
+
+
+@pytest.fixture
+async def redis_client():
+    import redis.asyncio as redis_asyncio
+
+    client = redis_asyncio.from_url(os.environ["REDIS_URL"])
+    try:
+        await client.ping()
+    except Exception as exc:  # pragma: no cover - environment guard
+        pytest.skip(f"Redis at REDIS_URL is unreachable: {exc}")
+    yield client
+    await client.aclose()
+
+
+@pytest.fixture
+def cache(redis_client) -> DelegatedCardRuntimeCache:
+    return DelegatedCardRuntimeCache(
+        redis_client, tenant=f"t-{uuid.uuid4().hex[:8]}", project=f"p-{uuid.uuid4().hex[:8]}"
+    )
+
+
+@pytest.fixture
+def store(tmp_path) -> BundleStorageDelegatedCardStore:
+    return BundleStorageDelegatedCardStore(tmp_path)
+
+
+@pytest.fixture
+def service(store, cache) -> DelegatedCardService:
+    return DelegatedCardService(store=store, cache=cache)
+
+
+def _authority(*, revision: int = 1, expires_at: int = NOW + 3600) -> CardAuthority:
+    return CardAuthority(
+        access_id=ACCESS_ID,
+        client_id="automation:abc",
+        grantor_subject="platform-user-1",
+        delegate_subject="integration:automation:abc",
+        source="manual",
+        label="CI bot",
+        card_revision=revision,
+        catalog_version="delegated_catalog_2026-08-11-10-30-00-123_d4e5f6a7b8c9",
+        state=CARD_STATE_ACTIVE,
+        resource_grants={"https://ex/mcp": ("slack:read",)},
+        named_service_operations=NamedServiceSelection.none(),
+        created_at=NOW,
+        expires_at=expires_at,
+    )
+
+
+@pytest.mark.asyncio
+async def test_create_commits_durably_before_exposing_authority(service, store, cache):
+    pointer = await service.commit(
+        _authority(), subject_hash=SUBJECT_HASH, expected_revision=0, now=NOW
+    )
+
+    assert pointer.card_revision == 1
+    durable = await store.read_current_authority(
+        subject_hash=SUBJECT_HASH, access_id=ACCESS_ID
+    )
+    assert durable is not None and durable[1].card_revision == 1
+    entry = await cache.read(ACCESS_ID)
+    assert entry.is_card and entry.card_revision == 1
+    assert await cache.index_members(subject_hash=SUBJECT_HASH, now=NOW) == [ACCESS_ID]
+
+
+@pytest.mark.asyncio
+async def test_a_stale_expected_revision_is_rejected(service):
+    await service.commit(_authority(), subject_hash=SUBJECT_HASH, expected_revision=0, now=NOW)
+
+    with pytest.raises(CardConflict) as exc:
+        await service.commit(
+            _authority(revision=2), subject_hash=SUBJECT_HASH, expected_revision=0, now=NOW
+        )
+    # The lost-update check reads durable state, not the cache projection.
+    assert exc.value.reason == "card_revision_moved"
+    assert exc.value.current_revision == 1
+
+
+@pytest.mark.asyncio
+async def test_a_slow_commit_keeps_writers_out_after_its_marker_expires(
+    service, store, cache, monkeypatch
+):
+    """The section, not the marker, is what excludes a second writer.
+
+    The marker carries a short fixed residency. A durable write slower than
+    that residency would let a second mutation in if exclusion depended on the
+    marker alone, producing two revisions with the same number and a lost
+    update.
+    """
+    await service.commit(_authority(), subject_hash=SUBJECT_HASH, expected_revision=0, now=NOW)
+
+    original = store.write_revision
+    started = asyncio.Event()
+
+    async def _slow_write(**kwargs):
+        started.set()
+        # The marker expires mid-write; only the section still holds.
+        await cache._redis.delete(cache.card_key(ACCESS_ID))
+        await asyncio.sleep(0.3)
+        return await original(**kwargs)
+
+    monkeypatch.setattr(store, "write_revision", _slow_write)
+
+    async def _second_writer():
+        await started.wait()
+        await asyncio.sleep(0.05)
+        return await service.commit(
+            _authority(revision=2), subject_hash=SUBJECT_HASH, expected_revision=1, now=NOW
+        )
+
+    results = await asyncio.gather(
+        service.commit(
+            _authority(revision=2), subject_hash=SUBJECT_HASH, expected_revision=1, now=NOW
+        ),
+        _second_writer(),
+        return_exceptions=True,
+    )
+    committed = [item for item in results if isinstance(item, CardCurrentPointer)]
+    assert len(committed) == 1, "a second writer committed behind the expired marker"
+
+    names = await store.list_revision_names(subject_hash=SUBJECT_HASH, access_id=ACCESS_ID)
+    assert len(names) == 2
+
+
+@pytest.mark.asyncio
+async def test_a_marker_left_by_another_mutation_is_not_displaced(service, cache):
+    await service.commit(_authority(), subject_hash=SUBJECT_HASH, expected_revision=0, now=NOW)
+    await cache.claim_transition(
+        ACCESS_ID, mutation_id="other", expected_revision=1, ttl_seconds=15
+    )
+
+    with pytest.raises(CardConflict) as exc:
+        await service.commit(
+            _authority(revision=2), subject_hash=SUBJECT_HASH, expected_revision=1, now=NOW
+        )
+    assert exc.value.reason == "card_transition_not_claimed"
+
+
+@pytest.mark.asyncio
+async def test_a_failed_durable_commit_leaves_the_previous_revision_serving(
+    service, store, cache, monkeypatch
+):
+    await service.commit(_authority(), subject_hash=SUBJECT_HASH, expected_revision=0, now=NOW)
+
+    async def _boom(**kwargs):
+        raise OSError("storage down")
+
+    monkeypatch.setattr(store, "write_revision", _boom)
+    with pytest.raises(CardCommitFailed):
+        await service.commit(
+            _authority(revision=2), subject_hash=SUBJECT_HASH, expected_revision=1, now=NOW
+        )
+
+    # The marker was released, so a read-through restores the committed revision.
+    assert await cache.read(ACCESS_ID) is None
+    resolver = DelegatedCardResolver(cache=cache, store=store)
+    monkeypatch.undo()
+    resolved = await resolver.resolve(
+        subject_hash=SUBJECT_HASH, access_id=ACCESS_ID, now=NOW
+    )
+    assert resolved.card_revision == 1
+
+
+@pytest.mark.asyncio
+async def test_requests_fail_closed_while_a_mutation_owns_the_card(service, store, cache):
+    await service.commit(_authority(), subject_hash=SUBJECT_HASH, expected_revision=0, now=NOW)
+    await cache.claim_transition(
+        ACCESS_ID, mutation_id="in-flight", expected_revision=1, ttl_seconds=15
+    )
+
+    resolver = DelegatedCardResolver(cache=cache, store=store)
+    with pytest.raises(CardUnavailable) as exc:
+        await resolver.resolve(subject_hash=SUBJECT_HASH, access_id=ACCESS_ID, now=NOW)
+    assert exc.value.reason == "card_updating"
+
+
+@pytest.mark.asyncio
+async def test_revoke_commits_durable_state_and_denies_immediately(service, store, cache):
+    await service.commit(_authority(), subject_hash=SUBJECT_HASH, expected_revision=0, now=NOW)
+
+    pointer = await service.revoke(
+        subject_hash=SUBJECT_HASH, access_id=ACCESS_ID, expected_revision=1
+    )
+    assert pointer is not None and pointer.state == CARD_STATE_REVOKED
+
+    _, durable = await store.read_current_authority(
+        subject_hash=SUBJECT_HASH, access_id=ACCESS_ID
+    )
+    assert durable.state == CARD_STATE_REVOKED
+    assert durable.card_revision == 2
+
+    resolver = DelegatedCardResolver(cache=cache, store=store)
+    assert await resolver.resolve(
+        subject_hash=SUBJECT_HASH, access_id=ACCESS_ID, now=NOW
+    ) is None
+    assert await cache.index_members(subject_hash=SUBJECT_HASH, now=NOW) == []
+
+
+@pytest.mark.asyncio
+async def test_revocation_survives_the_tombstone_expiring(service, store, cache, redis_client):
+    await service.commit(_authority(), subject_hash=SUBJECT_HASH, expected_revision=0, now=NOW)
+    await service.revoke(
+        subject_hash=SUBJECT_HASH, access_id=ACCESS_ID, expected_revision=1
+    )
+    await redis_client.delete(cache.card_key(ACCESS_ID))
+
+    resolver = DelegatedCardResolver(cache=cache, store=store)
+    assert await resolver.resolve(
+        subject_hash=SUBJECT_HASH, access_id=ACCESS_ID, now=NOW
+    ) is None
+    # Denial came from durable state; no active projection was rebuilt.
+    assert await cache.read(ACCESS_ID) is None
+
+
+@pytest.mark.asyncio
+async def test_history_is_retained_across_revisions(service, store):
+    await service.commit(_authority(), subject_hash=SUBJECT_HASH, expected_revision=0, now=NOW)
+    await service.commit(
+        _authority(revision=2), subject_hash=SUBJECT_HASH, expected_revision=1, now=NOW
+    )
+    await service.revoke(
+        subject_hash=SUBJECT_HASH, access_id=ACCESS_ID, expected_revision=2
+    )
+
+    names = await store.list_revision_names(subject_hash=SUBJECT_HASH, access_id=ACCESS_ID)
+    assert len(names) == 3
+    assert names == sorted(names)
+
+
+@pytest.mark.asyncio
+async def test_durable_revisions_contain_no_credential_material(service, store):
+    await service.commit(_authority(), subject_hash=SUBJECT_HASH, expected_revision=0, now=NOW)
+    names = await store.list_revision_names(subject_hash=SUBJECT_HASH, access_id=ACCESS_ID)
+    body = store.revision_path(
+        subject_hash=SUBJECT_HASH, access_id=ACCESS_ID, revision_name=names[0]
+    ).read_text(encoding="utf-8")
+
+    for forbidden in ("access_token", "refresh_token", "session_id"):
+        assert forbidden not in body
+
+
+@pytest.mark.asyncio
+async def test_an_expired_card_is_not_indexed_or_served(service, cache, store):
+    await service.commit(
+        _authority(expires_at=NOW - 1), subject_hash=SUBJECT_HASH, expected_revision=0, now=NOW
+    )
+
+    assert await cache.index_members(subject_hash=SUBJECT_HASH, now=NOW) == []
+    resolver = DelegatedCardResolver(cache=cache, store=store)
+    assert await resolver.resolve(
+        subject_hash=SUBJECT_HASH, access_id=ACCESS_ID, now=NOW
+    ) is None

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/tests/test_card_service.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/tests/test_card_service.py
@@ -389,3 +389,85 @@ async def test_a_short_card_expiring_does_not_hide_a_long_one(service, store, ca
     resolver = DelegatedCardResolver(cache=cache, store=store)
     listed = await resolver.list_active(subject_hash=SUBJECT_HASH, now=later)
     assert [item.access_id for item in listed] == ["oauth-longlived"]
+
+
+# -- interruption windows ---------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_revision_written_without_becoming_current_is_not_authority(
+    service, store, cache, monkeypatch
+):
+    """The pointer is the commit point, not the revision file.
+
+    An interruption between ``write_revision`` and ``advance_current`` leaves an
+    orphan revision on disk; it must never be served.
+    """
+    await service.commit(_authority(), subject_hash=SUBJECT_HASH, expected_revision=0, now=NOW)
+
+    async def _boom(**kwargs):
+        raise OSError("interrupted before the pointer advanced")
+
+    monkeypatch.setattr(store, "advance_current", _boom)
+    with pytest.raises(CardCommitFailed):
+        await service.commit(
+            _authority(revision=2), subject_hash=SUBJECT_HASH, expected_revision=1, now=NOW
+        )
+    monkeypatch.undo()
+
+    # The orphan revision exists, and the pointer still names the committed one.
+    revisions = await store.list_revision_names(
+        subject_hash=SUBJECT_HASH, access_id=ACCESS_ID
+    )
+    assert len(revisions) == 2
+    current = await store.read_current_authority(
+        subject_hash=SUBJECT_HASH, access_id=ACCESS_ID
+    )
+    assert current[1].card_revision == 1
+
+    assert await cache.read(ACCESS_ID) is None
+    resolver = DelegatedCardResolver(cache=cache, store=store)
+    resolved = await resolver.resolve(
+        subject_hash=SUBJECT_HASH, access_id=ACCESS_ID, now=NOW
+    )
+    assert resolved.card_revision == 1
+
+
+@pytest.mark.asyncio
+async def test_a_committed_revision_is_restored_after_the_projection_write_fails(
+    service, store, cache, redis_client, monkeypatch
+):
+    """Durable commit is the point of no return.
+
+    When the projection write fails after it, read-through must restore the NEW
+    revision — never the superseded one.
+    """
+    await service.commit(_authority(), subject_hash=SUBJECT_HASH, expected_revision=0, now=NOW)
+
+    async def _boom(*args, **kwargs):
+        raise ConnectionError("projection write failed")
+
+    monkeypatch.setattr(cache, "commit_projection", _boom)
+    with pytest.raises(ConnectionError):
+        await service.commit(
+            _authority(revision=2), subject_hash=SUBJECT_HASH, expected_revision=1, now=NOW
+        )
+    monkeypatch.undo()
+
+    current = await store.read_current_authority(
+        subject_hash=SUBJECT_HASH, access_id=ACCESS_ID
+    )
+    assert current[1].card_revision == 2
+
+    # The marker outlives the failure; readers fail closed until it expires.
+    resolver = DelegatedCardResolver(cache=cache, store=store)
+    with pytest.raises(CardUnavailable) as exc:
+        await resolver.resolve(subject_hash=SUBJECT_HASH, access_id=ACCESS_ID, now=NOW)
+    assert exc.value.reason == "card_updating"
+
+    # The marker expires; read-through resolves the committed revision.
+    await redis_client.delete(cache.card_key(ACCESS_ID))
+    resolved = await resolver.resolve(
+        subject_hash=SUBJECT_HASH, access_id=ACCESS_ID, now=NOW
+    )
+    assert resolved.card_revision == 2

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/tests/test_card_service.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/tests/test_card_service.py
@@ -296,3 +296,79 @@ async def test_an_expired_card_is_not_indexed_or_served(service, cache, store):
     assert await resolver.resolve(
         subject_hash=SUBJECT_HASH, access_id=ACCESS_ID, now=NOW
     ) is None
+
+
+@pytest.mark.asyncio
+async def test_a_damaged_projection_is_repaired_from_durable_state(service, store, cache, redis_client):
+    """Unusable cache data must not read as a revoked card."""
+    await service.commit(_authority(), subject_hash=SUBJECT_HASH, expected_revision=0, now=NOW)
+    await redis_client.set(cache.card_key(ACCESS_ID), "{truncated")
+
+    resolver = DelegatedCardResolver(cache=cache, store=store)
+    resolved = await resolver.resolve(
+        subject_hash=SUBJECT_HASH, access_id=ACCESS_ID, now=NOW
+    )
+    assert resolved is not None and resolved.card_revision == 1
+    # The projection was repaired, not left damaged.
+    assert (await cache.read(ACCESS_ID)).card_revision == 1
+
+
+@pytest.mark.asyncio
+async def test_a_damaged_projection_without_a_durable_source_is_unavailable(cache, redis_client):
+    """The guard path has no store: it must report unavailability, not denial."""
+    from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.cards.cache import (
+        CardCacheUnusable,
+    )
+
+    await redis_client.set(cache.card_key(ACCESS_ID), "{truncated")
+    with pytest.raises(CardCacheUnusable) as exc:
+        await cache.read(ACCESS_ID)
+    assert exc.value.reason == "cached_card_not_decodable"
+
+
+@pytest.mark.asyncio
+async def test_an_idle_long_lived_card_stays_listed_and_revocable(service, store, cache):
+    """An OAuth card idle past the old fixed index lifetime is still discoverable.
+
+    The index scores each card by its own expires_at, so nothing about one
+    card's lifetime, or about a week passing without writes, can hide another.
+    """
+    long_lived = _authority(revision=1, expires_at=NOW + 180 * 24 * 3600)
+    await service.commit(long_lived, subject_hash=SUBJECT_HASH, expected_revision=0, now=NOW)
+
+    eight_days_later = NOW + 8 * 24 * 3600
+    resolver = DelegatedCardResolver(cache=cache, store=store)
+    listed = await resolver.list_active(subject_hash=SUBJECT_HASH, now=eight_days_later)
+    assert [item.access_id for item in listed] == [ACCESS_ID]
+
+    pointer = await service.revoke(
+        subject_hash=SUBJECT_HASH, access_id=ACCESS_ID, expected_revision=1
+    )
+    assert pointer is not None and pointer.state == CARD_STATE_REVOKED
+    assert await resolver.list_active(subject_hash=SUBJECT_HASH, now=eight_days_later) == []
+
+
+@pytest.mark.asyncio
+async def test_a_short_card_expiring_does_not_hide_a_long_one(service, store, cache):
+    await service.commit(
+        _authority(expires_at=NOW + 60), subject_hash=SUBJECT_HASH, expected_revision=0, now=NOW
+    )
+    base = _authority()
+    long_lived = CardAuthority(
+        access_id="oauth-longlived",
+        client_id=base.client_id,
+        grantor_subject=base.grantor_subject,
+        delegate_subject=base.delegate_subject,
+        source="oauth",
+        card_revision=1,
+        resource_grants=base.resource_grants,
+        named_service_operations=base.named_service_operations,
+        created_at=NOW,
+        expires_at=NOW + 180 * 24 * 3600,
+    )
+    await service.commit(long_lived, subject_hash=SUBJECT_HASH, expected_revision=0, now=NOW)
+
+    later = NOW + 8 * 24 * 3600
+    resolver = DelegatedCardResolver(cache=cache, store=store)
+    listed = await resolver.list_active(subject_hash=SUBJECT_HASH, now=later)
+    assert [item.access_id for item in listed] == ["oauth-longlived"]

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/tests/test_catalog_authorization.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/tests/test_catalog_authorization.py
@@ -1,0 +1,390 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Elena Viter
+
+import copy
+
+import pytest
+
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.catalog.authorization import (
+    CAPABILITY_NAMED_SERVICE_NAMESPACE,
+    CAPABILITY_NAMED_SERVICE_OPERATION,
+    CAPABILITY_OUTER_OPERATION,
+    CAPABILITY_RESOURCE,
+    CAPABILITY_RESOURCE_CLAIM,
+    DENIAL_CODE,
+    DENIAL_REASON,
+    ActiveCatalogCapabilities,
+    CapabilityRequest,
+    CardProvenance,
+    authorize_current_capability,
+    catalog_unavailable_denial,
+)
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.catalog.models import (
+    CatalogDocument,
+)
+
+SELECTOR = "*/api/integrations/bundles/*/*/kdcube-services@1-0/public/mcp/named_services*"
+REQUEST_URL = (
+    "https://kdcube.example/api/integrations/bundles/acme/prod/"
+    "kdcube-services@1-0/public/mcp/named_services"
+)
+
+CONNECTIONS = {
+    "delegated_credentials": {
+        "oauth": {
+            "enabled": True,
+            "resources": [
+                {
+                    "resource": SELECTOR,
+                    "label": "KDCube named services MCP",
+                    "tools": {
+                        "named_services_schema": {"grants": ["named_services:use"]},
+                        "named_services_search": {"grants": ["named_services:use"]},
+                    },
+                    "named_services": {
+                        "namespaces": {
+                            "mail": {
+                                "tools": {
+                                    "schema": {
+                                        "operation": "object.schema",
+                                        "grants": ["named_services:use"],
+                                    },
+                                    "search": {
+                                        "operation": "object.search",
+                                        "grants": ["named_services:use", "mail:read"],
+                                    },
+                                },
+                            },
+                            "linkedin": {
+                                "tools": {
+                                    "call": {
+                                        "operations": {
+                                            "object.action.publish": {"grants": ["linkedin:write"]},
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            ],
+        },
+    },
+}
+
+PROVENANCE = CardProvenance(
+    access_id="oauth-5aa44826664a0bdd",
+    card_revision=8,
+    catalog_version="delegated_catalog_2026-08-09-09-00-00-000_a1b2c3d4e5f6",
+)
+
+
+def _catalog(connections=None) -> ActiveCatalogCapabilities:
+    return ActiveCatalogCapabilities(
+        CatalogDocument.build(connections if connections is not None else CONNECTIONS)
+    )
+
+
+def _authorize(request, *, connections=None):
+    return authorize_current_capability(
+        catalog=_catalog(connections), provenance=PROVENANCE, request=request
+    )
+
+
+def _without_namespace(name: str) -> dict:
+    trimmed = copy.deepcopy(CONNECTIONS)
+    resource = trimmed["delegated_credentials"]["oauth"]["resources"][0]
+    resource["named_services"]["namespaces"].pop(name)
+    return trimmed
+
+
+# -- what the active catalog still offers --------------------------------------
+
+
+@pytest.mark.parametrize(
+    "request_",
+    [
+        CapabilityRequest(kind=CAPABILITY_RESOURCE, resource=SELECTOR, request_resource=REQUEST_URL),
+        CapabilityRequest(
+            kind=CAPABILITY_RESOURCE_CLAIM,
+            resource=SELECTOR,
+            request_resource=REQUEST_URL,
+            claim="named_services:use",
+        ),
+        CapabilityRequest(
+            kind=CAPABILITY_OUTER_OPERATION,
+            resource=SELECTOR,
+            request_resource=REQUEST_URL,
+            surface="mcp",
+            outer_operation="named_services_schema",
+        ),
+        CapabilityRequest(
+            kind=CAPABILITY_NAMED_SERVICE_NAMESPACE,
+            resource=SELECTOR,
+            request_resource=REQUEST_URL,
+            surface="mcp",
+            namespace="mail",
+        ),
+        CapabilityRequest(
+            kind=CAPABILITY_NAMED_SERVICE_OPERATION,
+            resource=SELECTOR,
+            request_resource=REQUEST_URL,
+            surface="mcp",
+            namespace="mail",
+            operation="object.schema",
+        ),
+    ],
+)
+def test_a_capability_the_catalog_still_offers_is_allowed(request_):
+    assert _authorize(request_) is None
+
+
+def test_nested_operations_mapping_is_read_as_well_as_the_flat_form():
+    allowed = CapabilityRequest(
+        kind=CAPABILITY_NAMED_SERVICE_OPERATION,
+        resource=SELECTOR,
+        request_resource=REQUEST_URL,
+        surface="mcp",
+        namespace="linkedin",
+        operation="object.action.publish",
+    )
+    assert _authorize(allowed) is None
+
+
+def test_a_namespace_key_is_matched_after_normalization():
+    request_ = CapabilityRequest(
+        kind=CAPABILITY_NAMED_SERVICE_NAMESPACE,
+        resource=SELECTOR,
+        request_resource=REQUEST_URL,
+        surface="mcp",
+        namespace="Mail:",
+    )
+    assert _authorize(request_) is None
+
+
+# -- what the active catalog no longer offers ----------------------------------
+
+
+def test_a_removed_namespace_denies_and_names_the_whole_path():
+    request_ = CapabilityRequest(
+        kind=CAPABILITY_NAMED_SERVICE_OPERATION,
+        resource=SELECTOR,
+        request_resource=REQUEST_URL,
+        surface="mcp",
+        outer_operation="named_services_schema",
+        namespace="mail",
+        operation="object.schema",
+    )
+    denial = _authorize(request_, connections=_without_namespace("mail"))
+
+    assert denial is not None
+    assert denial["ok"] is False
+    assert denial["error"]["code"] == DENIAL_CODE
+    assert denial["error"]["retryable"] is False
+    ret = denial["ret"]
+    assert ret["reason"] == DENIAL_REASON
+    assert ret["access_id"] == PROVENANCE.access_id
+    assert ret["card_revision"] == 8
+    assert ret["card_catalog_version"] == PROVENANCE.catalog_version
+    assert ret["active_catalog_version"] != PROVENANCE.catalog_version
+    assert ret["recovery"]["retry_same_request"] is False
+    assert ret["requested_capability"] == {
+        "kind": CAPABILITY_NAMED_SERVICE_OPERATION,
+        "resource": SELECTOR,
+        "request_resource": REQUEST_URL,
+        "surface": "mcp",
+        "outer_operation": "named_services_schema",
+        "namespace": "mail",
+        "operation": "object.schema",
+    }
+
+
+def test_a_removed_operation_denies_while_its_namespace_survives():
+    trimmed = copy.deepcopy(CONNECTIONS)
+    namespaces = trimmed["delegated_credentials"]["oauth"]["resources"][0]["named_services"]["namespaces"]
+    namespaces["mail"]["tools"].pop("schema")
+
+    denied = CapabilityRequest(
+        kind=CAPABILITY_NAMED_SERVICE_OPERATION,
+        resource=SELECTOR,
+        request_resource=REQUEST_URL,
+        surface="mcp",
+        namespace="mail",
+        operation="object.schema",
+    )
+    still_offered = CapabilityRequest(
+        kind=CAPABILITY_NAMED_SERVICE_NAMESPACE,
+        resource=SELECTOR,
+        request_resource=REQUEST_URL,
+        surface="mcp",
+        namespace="mail",
+    )
+
+    assert _authorize(denied, connections=trimmed) is not None
+    assert _authorize(still_offered, connections=trimmed) is None
+
+
+def test_a_removed_claim_denies_even_though_the_resource_survives():
+    trimmed = copy.deepcopy(CONNECTIONS)
+    resource = trimmed["delegated_credentials"]["oauth"]["resources"][0]
+    resource["named_services"]["namespaces"]["mail"]["tools"]["search"]["grants"] = [
+        "named_services:use"
+    ]
+
+    denied = CapabilityRequest(
+        kind=CAPABILITY_RESOURCE_CLAIM,
+        resource=SELECTOR,
+        request_resource=REQUEST_URL,
+        claim="mail:read",
+    )
+    resource_itself = CapabilityRequest(
+        kind=CAPABILITY_RESOURCE, resource=SELECTOR, request_resource=REQUEST_URL
+    )
+
+    assert _authorize(denied, connections=trimmed) is not None
+    assert _authorize(resource_itself, connections=trimmed) is None
+
+
+def test_a_removed_outer_operation_denies():
+    trimmed = copy.deepcopy(CONNECTIONS)
+    trimmed["delegated_credentials"]["oauth"]["resources"][0]["tools"].pop("named_services_schema")
+    request_ = CapabilityRequest(
+        kind=CAPABILITY_OUTER_OPERATION,
+        resource=SELECTOR,
+        request_resource=REQUEST_URL,
+        surface="mcp",
+        outer_operation="named_services_schema",
+    )
+    assert _authorize(request_, connections=trimmed) is not None
+
+
+def test_a_removed_resource_denies_every_kind_beneath_it():
+    empty = {"delegated_credentials": {"oauth": {"enabled": True, "resources": []}}}
+    for request_ in (
+        CapabilityRequest(kind=CAPABILITY_RESOURCE, resource=SELECTOR, request_resource=REQUEST_URL),
+        CapabilityRequest(
+            kind=CAPABILITY_RESOURCE_CLAIM,
+            resource=SELECTOR,
+            request_resource=REQUEST_URL,
+            claim="named_services:use",
+        ),
+        CapabilityRequest(
+            kind=CAPABILITY_NAMED_SERVICE_OPERATION,
+            resource=SELECTOR,
+            request_resource=REQUEST_URL,
+            surface="mcp",
+            namespace="mail",
+            operation="object.schema",
+        ),
+    ):
+        assert _authorize(request_, connections=empty) is not None
+
+
+def test_a_namespace_block_emptied_of_namespaces_is_a_removal_not_an_absent_section():
+    emptied = copy.deepcopy(CONNECTIONS)
+    resource = emptied["delegated_credentials"]["oauth"]["resources"][0]
+    resource["named_services"]["namespaces"] = {}
+
+    request_ = CapabilityRequest(
+        kind=CAPABILITY_NAMED_SERVICE_OPERATION,
+        resource=SELECTOR,
+        request_resource=REQUEST_URL,
+        surface="mcp",
+        namespace="mail",
+        operation="object.schema",
+    )
+    assert _authorize(request_, connections=emptied) is not None
+
+
+def test_a_resource_that_enumerates_no_named_services_carries_no_inner_ceiling():
+    without_block = copy.deepcopy(CONNECTIONS)
+    without_block["delegated_credentials"]["oauth"]["resources"][0].pop("named_services")
+
+    request_ = CapabilityRequest(
+        kind=CAPABILITY_NAMED_SERVICE_OPERATION,
+        resource=SELECTOR,
+        request_resource=REQUEST_URL,
+        surface="mcp",
+        namespace="mail",
+        operation="object.schema",
+    )
+    assert _authorize(request_, connections=without_block) is None
+
+
+def test_a_resource_that_enumerates_no_tools_carries_no_outer_ceiling():
+    without_tools = {
+        "delegated_credentials": {
+            "oauth": {
+                "enabled": True,
+                "resources": [{"resource": "*", "grants": ["kdcube:role:super-admin"]}],
+            }
+        }
+    }
+    request_ = CapabilityRequest(
+        kind=CAPABILITY_OUTER_OPERATION,
+        resource="*",
+        request_resource=REQUEST_URL,
+        surface="rest",
+        outer_operation="anything",
+    )
+    assert _authorize(request_, connections=without_tools) is None
+
+
+def test_an_empty_catalog_body_denies_rather_than_permitting_everything():
+    request_ = CapabilityRequest(
+        kind=CAPABILITY_NAMED_SERVICE_OPERATION,
+        resource=SELECTOR,
+        request_resource=REQUEST_URL,
+        surface="mcp",
+        namespace="mail",
+        operation="object.schema",
+    )
+    assert _authorize(request_, connections={}) is not None
+
+
+# -- denial shape ---------------------------------------------------------------
+
+
+def test_the_path_carries_only_the_fields_its_kind_requires():
+    request_ = CapabilityRequest(
+        kind=CAPABILITY_RESOURCE_CLAIM,
+        resource=SELECTOR,
+        request_resource=REQUEST_URL,
+        surface="mcp",
+        outer_operation="named_services_schema",
+        claim="mail:read",
+        namespace="mail",
+        operation="object.schema",
+    )
+    empty = {"delegated_credentials": {"oauth": {"enabled": True, "resources": []}}}
+    path = _authorize(request_, connections=empty)["ret"]["requested_capability"]
+
+    assert path == {
+        "kind": CAPABILITY_RESOURCE_CLAIM,
+        "resource": SELECTOR,
+        "request_resource": REQUEST_URL,
+        "claim": "mail:read",
+    }
+
+
+def test_a_denial_never_names_the_leaf_operation_alone():
+    request_ = CapabilityRequest(
+        kind=CAPABILITY_NAMED_SERVICE_OPERATION,
+        resource=SELECTOR,
+        request_resource=REQUEST_URL,
+        surface="mcp",
+        namespace="mail",
+        operation="object.schema",
+    )
+    path = _authorize(request_, connections=_without_namespace("mail"))["ret"][
+        "requested_capability"
+    ]
+    assert {"resource", "surface", "namespace", "operation"}.issubset(path)
+
+
+def test_unavailability_is_retryable_and_distinct_from_removal():
+    payload = catalog_unavailable_denial("cache_unavailable")
+    assert payload["ok"] is False
+    assert payload["error"]["retryable"] is True
+    assert payload["error"]["code"] != DENIAL_CODE
+    assert payload["ret"]["reason"] == "cache_unavailable"

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/tests/test_catalog_documents.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/tests/test_catalog_documents.py
@@ -1,0 +1,160 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Elena Viter
+
+import copy
+import json
+
+import pytest
+
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.catalog.hashing import (
+    connections_content_hash,
+)
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.catalog.models import (
+    CatalogDocument,
+    CatalogDocumentError,
+)
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.catalog.source import (
+    connections_from_props,
+)
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.catalog.store import (
+    BundleStorageDelegatedCatalogStore,
+    CatalogStorageError,
+)
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.durable_io import (
+    DurableDecodeError,
+)
+
+CONNECTIONS = {
+    "delegated_credentials": {
+        "oauth": {
+            "enabled": True,
+            "resources": [
+                {
+                    "resource": "https://example.test/mcp/named-services",
+                    "grants": ["named_services:use", "slack:read"],
+                    "named_services": {
+                        "namespaces": {
+                            "slack": {"tools": {"call": {"operations": {"object.search": {}}}}},
+                        },
+                    },
+                },
+            ],
+        },
+    },
+}
+
+
+def _reordered(mapping):
+    """Same content, reversed key insertion order at every mapping level."""
+    if isinstance(mapping, dict):
+        return {key: _reordered(mapping[key]) for key in reversed(list(mapping))}
+    if isinstance(mapping, list):
+        return [_reordered(item) for item in mapping]
+    return mapping
+
+
+def test_hash_is_full_lowercase_sha256():
+    digest = connections_content_hash(CONNECTIONS)
+    assert len(digest) == 64
+    assert digest == digest.lower()
+    int(digest, 16)
+
+
+def test_map_key_order_does_not_change_the_hash():
+    assert connections_content_hash(_reordered(CONNECTIONS)) == connections_content_hash(CONNECTIONS)
+
+
+def test_any_value_change_changes_the_hash():
+    changed = copy.deepcopy(CONNECTIONS)
+    changed["delegated_credentials"]["oauth"]["resources"][0]["grants"] = [
+        "named_services:use",
+        "slack:write",
+    ]
+    assert connections_content_hash(changed) != connections_content_hash(CONNECTIONS)
+
+
+def test_list_order_changes_the_hash():
+    changed = copy.deepcopy(CONNECTIONS)
+    changed["delegated_credentials"]["oauth"]["resources"][0]["grants"] = [
+        "slack:read",
+        "named_services:use",
+    ]
+    assert connections_content_hash(changed) != connections_content_hash(CONNECTIONS)
+
+
+def test_unsupported_value_is_a_publication_error_not_a_coerced_string():
+    with pytest.raises(TypeError):
+        connections_content_hash({"resources": {object()}})
+
+
+def test_document_preserves_the_exact_mapping_without_enrichment():
+    document = CatalogDocument.build(CONNECTIONS)
+    assert document.connections == CONNECTIONS
+    assert json.loads(json.dumps(document.to_dict()))["connections"] == CONNECTIONS
+
+
+def test_document_round_trips_and_verifies():
+    document = CatalogDocument.build(CONNECTIONS)
+    parsed = CatalogDocument.from_mapping(document.to_dict())
+    assert parsed == document
+    assert parsed.version.startswith("delegated_catalog_")
+    assert parsed.version.endswith(document.content_hash[:12])
+
+
+def test_tampered_body_fails_hash_validation():
+    payload = CatalogDocument.build(CONNECTIONS).to_dict()
+    payload["connections"]["delegated_credentials"]["oauth"]["enabled"] = False
+    with pytest.raises(CatalogDocumentError) as exc:
+        CatalogDocument.from_mapping(payload)
+    assert exc.value.reason == "content_hash_mismatch"
+
+
+def test_document_build_snapshots_the_mapping():
+    source = copy.deepcopy(CONNECTIONS)
+    document = CatalogDocument.build(source)
+    source["delegated_credentials"]["oauth"]["enabled"] = False
+    document.verify()
+
+
+def test_connections_from_props_reads_the_exact_mapping():
+    assert connections_from_props({"connections": CONNECTIONS}) == CONNECTIONS
+    assert connections_from_props({"identity": {}}) == {}
+    assert connections_from_props(None) == {}
+
+
+@pytest.mark.asyncio
+async def test_catalog_store_round_trip(tmp_path):
+    store = BundleStorageDelegatedCatalogStore(tmp_path)
+    document = CatalogDocument.build(CONNECTIONS)
+
+    assert await store.read_active() is None
+    assert await store.read_version(document.version) is None
+    assert await store.version_exists(document.version) is False
+
+    await store.write_version(document)
+    await store.publish_active(document)
+
+    assert await store.version_exists(document.version) is True
+    assert await store.read_version(document.version) == document
+    active = await store.read_active()
+    assert active == document
+    assert active.connections == CONNECTIONS
+
+
+@pytest.mark.asyncio
+async def test_catalog_store_rejects_a_malformed_version_name(tmp_path):
+    store = BundleStorageDelegatedCatalogStore(tmp_path)
+    for bad in ("../../etc/passwd", "delegated_catalog_x", "", "delegated_catalog_2026-08-11_zz"):
+        with pytest.raises(CatalogStorageError) as exc:
+            await store.read_version(bad)
+        assert exc.value.reason == "version_name_invalid"
+
+
+@pytest.mark.asyncio
+async def test_catalog_store_reports_corrupt_content_distinctly_from_absence(tmp_path):
+    store = BundleStorageDelegatedCatalogStore(tmp_path)
+    path = store.active_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("{not json", encoding="utf-8")
+    with pytest.raises(DurableDecodeError):
+        await store.read_active()

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/tests/test_catalog_drift.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/tests/test_catalog_drift.py
@@ -305,3 +305,65 @@ def test_removal_and_addition_are_reported_together():
     assert [row["operation"] for row in drift["added"]["named_service_operations"]] == [
         "object.comments"
     ]
+
+
+# -- the administrator all-resource row does not mask a withdrawal --------------
+
+
+def test_a_withdrawn_resource_reads_as_removed_even_beside_a_wildcard_row():
+    """The deployment kept its admin `*` row and withdrew this card's door.
+
+    Judged by the request URL, the `*` row would answer and the card would be
+    described as intact; worse, the live run saw its claims reported as
+    withdrawn and "already ineffective" while the calls kept working. The card
+    holds no `*`, so the row is not its row: the resource itself is the removal.
+    """
+    withdrawn = copy.deepcopy(CONNECTIONS)
+    withdrawn["delegated_credentials"]["oauth"]["resources"] = [
+        {
+            "resource": "*",
+            "label": "All platform and application APIs",
+            "admin_only": True,
+            "grants": ["kdcube:role:super-admin"],
+        }
+    ]
+
+    drift = card_drift(
+        card=_card(),
+        active=_document(withdrawn),
+        baseline=_document(),
+    )
+
+    assert drift["status"] == DRIFT_CHANGED
+    removed = drift["removed"]
+    assert [row["resource"] for row in removed["resources"]] == [RESOURCE]
+    assert removed["resources"][0]["effect"] == EFFECT_DENIED
+    # What sits beneath a removed resource is not enumerated again, and none of
+    # it is described against the admin row.
+    assert removed["claims"] == []
+    assert removed["outer_operations"] == []
+    assert removed["named_service_operations"] == []
+
+
+def test_an_administrator_card_reads_the_wildcard_row_as_its_own():
+    """The mirror: a card that holds `*` is current against that row."""
+    catalog = copy.deepcopy(CONNECTIONS)
+    catalog["delegated_credentials"]["oauth"]["resources"].append(
+        {
+            "resource": "*",
+            "label": "All platform and application APIs",
+            "admin_only": True,
+            "grants": ["kdcube:role:super-admin"],
+        }
+    )
+    document = _document(catalog)
+    card = _card(
+        resource_grants={"*": ("kdcube:role:super-admin",)},
+        operations=(),
+        named_service_operations=NamedServiceSelection.none(),
+    )
+
+    drift = card_drift(card=card, active=document, baseline=document)
+
+    assert drift["removed"]["resources"] == []
+    assert drift["removed"]["claims"] == []

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/tests/test_catalog_drift.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/tests/test_catalog_drift.py
@@ -1,0 +1,307 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Elena Viter
+
+"""Drift is computed from the card and two catalog generations, and explains
+the card without changing it."""
+
+import copy
+
+import pytest
+
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.catalog.drift import (
+    DRIFT_BASELINE_MISSING,
+    DRIFT_CHANGED,
+    DRIFT_CURRENT,
+    DRIFT_NO_RELEVANT_CHANGE,
+    DRIFT_UNAVAILABLE,
+    EFFECT_DENIED,
+    card_drift,
+    drift_unavailable,
+)
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.catalog.models import (
+    CatalogDocument,
+)
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.cards.model import (
+    CardAuthority,
+    NamedServiceSelection,
+)
+
+RESOURCE = "*/api/integrations/bundles/*/*/kdcube-services@1-0/public/mcp/named_services*"
+
+NAMED_SERVICES = {
+    "namespaces": {
+        "mail": {
+            "tools": {
+                "search": {"operation": "object.search", "grants": ["mail:read"]},
+                "schema": {"operation": "object.schema", "grants": ["named_services:use"]},
+            },
+        },
+    },
+}
+
+CONNECTIONS = {
+    "delegated_credentials": {
+        "oauth": {
+            "enabled": True,
+            "resources": [
+                {
+                    "resource": RESOURCE,
+                    "grants": ["named_services:use", "mail:read"],
+                    "tools": {
+                        "named_services_search": {"grants": ["named_services:use"]},
+                        "named_services_schema": {"grants": ["named_services:use"]},
+                    },
+                    "named_services": copy.deepcopy(NAMED_SERVICES),
+                },
+            ],
+        },
+    },
+}
+
+
+def _document(connections=None) -> CatalogDocument:
+    return CatalogDocument.build(connections if connections is not None else CONNECTIONS)
+
+
+def _card(**overrides) -> CardAuthority:
+    base = dict(
+        access_id="aut_abc123",
+        client_id="claude",
+        grantor_subject="platform-user-1",
+        delegate_subject="integration:claude:platform-user-1",
+        source="oauth",
+        card_revision=3,
+        catalog_version="delegated_catalog_2026-08-09-09-00-00-000_a1b2c3d4e5f6",
+        resource_grants={RESOURCE: ("named_services:use", "mail:read")},
+        operations=("named_services_search", "named_services_schema"),
+        named_service_operations=NamedServiceSelection.exact(
+            {RESOURCE: {"mail": ["object.search", "object.schema"]}}
+        ),
+        expires_at=1_780_003_600,
+    )
+    base.update(overrides)
+    return CardAuthority(**base)
+
+
+def _trim(**changes) -> dict:
+    trimmed = copy.deepcopy(CONNECTIONS)
+    resource = trimmed["delegated_credentials"]["oauth"]["resources"][0]
+    if changes.get("drop_resource"):
+        trimmed["delegated_credentials"]["oauth"]["resources"] = []
+        return trimmed
+    if claim := changes.get("drop_claim"):
+        resource["grants"] = [g for g in resource["grants"] if g != claim]
+    if tool := changes.get("drop_tool"):
+        resource["tools"].pop(tool, None)
+    if ns_tool := changes.get("drop_named_service_tool"):
+        resource["named_services"]["namespaces"]["mail"]["tools"].pop(ns_tool, None)
+    if changes.get("drop_namespace"):
+        resource["named_services"]["namespaces"].pop("mail", None)
+    if added := changes.get("add_named_service_tool"):
+        resource["named_services"]["namespaces"]["mail"]["tools"][added] = {
+            "operation": f"object.{added}",
+            "grants": ["named_services:use"],
+        }
+    if added_tool := changes.get("add_tool"):
+        resource["tools"][added_tool] = {"grants": ["named_services:use"]}
+    return trimmed
+
+
+# -- status ---------------------------------------------------------------------
+
+
+def test_a_card_on_the_active_version_is_current():
+    active = _document()
+    drift = card_drift(card=_card(catalog_version=active.version), active=active, baseline=active)
+
+    assert drift["status"] == DRIFT_CURRENT
+    assert drift["saved_version"] == active.version
+    assert "removed" not in drift
+
+
+def test_an_advanced_catalog_that_touches_nothing_is_not_a_change():
+    baseline = _document()
+    # A resource this card does not hold gains a tool.
+    widened = copy.deepcopy(CONNECTIONS)
+    widened["delegated_credentials"]["oauth"]["resources"].append(
+        {"resource": "https://other.test/mcp", "grants": ["records:read"]}
+    )
+    active = _document(widened)
+
+    drift = card_drift(card=_card(), active=active, baseline=baseline)
+
+    assert drift["status"] == DRIFT_NO_RELEVANT_CHANGE
+    assert drift["saved_version"] != drift["current_version"]
+
+
+def test_a_missing_baseline_still_reports_removals_but_no_additions():
+    active = _document(_trim(drop_named_service_tool="schema"))
+
+    drift = card_drift(card=_card(), active=active, baseline=None, baseline_confirmed_absent=True)
+
+    assert drift["status"] == DRIFT_BASELINE_MISSING
+    assert drift["baseline_confirmed_absent"] is True
+    assert [row["operation"] for row in drift["removed"]["named_service_operations"]] == [
+        "object.schema"
+    ]
+    assert drift["added"] == {
+        "claims": [],
+        "outer_operations": [],
+        "named_service_operations": [],
+    }
+
+
+def test_unavailability_is_its_own_status():
+    payload = drift_unavailable("durable_active_unreadable")
+
+    assert payload["status"] == DRIFT_UNAVAILABLE
+    assert payload["reason"] == "durable_active_unreadable"
+
+
+# -- removals -------------------------------------------------------------------
+
+
+def test_a_removed_resource_is_reported_once_and_stops_there():
+    active = _document(_trim(drop_resource=True))
+
+    drift = card_drift(card=_card(), active=active, baseline=_document())
+
+    assert drift["status"] == DRIFT_CHANGED
+    assert drift["removed"]["resources"] == [
+        {"resource": RESOURCE, "was_selected": True, "effect": EFFECT_DENIED}
+    ]
+    # Nothing beneath a removed resource is enumerated separately.
+    assert drift["removed"]["claims"] == []
+    assert drift["removed"]["named_service_operations"] == []
+
+
+def test_a_removed_claim_is_reported_with_its_resource():
+    active = _document(_trim(drop_claim="mail:read"))
+
+    drift = card_drift(card=_card(), active=active, baseline=_document())
+
+    assert drift["removed"]["claims"] == [
+        {
+            "resource": RESOURCE,
+            "claim": "mail:read",
+            "was_selected": True,
+            "effect": EFFECT_DENIED,
+        }
+    ]
+
+
+def test_a_removed_outer_operation_is_reported():
+    active = _document(_trim(drop_tool="named_services_schema"))
+
+    drift = card_drift(card=_card(), active=active, baseline=_document())
+
+    assert drift["removed"]["outer_operations"] == [
+        {
+            "resource": RESOURCE,
+            "operation": "named_services_schema",
+            "was_selected": True,
+            "effect": EFFECT_DENIED,
+        }
+    ]
+
+
+def test_a_removed_namespace_reports_every_selected_operation_under_it():
+    active = _document(_trim(drop_namespace=True))
+
+    drift = card_drift(card=_card(), active=active, baseline=_document())
+
+    assert sorted(
+        row["operation"] for row in drift["removed"]["named_service_operations"]
+    ) == ["object.schema", "object.search"]
+
+
+def test_a_wildcard_card_is_compared_through_its_materialized_boundary():
+    """"*" is not a live grant: what it expanded to at save time is."""
+    card = _card(
+        named_service_operations=NamedServiceSelection.all(),
+        named_services=copy.deepcopy(NAMED_SERVICES),
+    )
+    active = _document(_trim(drop_named_service_tool="search"))
+
+    drift = card_drift(card=card, active=active, baseline=_document())
+
+    assert [row["operation"] for row in drift["removed"]["named_service_operations"]] == [
+        "object.search"
+    ]
+
+
+def test_a_card_that_selected_nothing_reports_no_inner_removals():
+    card = _card(named_service_operations=NamedServiceSelection.none(), named_services={})
+    active = _document(_trim(drop_namespace=True))
+
+    drift = card_drift(card=card, active=active, baseline=_document())
+
+    assert drift["removed"]["named_service_operations"] == []
+
+
+def test_a_resource_that_enumerates_no_named_services_reports_no_inner_removals():
+    without_block = copy.deepcopy(CONNECTIONS)
+    without_block["delegated_credentials"]["oauth"]["resources"][0].pop("named_services")
+
+    drift = card_drift(card=_card(), active=_document(without_block), baseline=_document())
+
+    assert drift["removed"]["named_service_operations"] == []
+
+
+# -- additions ------------------------------------------------------------------
+
+
+def test_a_new_named_service_operation_is_offered_unselected():
+    active = _document(_trim(add_named_service_tool="comments"))
+
+    drift = card_drift(card=_card(), active=active, baseline=_document())
+
+    assert drift["status"] == DRIFT_CHANGED
+    assert drift["added"]["named_service_operations"] == [
+        {
+            "resource": RESOURCE,
+            "namespace": "mail",
+            "operation": "object.comments",
+            "selected": False,
+        }
+    ]
+
+
+def test_a_new_outer_operation_is_offered_unselected():
+    active = _document(_trim(add_tool="named_services_upsert"))
+
+    drift = card_drift(card=_card(), active=active, baseline=_document())
+
+    assert drift["added"]["outer_operations"] == [
+        {"resource": RESOURCE, "operation": "named_services_upsert", "selected": False}
+    ]
+
+
+def test_additions_are_not_reported_for_resources_the_card_does_not_hold():
+    widened = copy.deepcopy(CONNECTIONS)
+    widened["delegated_credentials"]["oauth"]["resources"].append(
+        {
+            "resource": "https://other.test/mcp",
+            "grants": ["records:read"],
+            "tools": {"records_export": {"grants": ["records:read"]}},
+        }
+    )
+
+    drift = card_drift(card=_card(), active=_document(widened), baseline=_document())
+
+    assert drift["added"]["outer_operations"] == []
+    assert drift["added"]["claims"] == []
+
+
+def test_removal_and_addition_are_reported_together():
+    active = _document(_trim(drop_named_service_tool="schema", add_named_service_tool="comments"))
+
+    drift = card_drift(card=_card(), active=active, baseline=_document())
+
+    assert drift["status"] == DRIFT_CHANGED
+    assert [row["operation"] for row in drift["removed"]["named_service_operations"]] == [
+        "object.schema"
+    ]
+    assert [row["operation"] for row in drift["added"]["named_service_operations"]] == [
+        "object.comments"
+    ]

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/tests/test_catalog_publication_windows.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/tests/test_catalog_publication_windows.py
@@ -1,0 +1,370 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Elena Viter
+
+"""Publication windows and serving-entry damage, against real Redis.
+
+Covers the cases the happy-path publication tests do not reach: a publication
+interrupted between its durable steps, a serving write that does not land, a
+changed source that has not been published yet, and a projection that must be
+repaired or refused.
+"""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+import os
+import uuid
+
+import pytest
+
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.cache_settings import (
+    DelegatedCacheSettings,
+)
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.catalog.publisher import (
+    ensure_delegated_catalog,
+)
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.catalog.resolver import (
+    CatalogUnavailable,
+    DelegatedCatalogResolver,
+)
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.catalog.runtime_cache import (
+    DelegatedCatalogRuntimeCache,
+)
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.catalog.store import (
+    BundleStorageDelegatedCatalogStore,
+)
+
+CONNECTIONS = {
+    "delegated_credentials": {
+        "oauth": {
+            "enabled": True,
+            "resources": [
+                {
+                    "resource": "https://ex/mcp",
+                    "grants": ["named_services:use", "mem:read"],
+                    "named_services": {
+                        "namespaces": {
+                            "mem": {
+                                "tools": {
+                                    "list": {"operation": "object.list"},
+                                    "get": {"operation": "object.get"},
+                                }
+                            }
+                        }
+                    },
+                }
+            ],
+        }
+    }
+}
+
+
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("REDIS_URL"),
+    reason="REDIS_URL is not set; catalog publication tests are skipped",
+)
+
+
+@pytest.fixture
+async def redis_client():
+    import redis.asyncio as redis_asyncio
+
+    client = redis_asyncio.from_url(os.environ["REDIS_URL"])
+    try:
+        await client.ping()
+    except Exception as exc:  # pragma: no cover - environment guard
+        pytest.skip(f"Redis at REDIS_URL is unreachable: {exc}")
+    yield client
+    await client.aclose()
+
+
+@pytest.fixture
+def cache(redis_client) -> DelegatedCatalogRuntimeCache:
+    return DelegatedCatalogRuntimeCache(
+        redis_client, tenant=f"t-{uuid.uuid4().hex[:8]}", project=f"p-{uuid.uuid4().hex[:8]}"
+    )
+
+
+def _changed(grants: list[str]) -> dict:
+    other = copy.deepcopy(CONNECTIONS)
+    other["delegated_credentials"]["oauth"]["resources"][0]["grants"] = grants
+    return other
+
+
+async def _ensure(connections, store, cache, **kwargs):
+    return await ensure_delegated_catalog(
+        connections=connections, store=store, cache=cache, **kwargs
+    )
+
+
+# -- interrupted publication ------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_interrupted_publication_leaves_the_previous_catalog_active(
+    tmp_path, cache, monkeypatch
+):
+    """The durable active replacement is the commit point."""
+    store = BundleStorageDelegatedCatalogStore(tmp_path)
+    first = await _ensure(CONNECTIONS, store, cache)
+
+    async def _fail(_document):
+        raise OSError("interrupted before the active replacement")
+
+    monkeypatch.setattr(store, "publish_active", _fail)
+    with pytest.raises(OSError):
+        await _ensure(_changed(["mem:read"]), store, cache)
+    monkeypatch.undo()
+
+    assert (await store.read_active()).version == first.version
+    assert (await cache.read_active()).version == first.version
+
+    # The generation is not ready, so the next deployment completes it.
+    second = await _ensure(_changed(["mem:read"]), store, cache, reason="app_deploy:retry")
+    assert second.created is True
+    assert second.version != first.version
+    assert (await store.read_active()).version == second.version
+    assert await store.version_exists(first.version) is True
+
+
+@pytest.mark.asyncio
+async def test_an_interrupted_first_publication_serves_no_catalog_at_all(
+    tmp_path, cache, monkeypatch
+):
+    """With no previous catalog, requests are refused rather than guessed."""
+    store = BundleStorageDelegatedCatalogStore(tmp_path)
+
+    async def _fail(_document):
+        raise OSError("interrupted before the active replacement")
+
+    monkeypatch.setattr(store, "publish_active", _fail)
+    with pytest.raises(OSError):
+        await _ensure(CONNECTIONS, store, cache)
+    monkeypatch.undo()
+
+    resolver = DelegatedCatalogResolver(cache=cache, store=store)
+    with pytest.raises(CatalogUnavailable) as exc:
+        await resolver.resolve_active()
+    assert exc.value.reason == "active_catalog_not_registered"
+
+    published = await _ensure(CONNECTIONS, store, cache, reason="app_deploy:startup")
+    assert (await resolver.resolve_active()).version == published.version
+
+
+@pytest.mark.asyncio
+async def test_a_serving_write_that_does_not_land_fails_the_generation(
+    tmp_path, cache, monkeypatch
+):
+    """Durable success alone does not make a generation ready.
+
+    The write reports success and stores nothing, so the failure can only be
+    caught by the readiness probe rather than by a propagating exception.
+    """
+    store = BundleStorageDelegatedCatalogStore(tmp_path)
+
+    async def _silently_drop(_document, **_kwargs):
+        return True
+
+    monkeypatch.setattr(cache, "publish_active", _silently_drop)
+    with pytest.raises(RuntimeError, match="ready"):
+        await _ensure(CONNECTIONS, store, cache)
+    monkeypatch.undo()
+
+    # Durable state committed; the serving entry did not.
+    assert await store.read_active() is not None
+    assert await cache.read_active() is None
+
+    repeated = await _ensure(CONNECTIONS, store, cache, reason="app_deploy:retry")
+    assert repeated.created is False
+    assert (await cache.read_active()).version == repeated.version
+
+
+@pytest.mark.asyncio
+async def test_an_unwritable_serving_entry_fails_the_generation(
+    tmp_path, cache, monkeypatch
+):
+    """The raising variant: the failure reaches the deployer."""
+    store = BundleStorageDelegatedCatalogStore(tmp_path)
+
+    async def _fail(_document, **_kwargs):
+        raise ConnectionError("serving entry unwritable")
+
+    monkeypatch.setattr(cache, "publish_active", _fail)
+    with pytest.raises(ConnectionError):
+        await _ensure(CONNECTIONS, store, cache)
+    monkeypatch.undo()
+
+    assert await cache.read_active() is None
+
+
+@pytest.mark.asyncio
+async def test_the_serving_entry_is_a_complete_self_contained_document(
+    tmp_path, cache, redis_client
+):
+    """The serving entry carries the catalog, not a pointer to it."""
+    store = BundleStorageDelegatedCatalogStore(tmp_path)
+    published = await _ensure(CONNECTIONS, store, cache)
+
+    raw = await redis_client.get(cache.active_key())
+    body = json.loads(raw)
+    assert body["version"] == published.version
+    assert body["content_hash"] == published.content_hash
+    assert body["connections"] == CONNECTIONS
+
+
+# -- missing durable state --------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_missing_durable_state_is_republished_by_the_next_deployment(
+    tmp_path, cache, redis_client
+):
+    """Reconciliation is idempotent from an empty durable root."""
+    store = BundleStorageDelegatedCatalogStore(tmp_path)
+    first = await _ensure(CONNECTIONS, store, cache)
+
+    (store.root / "active.json").unlink()
+    for path in (store.root / "versions").iterdir():
+        path.unlink()
+    await redis_client.delete(cache.active_key(), cache.version_key(first.version))
+
+    restored = await _ensure(CONNECTIONS, store, cache, reason="app_deploy:startup")
+    assert restored.content_hash == first.content_hash
+    assert (await store.read_active()).version == restored.version
+    assert await store.version_exists(restored.version) is True
+    assert (await cache.read_active()).version == restored.version
+
+    again = await _ensure(CONNECTIONS, store, cache, reason="app_deploy:startup")
+    assert again.version == restored.version
+    assert again.created is False
+    assert len(list((store.root / "versions").iterdir())) == 1
+
+
+# -- source changed but not published ---------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_changed_connections_do_not_reach_requests_until_publication(tmp_path, cache):
+    """Requests read the registered catalog, never the current source."""
+    store = BundleStorageDelegatedCatalogStore(tmp_path)
+    first = await _ensure(CONNECTIONS, store, cache)
+    resolver = DelegatedCatalogResolver(cache=cache, store=store)
+
+    changed = _changed(["mem:read", "mem:write"])
+    active = await resolver.resolve_active()
+    assert active.version == first.version
+    assert active.connections == CONNECTIONS
+    assert active.connections != changed
+
+    second = await _ensure(changed, store, cache, reason="app_deploy:props_changed")
+    assert (await resolver.resolve_active()).version == second.version
+
+
+# -- damaged projections ----------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_corrupt_serving_entry_is_repaired_from_durable_state(
+    tmp_path, cache, redis_client
+):
+    """A damaged projection is repaired, not served and not fatal."""
+    store = BundleStorageDelegatedCatalogStore(tmp_path)
+    published = await _ensure(CONNECTIONS, store, cache)
+
+    await redis_client.set(cache.active_key(), "{not json")
+    resolver = DelegatedCatalogResolver(cache=cache, store=store)
+
+    resolved = await resolver.resolve_active()
+    assert resolved.version == published.version
+    assert resolved.connections == CONNECTIONS
+    assert (await cache.read_active()).version == published.version
+
+
+@pytest.mark.asyncio
+async def test_an_unreadable_durable_active_is_refused_without_stale_fallback(
+    tmp_path, cache, redis_client
+):
+    """Damage on both tiers denies; the corrupt entry is never authority."""
+    store = BundleStorageDelegatedCatalogStore(tmp_path)
+    await _ensure(CONNECTIONS, store, cache)
+
+    await redis_client.set(cache.active_key(), "{not json")
+    (store.root / "active.json").write_text("{not json either", encoding="utf-8")
+
+    resolver = DelegatedCatalogResolver(cache=cache, store=store)
+    with pytest.raises(CatalogUnavailable) as exc:
+        await resolver.resolve_active()
+    assert exc.value.reason == "durable_active_unreadable"
+
+
+# -- residency --------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_an_ordinary_active_read_does_not_extend_residency(
+    tmp_path, cache, redis_client
+):
+    """Only publication and read-through assign a TTL."""
+    store = BundleStorageDelegatedCatalogStore(tmp_path)
+    settings = DelegatedCacheSettings.from_connections(
+        {"delegated_credentials": {"catalog": {"active_cache_seconds": 40}}}
+    )
+    await _ensure(CONNECTIONS, store, cache, settings=settings)
+
+    resolver = DelegatedCatalogResolver(cache=cache, store=store, settings=settings)
+    await redis_client.expire(cache.active_key(), 12)
+    for _ in range(3):
+        await resolver.resolve_active()
+
+    assert await redis_client.ttl(cache.active_key()) <= 12
+
+
+@pytest.mark.asyncio
+async def test_read_through_assigns_the_configured_residency(tmp_path, cache, redis_client):
+    """Repair installs the configured lifetime, not the remainder."""
+    store = BundleStorageDelegatedCatalogStore(tmp_path)
+    settings = DelegatedCacheSettings.from_connections(
+        {"delegated_credentials": {"catalog": {"active_cache_seconds": 40}}}
+    )
+    published = await _ensure(CONNECTIONS, store, cache, settings=settings)
+
+    await redis_client.delete(cache.active_key())
+    resolver = DelegatedCatalogResolver(cache=cache, store=store, settings=settings)
+    assert (await resolver.resolve_active()).version == published.version
+
+    ttl = await redis_client.ttl(cache.active_key())
+    assert 30 < ttl <= 40
+    assert len(list((store.root / "versions").iterdir())) == 1
+
+
+@pytest.mark.asyncio
+async def test_unavailable_resolution_leaves_durable_catalog_storage_untouched(
+    tmp_path, cache, monkeypatch
+):
+    """A refused read is not a repair attempt: history is append-only here."""
+    store = BundleStorageDelegatedCatalogStore(tmp_path)
+    await _ensure(CONNECTIONS, store, cache)
+
+    def _digest() -> dict[str, str]:
+        out: dict[str, str] = {}
+        for path in sorted(store.root.rglob("*")):
+            if path.is_file():
+                out[str(path.relative_to(store.root))] = hashlib.sha256(
+                    path.read_bytes()
+                ).hexdigest()
+        return out
+
+    before = _digest()
+
+    async def _unreachable():
+        raise ConnectionError("redis is gone")
+
+    monkeypatch.setattr(cache, "read_active", _unreachable)
+    resolver = DelegatedCatalogResolver(cache=cache, store=store)
+    with pytest.raises(CatalogUnavailable) as exc:
+        await resolver.resolve_active()
+    assert exc.value.reason == "cache_unavailable"
+
+    assert _digest() == before

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/tests/test_catalog_publisher.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/tests/test_catalog_publisher.py
@@ -1,0 +1,178 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Elena Viter
+
+"""Catalog publication under the shared critical section, against real Redis."""
+
+from __future__ import annotations
+
+import asyncio
+import copy
+import os
+import uuid
+
+import pytest
+
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.catalog.publisher import (
+    CatalogPublicationError,
+    ensure_delegated_catalog,
+)
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.catalog.resolver import (
+    DelegatedCatalogResolver,
+)
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.catalog.runtime_cache import (
+    DelegatedCatalogRuntimeCache,
+)
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.catalog.store import (
+    BundleStorageDelegatedCatalogStore,
+)
+
+CONNECTIONS = {
+    "delegated_credentials": {
+        "oauth": {
+            "enabled": True,
+            "resources": [
+                {"resource": "https://ex/mcp", "grants": ["named_services:use", "slack:read"]}
+            ],
+        }
+    }
+}
+
+
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("REDIS_URL"),
+    reason="REDIS_URL is not set; catalog publication tests are skipped",
+)
+
+
+@pytest.fixture
+async def redis_client():
+    import redis.asyncio as redis_asyncio
+
+    client = redis_asyncio.from_url(os.environ["REDIS_URL"])
+    try:
+        await client.ping()
+    except Exception as exc:  # pragma: no cover - environment guard
+        pytest.skip(f"Redis at REDIS_URL is unreachable: {exc}")
+    yield client
+    await client.aclose()
+
+
+@pytest.fixture
+def cache(redis_client) -> DelegatedCatalogRuntimeCache:
+    return DelegatedCatalogRuntimeCache(
+        redis_client, tenant=f"t-{uuid.uuid4().hex[:8]}", project=f"p-{uuid.uuid4().hex[:8]}"
+    )
+
+
+async def _ensure(connections, store, cache, **kwargs):
+    return await ensure_delegated_catalog(
+        connections=connections, store=store, cache=cache, **kwargs
+    )
+
+
+@pytest.mark.asyncio
+async def test_first_publication_creates_one_version_and_active(tmp_path, cache):
+    store = BundleStorageDelegatedCatalogStore(tmp_path)
+    result = await _ensure(CONNECTIONS, store, cache, reason="app_deploy:startup")
+
+    assert result.created is True
+    active = await store.read_active()
+    assert active.version == result.version
+    assert active.connections == CONNECTIONS
+    assert await store.version_exists(result.version) is True
+    assert (await cache.read_active()).version == result.version
+
+
+@pytest.mark.asyncio
+async def test_unchanged_connections_do_not_create_a_second_version(tmp_path, cache):
+    store = BundleStorageDelegatedCatalogStore(tmp_path)
+    first = await _ensure(CONNECTIONS, store, cache, reason="app_deploy:startup")
+    second = await _ensure(CONNECTIONS, store, cache, reason="app_deploy:props_changed")
+
+    assert second.version == first.version
+    assert second.created is False
+    versions_dir = store.root / "versions"
+    assert len(list(versions_dir.iterdir())) == 1
+
+
+@pytest.mark.asyncio
+async def test_map_key_reordering_does_not_create_a_version(tmp_path, cache):
+    store = BundleStorageDelegatedCatalogStore(tmp_path)
+    first = await _ensure(CONNECTIONS, store, cache)
+
+    reordered = {
+        "delegated_credentials": {
+            "oauth": {
+                "resources": [
+                    {"grants": ["named_services:use", "slack:read"], "resource": "https://ex/mcp"}
+                ],
+                "enabled": True,
+            }
+        }
+    }
+    second = await _ensure(reordered, store, cache)
+    assert second.version == first.version
+    assert second.created is False
+
+
+@pytest.mark.asyncio
+async def test_a_real_change_creates_a_new_active_version(tmp_path, cache):
+    store = BundleStorageDelegatedCatalogStore(tmp_path)
+    first = await _ensure(CONNECTIONS, store, cache)
+
+    changed = copy.deepcopy(CONNECTIONS)
+    changed["delegated_credentials"]["oauth"]["resources"][0]["grants"] = ["slack:read"]
+    second = await _ensure(changed, store, cache)
+
+    assert second.version != first.version
+    assert second.created is True
+    assert (await store.read_active()).version == second.version
+    # The previous immutable version remains available as a card baseline.
+    assert await store.version_exists(first.version) is True
+
+
+@pytest.mark.asyncio
+async def test_concurrent_publishers_converge_on_one_version(tmp_path, cache):
+    store = BundleStorageDelegatedCatalogStore(tmp_path)
+    results = await asyncio.gather(
+        *(_ensure(CONNECTIONS, store, cache, reason=f"worker-{index}") for index in range(5))
+    )
+
+    versions = {result.version for result in results}
+    assert len(versions) == 1
+    assert len(list((store.root / "versions").iterdir())) == 1
+
+
+@pytest.mark.asyncio
+async def test_restart_restores_redis_without_creating_a_version(tmp_path, cache, redis_client):
+    store = BundleStorageDelegatedCatalogStore(tmp_path)
+    first = await _ensure(CONNECTIONS, store, cache)
+
+    await redis_client.delete(cache.active_key())
+    await redis_client.delete(cache.version_key(first.version))
+
+    second = await _ensure(CONNECTIONS, store, cache, reason="app_deploy:startup")
+    assert second.version == first.version
+    assert second.created is False
+    assert (await cache.read_active()).version == first.version
+    assert len(list((store.root / "versions").iterdir())) == 1
+
+
+@pytest.mark.asyncio
+async def test_unhashable_connections_are_a_publication_error(tmp_path, cache):
+    store = BundleStorageDelegatedCatalogStore(tmp_path)
+    with pytest.raises(CatalogPublicationError) as exc:
+        await _ensure({"resources": {object()}}, store, cache)
+    assert exc.value.reason == "connections_not_hashable"
+    assert await store.read_active() is None
+
+
+@pytest.mark.asyncio
+async def test_published_catalog_is_resolvable_for_request_serving(tmp_path, cache):
+    store = BundleStorageDelegatedCatalogStore(tmp_path)
+    published = await _ensure(CONNECTIONS, store, cache)
+
+    resolver = DelegatedCatalogResolver(cache=cache, store=store)
+    active = await resolver.resolve_active()
+    assert active.version == published.version
+    assert (await resolver.resolve_version(published.version)).connections == CONNECTIONS

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/tests/test_catalog_reconcile.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/tests/test_catalog_reconcile.py
@@ -1,0 +1,179 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Elena Viter
+
+"""Save prunes what the catalog no longer offers, and adds nothing."""
+
+import copy
+
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.catalog.models import (
+    CatalogDocument,
+)
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.catalog.reconcile import (
+    reconcile_selection,
+)
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.cards.model import (
+    NamedServiceSelection,
+)
+
+RESOURCE = "https://example.test/mcp/named-services"
+OTHER = "https://example.test/mcp/records"
+
+CONNECTIONS = {
+    "delegated_credentials": {
+        "oauth": {
+            "enabled": True,
+            "resources": [
+                {
+                    "resource": RESOURCE,
+                    "grants": ["named_services:use", "mail:read"],
+                    "tools": {"named_services_search": {"grants": ["named_services:use"]}},
+                    "named_services": {
+                        "namespaces": {
+                            "mail": {
+                                "tools": {
+                                    "search": {"operation": "object.search", "grants": ["mail:read"]},
+                                    "schema": {"operation": "object.schema", "grants": ["mail:read"]},
+                                },
+                            },
+                        },
+                    },
+                },
+            ],
+        },
+    },
+}
+
+
+def _document(connections=None) -> CatalogDocument:
+    return CatalogDocument.build(connections if connections is not None else CONNECTIONS)
+
+
+def _without(*, claim: str = "", operation_tool: str = "") -> dict:
+    trimmed = copy.deepcopy(CONNECTIONS)
+    resource = trimmed["delegated_credentials"]["oauth"]["resources"][0]
+    if claim:
+        resource["grants"] = [g for g in resource["grants"] if g != claim]
+    if operation_tool:
+        resource["named_services"]["namespaces"]["mail"]["tools"].pop(operation_tool)
+    return trimmed
+
+
+def _reconcile(grants, selection, connections=None):
+    return reconcile_selection(
+        resource_grants=grants,
+        named_service_operations=selection,
+        active=_document(connections),
+    )
+
+
+def test_a_selection_the_catalog_still_offers_survives_untouched():
+    result = _reconcile(
+        {RESOURCE: ["named_services:use", "mail:read"]},
+        NamedServiceSelection.exact({RESOURCE: {"mail": ["object.search"]}}),
+    )
+
+    assert result.anything_pruned is False
+    assert result.resource_grants == {RESOURCE: ["named_services:use", "mail:read"]}
+    assert result.named_service_operations.operations == {
+        RESOURCE: {"mail": ("object.search",)}
+    }
+
+
+def test_a_resource_the_catalog_dropped_is_pruned_with_everything_under_it():
+    result = _reconcile(
+        {RESOURCE: ["named_services:use"], OTHER: ["records:read"]},
+        NamedServiceSelection.exact({OTHER: {"mail": ["object.search"]}}),
+    )
+
+    assert result.pruned_resources == [OTHER]
+    assert OTHER not in result.resource_grants
+    assert result.pruned_named_service_operations == [
+        {"resource": OTHER, "namespace": "mail", "operation": "object.search"}
+    ]
+
+
+def test_a_claim_the_catalog_dropped_is_pruned_and_named():
+    result = _reconcile(
+        {RESOURCE: ["named_services:use", "mail:read"]},
+        NamedServiceSelection.none(),
+        connections=_without(claim="mail:read"),
+    )
+
+    assert result.pruned_claims == [{"resource": RESOURCE, "claim": "mail:read"}]
+    assert result.resource_grants == {RESOURCE: ["named_services:use"]}
+
+
+def test_an_operation_the_catalog_dropped_is_pruned_and_its_siblings_stay():
+    result = _reconcile(
+        {RESOURCE: ["named_services:use", "mail:read"]},
+        NamedServiceSelection.exact({RESOURCE: {"mail": ["object.search", "object.schema"]}}),
+        connections=_without(operation_tool="schema"),
+    )
+
+    assert result.pruned_named_service_operations == [
+        {"resource": RESOURCE, "namespace": "mail", "operation": "object.schema"}
+    ]
+    assert result.named_service_operations.operations == {
+        RESOURCE: {"mail": ("object.search",)}
+    }
+
+
+def test_a_wildcard_is_kept_as_a_wildcard():
+    """"*" means everything shown by the catalog this save acknowledges."""
+    result = _reconcile(
+        {RESOURCE: ["named_services:use"]},
+        NamedServiceSelection.all(),
+        connections=_without(operation_tool="schema"),
+    )
+
+    assert result.named_service_operations.is_all
+    assert result.pruned_named_service_operations == []
+
+
+def test_an_explicit_empty_selection_stays_empty():
+    result = _reconcile({RESOURCE: ["named_services:use"]}, NamedServiceSelection.none())
+
+    assert result.named_service_operations.is_none
+    assert result.anything_pruned is False
+
+
+def test_pruning_never_adds_what_the_catalog_gained():
+    widened = copy.deepcopy(CONNECTIONS)
+    namespaces = widened["delegated_credentials"]["oauth"]["resources"][0]["named_services"]["namespaces"]
+    namespaces["mail"]["tools"]["comments"] = {
+        "operation": "object.comments",
+        "grants": ["mail:read"],
+    }
+
+    result = _reconcile(
+        {RESOURCE: ["named_services:use"]},
+        NamedServiceSelection.exact({RESOURCE: {"mail": ["object.search"]}}),
+        connections=widened,
+    )
+
+    assert result.named_service_operations.operations == {
+        RESOURCE: {"mail": ("object.search",)}
+    }
+
+
+def test_a_resource_that_enumerates_no_claims_carries_no_ceiling():
+    without_grants = copy.deepcopy(CONNECTIONS)
+    resource = without_grants["delegated_credentials"]["oauth"]["resources"][0]
+    resource.pop("grants")
+    resource.pop("tools")
+    resource.pop("named_services")
+
+    result = _reconcile({RESOURCE: ["anything:at:all"]}, NamedServiceSelection.none(), without_grants)
+
+    assert result.pruned_claims == []
+    assert result.resource_grants == {RESOURCE: ["anything:at:all"]}
+
+
+def test_pruning_everything_leaves_a_card_with_no_authority():
+    result = _reconcile(
+        {RESOURCE: ["mail:read"]},
+        NamedServiceSelection.none(),
+        connections=_without(claim="mail:read"),
+    )
+
+    assert result.empty is True

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/tests/test_catalog_reconcile.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/tests/test_catalog_reconcile.py
@@ -177,3 +177,58 @@ def test_pruning_everything_leaves_a_card_with_no_authority():
     )
 
     assert result.empty is True
+
+
+# -- the administrator all-resource row is not a survival ticket ----------------
+
+
+def test_a_withdrawn_resource_is_pruned_even_beside_a_wildcard_row():
+    """Save must prune a door the deployment withdrew.
+
+    With the admin `*` row present, a resolution keyed on the raw string would
+    find it and the selection would survive every save, so the card could never
+    be brought back in line with the catalog.
+    """
+    catalog = copy.deepcopy(CONNECTIONS)
+    catalog["delegated_credentials"]["oauth"]["resources"] = [
+        {
+            "resource": "*",
+            "admin_only": True,
+            "grants": ["kdcube:role:super-admin"],
+        }
+    ]
+
+    result = _reconcile(
+        {RESOURCE: ["named_services:use", "mail:read"]},
+        NamedServiceSelection.exact({RESOURCE: {"mail": ["object.search"]}}),
+        connections=catalog,
+    )
+
+    assert result.pruned_resources == [RESOURCE]
+    assert result.resource_grants == {}
+    assert result.empty is True
+    assert [row["operation"] for row in result.pruned_named_service_operations] == [
+        "object.search"
+    ]
+
+
+def test_an_administrator_selection_survives_against_the_wildcard_row():
+    """A card that holds `*` keeps it: the row is its row."""
+    catalog = copy.deepcopy(CONNECTIONS)
+    catalog["delegated_credentials"]["oauth"]["resources"].append(
+        {
+            "resource": "*",
+            "admin_only": True,
+            "grants": ["kdcube:role:super-admin"],
+        }
+    )
+
+    result = _reconcile(
+        {"*": ["kdcube:role:super-admin"]},
+        NamedServiceSelection.none(),
+        connections=catalog,
+    )
+
+    assert result.pruned_resources == []
+    assert result.resource_grants == {"*": ["kdcube:role:super-admin"]}
+    assert result.empty is False

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/tests/test_consent_denial.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/tests/test_consent_denial.py
@@ -97,6 +97,34 @@ def test_manual_automation_is_not_sent_to_the_pending_pane():
     assert "pending_agent_grant" not in str(denial)
 
 
+def test_the_demand_names_the_inner_operation_it_wants():
+    """Claims cannot express which operation was refused.
+
+    A card may hold every claim the operation declares and still not cover it,
+    so a claims-only demand asks for consent that is already given. Approval
+    grants the exact operation, which means the demand has to carry it.
+    """
+    denial = _denial("kdcube-agent:app:main")
+    consent = denial["consent"]
+
+    assert consent["namespace"] == "slack"
+    assert consent["operation"] == "object.search"
+    assert consent["grant"]["payload"]["named_service_operations"] == {
+        "slack": ["object.search"],
+    }
+    url = consent["connection_hub_url"]
+    assert "namespace=slack" in url
+    assert "operation=object.search" in url
+
+
+def test_a_demand_without_an_operation_keeps_the_claims_only_link():
+    url = connection_hub_grant_url(
+        tenant="t", project="p", client_id="claude", resource=RESOURCE, claims=["mail:read"],
+    )
+    assert "namespace=" not in url
+    assert "operation=" not in url
+
+
 def test_the_per_account_binding_link_also_skips_the_pending_pane():
     """The binding denial builds its own URL, so the rule lives in the builder.
 

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/tests/test_delegated_cache_transitions.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/tests/test_delegated_cache_transitions.py
@@ -320,7 +320,7 @@ async def test_restore_installs_over_a_strictly_older_projection(card_cache):
     assert (await card_cache.read(ACCESS_ID)).card_revision == 8
 
 
-# -- per-grantor index (#222) -------------------------------------------------
+# -- per-grantor index --------------------------------------------------------
 
 
 @pytest.mark.asyncio

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/tests/test_delegated_cache_transitions.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/tests/test_delegated_cache_transitions.py
@@ -1,0 +1,421 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Elena Viter
+
+"""Catalog/card cache transitions against a real Redis.
+
+The compare-and-transition rules cannot be proved against a fake: they depend
+on Redis executing the Lua body atomically. Set ``REDIS_URL`` to run them.
+"""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.cache_settings import (
+    DelegatedCacheSettings,
+)
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.cards.cache import (
+    DelegatedCardRuntimeCache,
+)
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.cards.model import (
+    CARD_STATE_ACTIVE,
+    CARD_STATE_REVOKED,
+    CardAuthority,
+    NamedServiceSelection,
+)
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.cards.resolver import (
+    CardUnavailable,
+    DelegatedCardResolver,
+)
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.cards.store import (
+    BundleStorageDelegatedCardStore,
+)
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.catalog.models import (
+    CatalogDocument,
+)
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.catalog.resolver import (
+    CatalogUnavailable,
+    DelegatedCatalogResolver,
+)
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.catalog.runtime_cache import (
+    DelegatedCatalogRuntimeCache,
+)
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.catalog.store import (
+    BundleStorageDelegatedCatalogStore,
+)
+
+CONNECTIONS = {"delegated_credentials": {"oauth": {"enabled": True}}}
+SUBJECT_HASH = hashlib.sha256(b"platform-user-1").hexdigest()
+ACCESS_ID = "aut_abc123"
+
+
+def _redis_url() -> str:
+    return os.environ.get("REDIS_URL") or ""
+
+
+pytestmark = pytest.mark.skipif(
+    not _redis_url(), reason="REDIS_URL is not set; real-Redis cache transitions are skipped"
+)
+
+
+@pytest.fixture
+async def redis_client():
+    import redis.asyncio as redis_asyncio
+
+    client = redis_asyncio.from_url(_redis_url())
+    try:
+        await client.ping()
+    except Exception as exc:  # pragma: no cover - environment guard
+        pytest.skip(f"Redis at REDIS_URL is unreachable: {exc}")
+    yield client
+    await client.aclose()
+
+
+@pytest.fixture
+def namespace() -> tuple[str, str]:
+    return f"t-{uuid.uuid4().hex[:8]}", f"p-{uuid.uuid4().hex[:8]}"
+
+
+@pytest.fixture
+def catalog_cache(redis_client, namespace) -> DelegatedCatalogRuntimeCache:
+    tenant, project = namespace
+    return DelegatedCatalogRuntimeCache(redis_client, tenant=tenant, project=project)
+
+
+@pytest.fixture
+def card_cache(redis_client, namespace) -> DelegatedCardRuntimeCache:
+    tenant, project = namespace
+    return DelegatedCardRuntimeCache(redis_client, tenant=tenant, project=project)
+
+
+def _document(*, minute: int, enabled: bool = True) -> CatalogDocument:
+    body = copy.deepcopy(CONNECTIONS)
+    body["delegated_credentials"]["oauth"]["enabled"] = enabled
+    return CatalogDocument.build(
+        body, created_at=datetime(2026, 8, 11, 10, minute, 0, tzinfo=timezone.utc)
+    )
+
+
+def _authority(*, revision: int = 1, expires_at: int = 1_780_003_600, state: str = CARD_STATE_ACTIVE) -> CardAuthority:
+    return CardAuthority(
+        access_id=ACCESS_ID,
+        client_id="automation:abc",
+        grantor_subject="platform-user-1",
+        delegate_subject="integration:automation:abc",
+        source="manual",
+        card_revision=revision,
+        state=state,
+        resource_grants={"https://ex/mcp": ("slack:read",)},
+        named_service_operations=NamedServiceSelection.none(),
+        created_at=1_780_000_000,
+        expires_at=expires_at,
+    )
+
+
+class _RaisingCatalogStore:
+    """Durable double that fails the test if a hot path reads through."""
+
+    async def read_active(self):
+        raise AssertionError("governed read must not touch durable storage on a cache hit")
+
+    async def read_version(self, version):
+        raise AssertionError("governed read must not touch durable storage on a cache hit")
+
+
+# -- catalog cache transitions ------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_publish_then_read_active(catalog_cache):
+    document = _document(minute=30)
+    assert await catalog_cache.publish_active(document, ttl_seconds=300) is True
+    assert await catalog_cache.read_active() == document
+
+
+@pytest.mark.asyncio
+async def test_delayed_restore_cannot_downgrade_a_newer_published_catalog(catalog_cache):
+    older = _document(minute=30, enabled=True)
+    newer = _document(minute=45, enabled=False)
+
+    await catalog_cache.publish_active(newer, ttl_seconds=300)
+    assert await catalog_cache.restore_active(older, ttl_seconds=300) is False
+
+    active = await catalog_cache.read_active()
+    assert active.version == newer.version
+
+
+@pytest.mark.asyncio
+async def test_restore_installs_when_the_key_is_absent(catalog_cache):
+    document = _document(minute=30)
+    assert await catalog_cache.restore_active(document, ttl_seconds=300) is True
+    assert (await catalog_cache.read_active()).version == document.version
+
+
+@pytest.mark.asyncio
+async def test_restore_does_not_slide_an_equal_live_version(catalog_cache, redis_client):
+    document = _document(minute=30)
+    await catalog_cache.publish_active(document, ttl_seconds=300)
+    await redis_client.expire(catalog_cache.active_key(), 60)
+
+    assert await catalog_cache.restore_active(document, ttl_seconds=300) is False
+    assert await redis_client.ttl(catalog_cache.active_key()) <= 60
+
+
+@pytest.mark.asyncio
+async def test_publication_reinstalls_an_equal_version_with_fresh_residency(
+    catalog_cache, redis_client
+):
+    document = _document(minute=30)
+    await catalog_cache.publish_active(document, ttl_seconds=300)
+    await redis_client.expire(catalog_cache.active_key(), 60)
+
+    assert await catalog_cache.publish_active(document, ttl_seconds=300) is True
+    assert await redis_client.ttl(catalog_cache.active_key()) > 60
+
+
+@pytest.mark.asyncio
+async def test_corrupt_cached_active_reads_as_a_miss(catalog_cache, redis_client):
+    await redis_client.set(catalog_cache.active_key(), "{not json")
+    assert await catalog_cache.read_active() is None
+
+
+@pytest.mark.asyncio
+async def test_historical_versions_coexist_under_separate_keys(catalog_cache):
+    first = _document(minute=30, enabled=True)
+    second = _document(minute=45, enabled=False)
+    await catalog_cache.cache_version(first, ttl_seconds=3600)
+    await catalog_cache.cache_version(second, ttl_seconds=3600)
+
+    assert (await catalog_cache.read_version(first.version)).version == first.version
+    assert (await catalog_cache.read_version(second.version)).version == second.version
+
+
+# -- catalog resolver ---------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_warm_active_cache_serves_without_any_durable_read(catalog_cache):
+    document = _document(minute=30)
+    await catalog_cache.publish_active(document, ttl_seconds=300)
+    resolver = DelegatedCatalogResolver(cache=catalog_cache, store=_RaisingCatalogStore())
+
+    assert (await resolver.resolve_active()).version == document.version
+
+
+@pytest.mark.asyncio
+async def test_active_miss_reads_through_and_repopulates(catalog_cache, tmp_path):
+    document = _document(minute=30)
+    store = BundleStorageDelegatedCatalogStore(tmp_path)
+    await store.write_version(document)
+    await store.publish_active(document)
+
+    resolver = DelegatedCatalogResolver(
+        cache=catalog_cache, store=store, settings=DelegatedCacheSettings()
+    )
+    assert (await resolver.resolve_active()).version == document.version
+    assert (await catalog_cache.read_active()).version == document.version
+
+
+@pytest.mark.asyncio
+async def test_unregistered_active_catalog_is_unavailable(catalog_cache, tmp_path):
+    resolver = DelegatedCatalogResolver(
+        cache=catalog_cache, store=BundleStorageDelegatedCatalogStore(tmp_path)
+    )
+    with pytest.raises(CatalogUnavailable) as exc:
+        await resolver.resolve_active()
+    assert exc.value.reason == "active_catalog_not_registered"
+
+
+@pytest.mark.asyncio
+async def test_confirmed_absent_baseline_is_not_unavailable(catalog_cache, tmp_path):
+    resolver = DelegatedCatalogResolver(
+        cache=catalog_cache, store=BundleStorageDelegatedCatalogStore(tmp_path)
+    )
+    absent = _document(minute=30).version
+    assert await resolver.resolve_version(absent) is None
+    assert await resolver.resolve_version("not-a-version") is None
+
+
+# -- card cache transitions ---------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_marker_makes_the_card_fail_closed(card_cache):
+    await card_cache.restore_projection(_authority(revision=7), ttl_seconds=300)
+    assert await card_cache.claim_transition(
+        ACCESS_ID, mutation_id="m1", expected_revision=7, ttl_seconds=15
+    ) is True
+
+    entry = await card_cache.read(ACCESS_ID)
+    assert entry.is_updating and entry.mutation_id == "m1"
+
+
+@pytest.mark.asyncio
+async def test_a_second_mutation_cannot_claim_a_held_card(card_cache):
+    await card_cache.restore_projection(_authority(revision=7), ttl_seconds=300)
+    await card_cache.claim_transition(
+        ACCESS_ID, mutation_id="m1", expected_revision=7, ttl_seconds=15
+    )
+    assert await card_cache.claim_transition(
+        ACCESS_ID, mutation_id="m2", expected_revision=7, ttl_seconds=15
+    ) is False
+
+
+@pytest.mark.asyncio
+async def test_claim_is_refused_when_the_live_revision_moved(card_cache):
+    await card_cache.restore_projection(_authority(revision=8), ttl_seconds=300)
+    assert await card_cache.claim_transition(
+        ACCESS_ID, mutation_id="m1", expected_revision=7, ttl_seconds=15
+    ) is False
+
+
+@pytest.mark.asyncio
+async def test_delayed_restore_cannot_overwrite_a_newer_revision(card_cache):
+    await card_cache.restore_projection(_authority(revision=8), ttl_seconds=300)
+    assert await card_cache.restore_projection(_authority(revision=7), ttl_seconds=300) is False
+    assert (await card_cache.read(ACCESS_ID)).card_revision == 8
+
+
+@pytest.mark.asyncio
+async def test_delayed_restore_displaces_neither_marker_nor_tombstone(card_cache):
+    await card_cache.claim_transition(
+        ACCESS_ID, mutation_id="m1", expected_revision=0, ttl_seconds=15
+    )
+    assert await card_cache.restore_projection(_authority(revision=7), ttl_seconds=300) is False
+    assert (await card_cache.read(ACCESS_ID)).is_updating
+
+    await card_cache.commit_tombstone(
+        ACCESS_ID, card_revision=8, mutation_id="m1", ttl_seconds=60
+    )
+    assert await card_cache.restore_projection(_authority(revision=7), ttl_seconds=300) is False
+    assert (await card_cache.read(ACCESS_ID)).is_revoked
+
+
+@pytest.mark.asyncio
+async def test_only_the_owning_mutation_finalizes_its_marker(card_cache):
+    await card_cache.claim_transition(
+        ACCESS_ID, mutation_id="m1", expected_revision=0, ttl_seconds=15
+    )
+    assert await card_cache.commit_projection(
+        _authority(revision=1), mutation_id="intruder", ttl_seconds=300
+    ) is False
+    assert (await card_cache.read(ACCESS_ID)).is_updating
+
+    assert await card_cache.commit_projection(
+        _authority(revision=1), mutation_id="m1", ttl_seconds=300
+    ) is True
+    assert (await card_cache.read(ACCESS_ID)).card_revision == 1
+
+
+@pytest.mark.asyncio
+async def test_restore_installs_over_a_strictly_older_projection(card_cache):
+    await card_cache.restore_projection(_authority(revision=7), ttl_seconds=300)
+    assert await card_cache.restore_projection(_authority(revision=8), ttl_seconds=300) is True
+    assert (await card_cache.read(ACCESS_ID)).card_revision == 8
+
+
+# -- per-grantor index (#222) -------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_one_cards_expiry_does_not_hide_another(card_cache):
+    now = 1_780_000_000
+    await card_cache.index_add(subject_hash=SUBJECT_HASH, access_id="aut_short", expires_at=now + 10)
+    await card_cache.index_add(
+        subject_hash=SUBJECT_HASH, access_id="oauth-longlived", expires_at=now + 180 * 24 * 3600
+    )
+
+    later = now + 8 * 24 * 3600
+    members = await card_cache.index_members(subject_hash=SUBJECT_HASH, now=later)
+    assert members == ["oauth-longlived"]
+
+
+# -- card resolver ------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_resolver_fails_closed_while_a_mutation_owns_the_card(card_cache, tmp_path):
+    resolver = DelegatedCardResolver(
+        cache=card_cache, store=BundleStorageDelegatedCardStore(tmp_path)
+    )
+    await card_cache.claim_transition(
+        ACCESS_ID, mutation_id="m1", expected_revision=0, ttl_seconds=15
+    )
+    with pytest.raises(CardUnavailable) as exc:
+        await resolver.resolve(subject_hash=SUBJECT_HASH, access_id=ACCESS_ID)
+    assert exc.value.reason == "card_updating"
+
+
+@pytest.mark.asyncio
+async def test_resolver_denies_a_tombstoned_card_without_durable_read(card_cache, tmp_path):
+    resolver = DelegatedCardResolver(
+        cache=card_cache, store=BundleStorageDelegatedCardStore(tmp_path)
+    )
+    await card_cache.claim_transition(
+        ACCESS_ID, mutation_id="m1", expected_revision=0, ttl_seconds=15
+    )
+    await card_cache.commit_tombstone(
+        ACCESS_ID, card_revision=2, mutation_id="m1", ttl_seconds=60
+    )
+    assert await resolver.resolve(subject_hash=SUBJECT_HASH, access_id=ACCESS_ID) is None
+
+
+@pytest.mark.asyncio
+async def test_evicted_projection_is_restored_from_durable_state(card_cache, tmp_path):
+    store = BundleStorageDelegatedCardStore(tmp_path)
+    now = 1_780_000_000
+    authority = _authority(revision=3, expires_at=now + 3600)
+    pointer = await store.write_revision(
+        subject_hash=SUBJECT_HASH, authority=authority, updated_at=datetime.now(timezone.utc)
+    )
+    await store.advance_current(subject_hash=SUBJECT_HASH, pointer=pointer)
+
+    resolver = DelegatedCardResolver(cache=card_cache, store=store)
+    resolved = await resolver.resolve(
+        subject_hash=SUBJECT_HASH, access_id=ACCESS_ID, now=now
+    )
+    assert resolved == authority
+    assert (await card_cache.read(ACCESS_ID)).card_revision == 3
+
+
+@pytest.mark.asyncio
+async def test_expired_and_revoked_durable_state_is_denied_and_not_recached(card_cache, tmp_path):
+    store = BundleStorageDelegatedCardStore(tmp_path)
+    now = 1_780_000_000
+    resolver = DelegatedCardResolver(cache=card_cache, store=store)
+
+    for authority in (
+        _authority(revision=3, expires_at=now - 1),
+        _authority(revision=4, expires_at=now + 3600, state=CARD_STATE_REVOKED),
+    ):
+        pointer = await store.write_revision(
+            subject_hash=SUBJECT_HASH, authority=authority, updated_at=datetime.now(timezone.utc)
+        )
+        await store.advance_current(subject_hash=SUBJECT_HASH, pointer=pointer)
+        assert await resolver.resolve(
+            subject_hash=SUBJECT_HASH, access_id=ACCESS_ID, now=now
+        ) is None
+        assert await card_cache.read(ACCESS_ID) is None
+
+
+@pytest.mark.asyncio
+async def test_list_rebuilds_an_evicted_index_from_durable_records(card_cache, tmp_path):
+    store = BundleStorageDelegatedCardStore(tmp_path)
+    now = 1_780_000_000
+    live = _authority(revision=1, expires_at=now + 180 * 24 * 3600)
+    pointer = await store.write_revision(
+        subject_hash=SUBJECT_HASH, authority=live, updated_at=datetime.now(timezone.utc)
+    )
+    await store.advance_current(subject_hash=SUBJECT_HASH, pointer=pointer)
+
+    resolver = DelegatedCardResolver(cache=card_cache, store=store)
+    listed = await resolver.list_active(subject_hash=SUBJECT_HASH, now=now)
+
+    assert [item.access_id for item in listed] == [ACCESS_ID]
+    assert await card_cache.index_members(subject_hash=SUBJECT_HASH, now=now) == [ACCESS_ID]

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/tests/test_durable_io_off_loop.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/tests/test_durable_io_off_loop.py
@@ -1,0 +1,194 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Elena Viter
+
+"""Durable storage work must not run on the proc event loop.
+
+Delegated catalog and card storage sit on a shared mount, where a single read
+can take far longer than a local one. If any of that work ran inline, one slow
+mount would stall every other request the process is serving.
+
+The probe makes the synchronous primitives deliberately slow and measures how
+long the loop is ever unable to run a timer. Dispatched work leaves the loop
+responsive; inline work does not.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import os
+import time
+import uuid
+
+import pytest
+
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials import durable_io
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.cards.cache import (
+    DelegatedCardRuntimeCache,
+)
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.cards.model import (
+    CARD_STATE_ACTIVE,
+    CardAuthority,
+    NamedServiceSelection,
+)
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.cards.service import (
+    DelegatedCardService,
+)
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.cards.store import (
+    BundleStorageDelegatedCardStore,
+)
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.catalog.publisher import (
+    ensure_delegated_catalog,
+)
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.catalog.runtime_cache import (
+    DelegatedCatalogRuntimeCache,
+)
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.catalog.store import (
+    BundleStorageDelegatedCatalogStore,
+)
+
+CONNECTIONS = {"delegated_credentials": {"oauth": {"enabled": True, "resources": []}}}
+SUBJECT_HASH = hashlib.sha256(b"platform-user-1").hexdigest()
+NOW = 1_780_000_000
+
+SLOW_CALL_SECONDS = 0.12
+WATCHDOG_INTERVAL = 0.01
+# Generous: a dispatched call costs a thread handoff, never the call itself.
+MAX_TOLERATED_STALL = SLOW_CALL_SECONDS / 2
+
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("REDIS_URL"),
+    reason="REDIS_URL is not set; durable storage probes are skipped",
+)
+
+
+@pytest.fixture
+async def redis_client():
+    import redis.asyncio as redis_asyncio
+
+    client = redis_asyncio.from_url(os.environ["REDIS_URL"])
+    try:
+        await client.ping()
+    except Exception as exc:  # pragma: no cover - environment guard
+        pytest.skip(f"Redis at REDIS_URL is unreachable: {exc}")
+    yield client
+    await client.aclose()
+
+
+@pytest.fixture
+def scope() -> tuple[str, str]:
+    return f"t-{uuid.uuid4().hex[:8]}", f"p-{uuid.uuid4().hex[:8]}"
+
+
+@pytest.fixture
+def slow_storage(monkeypatch):
+    """Every synchronous filesystem primitive takes a visible amount of time."""
+    read = durable_io._read_text
+    write = durable_io._write_text_atomic
+    children = durable_io._list_children
+
+    def _slow_read(path):
+        time.sleep(SLOW_CALL_SECONDS)
+        return read(path)
+
+    def _slow_write(path, text):
+        time.sleep(SLOW_CALL_SECONDS)
+        return write(path, text)
+
+    def _slow_children(path):
+        time.sleep(SLOW_CALL_SECONDS)
+        return children(path)
+
+    monkeypatch.setattr(durable_io, "_read_text", _slow_read)
+    monkeypatch.setattr(durable_io, "_write_text_atomic", _slow_write)
+    monkeypatch.setattr(durable_io, "_list_children", _slow_children)
+
+
+class _LoopProbe:
+    """The longest interval in which the loop could not run a timer."""
+
+    def __init__(self) -> None:
+        self._stop = asyncio.Event()
+        self._task: asyncio.Task | None = None
+        self.worst = 0.0
+
+    async def __aenter__(self) -> "_LoopProbe":
+        self._task = asyncio.create_task(self._run())
+        await asyncio.sleep(WATCHDOG_INTERVAL * 2)
+        self.worst = 0.0
+        return self
+
+    async def __aexit__(self, *_exc) -> None:
+        self._stop.set()
+        if self._task is not None:
+            await self._task
+
+    async def _run(self) -> None:
+        last = time.perf_counter()
+        while not self._stop.is_set():
+            await asyncio.sleep(WATCHDOG_INTERVAL)
+            now = time.perf_counter()
+            self.worst = max(self.worst, now - last - WATCHDOG_INTERVAL)
+            last = now
+
+
+def _authority(access_id: str) -> CardAuthority:
+    return CardAuthority(
+        access_id=access_id,
+        client_id="automation:abc",
+        grantor_subject="platform-user-1",
+        delegate_subject="integration:automation:abc",
+        source="manual",
+        card_revision=1,
+        state=CARD_STATE_ACTIVE,
+        resource_grants={"https://ex/mcp": ("slack:read",)},
+        named_service_operations=NamedServiceSelection.none(),
+        created_at=NOW,
+        expires_at=NOW + 3600,
+    )
+
+
+@pytest.mark.asyncio
+async def test_catalog_publication_keeps_the_loop_responsive(
+    tmp_path, redis_client, scope, slow_storage
+):
+    tenant, project = scope
+    cache = DelegatedCatalogRuntimeCache(redis_client, tenant=tenant, project=project)
+    store = BundleStorageDelegatedCatalogStore(tmp_path)
+
+    started = time.perf_counter()
+    async with _LoopProbe() as probe:
+        await ensure_delegated_catalog(
+            connections=CONNECTIONS, store=store, cache=cache, reason="probe"
+        )
+    elapsed = time.perf_counter() - started
+
+    assert elapsed > SLOW_CALL_SECONDS, "the slow primitives were not exercised"
+    assert probe.worst < MAX_TOLERATED_STALL, (
+        f"the loop stalled for {probe.worst:.3f}s during publication"
+    )
+
+
+@pytest.mark.asyncio
+async def test_card_commit_keeps_the_loop_responsive(
+    tmp_path, redis_client, scope, slow_storage
+):
+    tenant, project = scope
+    cache = DelegatedCardRuntimeCache(redis_client, tenant=tenant, project=project)
+    store = BundleStorageDelegatedCardStore(tmp_path)
+    service = DelegatedCardService(store=store, cache=cache)
+
+    started = time.perf_counter()
+    async with _LoopProbe() as probe:
+        await service.commit(
+            _authority("aut_probe1"),
+            subject_hash=SUBJECT_HASH,
+            expected_revision=0,
+            now=NOW,
+        )
+    elapsed = time.perf_counter() - started
+
+    assert elapsed > SLOW_CALL_SECONDS, "the slow primitives were not exercised"
+    assert probe.worst < MAX_TOLERATED_STALL, (
+        f"the loop stalled for {probe.worst:.3f}s during a card commit"
+    )

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/tests/test_live_grant.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/tests/test_live_grant.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2026 Elena Viter
 
+"""Live card resolution on the guard path, which has no durable source."""
+
 from __future__ import annotations
 
 import json
@@ -8,17 +10,22 @@ import time
 
 import pytest
 
-from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.automation_access import (
-    ACCESS_SOURCE_OAUTH,
-    AutomationAccessRecord,
-    automation_record_key,
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.cache_io import (
+    encode_cache_value,
+)
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.cards.cache import (
+    DelegatedCardRuntimeCache,
+)
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.cards.model import (
+    CARD_STATE_REVOKED,
+    CardAuthority,
+    NamedServiceSelection,
 )
 from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.live_grant import (
     LiveGrantCardError,
     live_grants_for_resource,
     resolve_live_grant_card,
 )
-
 
 TENANT = "tenant-a"
 PROJECT = "project-a"
@@ -40,29 +47,45 @@ class _Redis:
         return self.values.get(key)
 
 
-def _record(
+def _authority(
     *,
     operations=("sheets_read",),
     resource_grants=None,
     expires_at=None,
-) -> AutomationAccessRecord:
-    return AutomationAccessRecord(
+    state="active",
+) -> CardAuthority:
+    return CardAuthority(
         access_id=ACCESS_ID,
         label="Claude productivity",
         client_id=CLIENT,
         grantor_subject=GRANTOR,
         delegate_subject=DELEGATE,
+        source="oauth",
+        state=state,
+        card_revision=1,
         operations=tuple(operations),
-        resource_grants=resource_grants
-        if resource_grants is not None
-        else {RESOURCE: ("sheets:read",)},
+        resource_grants=(
+            resource_grants
+            if resource_grants is not None
+            else {RESOURCE: ("sheets:read",)}
+        ),
+        named_service_operations=NamedServiceSelection.none(),
         expires_at=int(expires_at if expires_at is not None else time.time() + 3600),
-        source=ACCESS_SOURCE_OAUTH,
     )
 
 
 def _key() -> str:
-    return automation_record_key(TENANT, PROJECT, ACCESS_ID)
+    return DelegatedCardRuntimeCache(None, tenant=TENANT, project=PROJECT).card_key(ACCESS_ID)
+
+
+def _projection(authority: CardAuthority) -> str:
+    return encode_cache_value(
+        {
+            "kind": "card",
+            "card_revision": authority.card_revision,
+            "authority": authority.to_dict(),
+        }
+    )
 
 
 async def _resolve(redis: _Redis):
@@ -80,7 +103,7 @@ async def _resolve(redis: _Redis):
 @pytest.mark.asyncio
 async def test_live_grant_resolves_current_valid_card():
     redis = _Redis()
-    redis.values[_key()] = json.dumps(_record().to_dict())
+    redis.values[_key()] = _projection(_authority())
 
     resolved = await _resolve(redis)
 
@@ -90,14 +113,36 @@ async def test_live_grant_resolves_current_valid_card():
 
 
 @pytest.mark.asyncio
-async def test_live_grant_absent_or_expired_is_revoked():
+async def test_live_grant_absent_expired_or_revoked_denies():
     redis = _Redis()
     assert await _resolve(redis) is None
 
-    redis.values[_key()] = json.dumps(
-        _record(expires_at=int(time.time()) - 1).to_dict()
-    )
+    redis.values[_key()] = _projection(_authority(expires_at=int(time.time()) - 1))
     assert await _resolve(redis) is None
+
+    redis.values[_key()] = _projection(_authority(state=CARD_STATE_REVOKED))
+    assert await _resolve(redis) is None
+
+
+@pytest.mark.asyncio
+async def test_live_grant_revoked_tombstone_denies():
+    redis = _Redis()
+    redis.values[_key()] = encode_cache_value({"kind": "revoked", "card_revision": 2})
+
+    assert await _resolve(redis) is None
+
+
+@pytest.mark.asyncio
+async def test_live_grant_updating_marker_fails_closed():
+    redis = _Redis()
+    redis.values[_key()] = encode_cache_value(
+        {"kind": "updating", "mutation_id": "m1", "card_revision": 1}
+    )
+
+    with pytest.raises(LiveGrantCardError) as exc_info:
+        await _resolve(redis)
+
+    assert exc_info.value.reason == "card_updating"
 
 
 @pytest.mark.asyncio
@@ -115,21 +160,27 @@ async def test_live_grant_lookup_failure_is_not_a_snapshot_fallback():
 @pytest.mark.parametrize(
     ("payload", "reason"),
     [
-        ("{", "malformed_json"),
-        (json.dumps([]), "record_not_object"),
-        (json.dumps({"schema": "wrong"}), "schema_mismatch"),
+        ("{", "cached_card_not_decodable"),
+        (json.dumps([]), "cached_card_not_decodable"),
+        (json.dumps({"schema": "wrong"}), "cached_card_kind_unknown"),
         (
             json.dumps(
                 {
-                    **_record().to_dict(),
-                    "operations": "sheets_read",
+                    "kind": "card",
+                    "card_revision": 1,
+                    "authority": {**_authority().to_dict(), "operations": "sheets_read"},
                 }
             ),
-            "operations_invalid",
+            "cached_card_invalid",
         ),
     ],
 )
-async def test_live_grant_malformed_or_invalid_card_fails_closed(payload, reason):
+async def test_live_grant_unusable_projection_is_unavailable_not_denial(payload, reason):
+    """Damaged cache data must not read as a revoked card.
+
+    The guard has no durable source, so it reports unavailability and the
+    caller retries instead of being told to seek consent again.
+    """
     redis = _Redis()
     redis.values[_key()] = payload
 
@@ -142,8 +193,9 @@ async def test_live_grant_malformed_or_invalid_card_fails_closed(payload, reason
 @pytest.mark.asyncio
 async def test_live_grant_binding_mismatch_fails_closed():
     redis = _Redis()
-    payload = _record().to_dict()
-    payload["client_id"] = "different-client"
+    authority = _authority()
+    payload = json.loads(_projection(authority))
+    payload["authority"]["client_id"] = "different-client"
     redis.values[_key()] = json.dumps(payload)
 
     with pytest.raises(LiveGrantCardError) as exc_info:
@@ -153,7 +205,7 @@ async def test_live_grant_binding_mismatch_fails_closed():
 
 
 def test_live_resource_grants_preserve_explicit_empty_narrowing():
-    record = _record(resource_grants={RESOURCE: ()})
+    authority = _authority(resource_grants={RESOURCE: ()})
 
-    assert live_grants_for_resource(record, RESOURCE) == ()
-    assert live_grants_for_resource(record, "https://runtime.example.test/mcp/other") is None
+    assert live_grants_for_resource(authority, RESOURCE) == ()
+    assert live_grants_for_resource(authority, "https://runtime.example.test/mcp/other") is None

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/tests/test_named_service_selection_persistence.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/tests/test_named_service_selection_persistence.py
@@ -15,6 +15,7 @@ from test_automation_access import (
     _Authority,
     _minter,
     _named_services_config,
+    _named_services_connections,
     _NamedServiceDiscovery,
     _Redis,
     _Store,
@@ -72,7 +73,7 @@ USER = {"user_id": "platform-user-1", "roles": ["kdcube:role:registered"], "perm
 
 def _service(card_persistence) -> AutomationAccessService:
     return AutomationAccessService(
-        catalog_resolver=_CatalogResolver(),
+        catalog_resolver=_CatalogResolver(connections=_named_services_connections()),
         card_persistence=card_persistence,
         redis=_Redis(),
         tenant="demo-tenant",

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/tests/test_named_service_selection_persistence.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/tests/test_named_service_selection_persistence.py
@@ -4,6 +4,8 @@
 """Named-service selection persistence across delegated-card updates."""
 
 import json
+import os
+import uuid
 
 import pytest
 
@@ -18,18 +20,60 @@ from test_automation_access import (
     _Store,
 )
 
+from dataclasses import replace
+
 from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.automation_access import (
     AutomationAccessRecord,
+    _subject_key,
+    card_authority_from_record,
+    card_handles_from_record,
+    oauth_access_id,
 )
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.cards.model import (
+    NamedServiceSelection,
+)
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.cards.persistence import (
+    DurableCardPersistence,
+)
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.cards.store import (
+    BundleStorageDelegatedCardStore,
+)
+
+REDIS_URL = os.environ.get("REDIS_URL") or ""
+
+pytestmark = pytest.mark.skipif(
+    not REDIS_URL,
+    reason="REDIS_URL is not set; delegated-card persistence needs a real Redis",
+)
+
+
+@pytest.fixture
+async def card_persistence(tmp_path):
+    """Production card persistence: durable revisions plus a Redis projection."""
+    import redis.asyncio as redis_asyncio
+
+    client = redis_asyncio.from_url(REDIS_URL)
+    try:
+        await client.ping()
+    except Exception as exc:  # pragma: no cover - environment guard
+        pytest.skip(f"Redis at REDIS_URL is unreachable: {exc}")
+    yield DurableCardPersistence(
+        redis=client,
+        tenant=f"t-{uuid.uuid4().hex[:8]}",
+        project=f"p-{uuid.uuid4().hex[:8]}",
+        card_store=BundleStorageDelegatedCardStore(tmp_path),
+    )
+    await client.aclose()
 
 RESOURCE = "https://example.test/mcp/named-services"
 GRANTS = ["named_services:use", "slack:read", "slack:write"]
 USER = {"user_id": "platform-user-1", "roles": ["kdcube:role:registered"], "permissions": []}
 
 
-def _service() -> AutomationAccessService:
+def _service(card_persistence) -> AutomationAccessService:
     return AutomationAccessService(
         catalog_resolver=_CatalogResolver(),
+        card_persistence=card_persistence,
         redis=_Redis(),
         tenant="demo-tenant",
         project="demo-project",
@@ -41,15 +85,30 @@ def _service() -> AutomationAccessService:
     )
 
 
-def _stored(service: AutomationAccessService, access_id: str) -> tuple[object, list[str]]:
-    raw = json.loads(service._redis.values[service._record_key(access_id)])
+async def _stored(
+    service: AutomationAccessService, access_id: str
+) -> tuple[object, list[str]]:
+    """Read the committed card through the persistence port."""
+    record = await service._load_record(access_id, grantor_subject=USER["user_id"])
+    assert record is not None, f"card {access_id} is not committed"
+    raw = record.to_dict()
     namespaces = (raw.get("named_services") or {}).get("namespaces") or {}
     return raw.get("named_service_operations", "<absent>"), sorted(namespaces)
 
 
+async def _put(service: AutomationAccessService, record: AutomationAccessRecord) -> None:
+    """Commit a hand-built record through the persistence port."""
+    await service._persistence.persist(
+        card_authority_from_record(record),
+        card_handles_from_record(record),
+        subject_hash=_subject_key(record.grantor_subject),
+        expected_revision=record.card_revision,
+    )
+
+
 @pytest.mark.asyncio
-async def test_manual_clear_survives_an_unrelated_update():
-    service = _service()
+async def test_manual_clear_survives_an_unrelated_update(card_persistence):
+    service = _service(card_persistence)
     created = await service.create_access(
         USER, label="CI bot", resource_grants={RESOURCE: GRANTS}
     )
@@ -59,19 +118,19 @@ async def test_manual_clear_survives_an_unrelated_update():
         USER, access_id=access_id, resource_grants={RESOURCE: GRANTS},
         named_service_operations={},
     )
-    assert _stored(service, access_id) == ({}, [])
+    assert await _stored(service, access_id) == ({}, [])
 
     renamed = await service.update_access(
         USER, access_id=access_id, resource_grants={RESOURCE: GRANTS}, label="Renamed",
     )
     assert renamed["ok"] is True
-    assert _stored(service, access_id) == ({}, [])
+    assert await _stored(service, access_id) == ({}, [])
     assert renamed["access"]["named_service_operations"] == {}
 
 
 @pytest.mark.asyncio
-async def test_agent_clear_survives_a_replace_edit_that_omits_the_field():
-    service = _service()
+async def test_agent_clear_survives_a_replace_edit_that_omits_the_field(card_persistence):
+    service = _service(card_persistence)
     await service.create_access(
         USER, label="agent", client_id="kdcube-agent:app:a1",
         resource_grants={RESOURCE: GRANTS},
@@ -84,28 +143,21 @@ async def test_agent_clear_survives_a_replace_edit_that_omits_the_field():
         )
     )["access"]["access_id"]
 
-    assert _stored(service, access_id) == ({}, [])
+    assert await _stored(service, access_id) == ({}, [])
 
 
 @pytest.mark.asyncio
-async def test_oauth_refresh_does_not_widen_a_cleared_card():
-    service = _service()
+async def test_oauth_refresh_does_not_widen_a_cleared_card(card_persistence):
+    service = _service(card_persistence)
     created = await service.create_access(
         USER, label="CI bot", resource_grants={RESOURCE: GRANTS},
         named_service_operations={RESOURCE: {"slack": ["object.search"]}},
     )
     access_id = created["access"]["access_id"]
     # Re-key the manual card as an OAuth card so the refresh path reads it.
-    raw = json.loads(service._redis.values[service._record_key(access_id)])
-    raw["source"] = "oauth"
-    oauth_id = service._redis.values.setdefault
-    from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.automation_access import (
-        oauth_access_id,
-    )
-
     card_id = oauth_access_id("platform-user-1", "claude", RESOURCE)
-    raw["access_id"] = card_id
-    oauth_id(service._record_key(card_id), json.dumps(raw))
+    manual = await service._load_record(access_id, grantor_subject=USER["user_id"])
+    await _put(service, replace(manual, access_id=card_id, source="oauth", card_revision=0))
 
     await service.record_oauth_grant(
         grantor_subject="platform-user-1",
@@ -116,32 +168,32 @@ async def test_oauth_refresh_does_not_widen_a_cleared_card():
         refresh_token="rt",
     )
 
-    selection, namespaces = _stored(service, card_id)
+    selection, namespaces = await _stored(service, card_id)
     assert selection == {RESOURCE: {"slack": ["object.search"]}}
     assert namespaces == ["slack"]
 
 
 @pytest.mark.asyncio
-async def test_wildcard_is_persisted_and_survives_a_rename():
-    service = _service()
+async def test_wildcard_is_persisted_and_survives_a_rename(card_persistence):
+    service = _service(card_persistence)
     created = await service.create_access(
         USER, label="all ops", resource_grants={RESOURCE: GRANTS}
     )
     access_id = created["access"]["access_id"]
 
     # A create that names no selection is stored explicitly, not as absence.
-    assert _stored(service, access_id) == ("*", ["mail", "slack"])
+    assert await _stored(service, access_id) == ("*", ["mail", "slack"])
     assert created["access"]["named_service_operations"] == "*"
 
     await service.update_access(
         USER, access_id=access_id, resource_grants={RESOURCE: GRANTS}, label="Renamed",
     )
-    assert _stored(service, access_id) == ("*", ["mail", "slack"])
+    assert await _stored(service, access_id) == ("*", ["mail", "slack"])
 
 
 @pytest.mark.asyncio
-async def test_exact_selection_survives_a_rename():
-    service = _service()
+async def test_exact_selection_survives_a_rename(card_persistence):
+    service = _service(card_persistence)
     created = await service.create_access(
         USER, label="search only", resource_grants={RESOURCE: GRANTS},
         named_service_operations={RESOURCE: {"slack": ["object.search"]}},
@@ -151,26 +203,26 @@ async def test_exact_selection_survives_a_rename():
     await service.update_access(
         USER, access_id=access_id, resource_grants={RESOURCE: GRANTS}, label="Renamed",
     )
-    selection, namespaces = _stored(service, access_id)
+    selection, namespaces = await _stored(service, access_id)
     assert selection == {RESOURCE: {"slack": ["object.search"]}}
     assert namespaces == ["slack"]
 
 
 @pytest.mark.asyncio
-async def test_an_explicit_wildcard_update_reopens_a_cleared_card():
-    service = _service()
+async def test_an_explicit_wildcard_update_reopens_a_cleared_card(card_persistence):
+    service = _service(card_persistence)
     created = await service.create_access(
         USER, label="CI bot", resource_grants={RESOURCE: GRANTS},
         named_service_operations={},
     )
     access_id = created["access"]["access_id"]
-    assert _stored(service, access_id) == ({}, [])
+    assert await _stored(service, access_id) == ({}, [])
 
     await service.update_access(
         USER, access_id=access_id, resource_grants={RESOURCE: GRANTS},
         named_service_operations="*",
     )
-    assert _stored(service, access_id) == ("*", ["mail", "slack"])
+    assert await _stored(service, access_id) == ("*", ["mail", "slack"])
 
 
 def test_pre_migration_record_is_projected_as_legacy_not_as_empty():
@@ -233,11 +285,12 @@ def test_public_projection_distinguishes_all_four_states():
     assert "named_service_operations" not in _public("<absent>", {})
 
 
-def _service_without_catalog() -> AutomationAccessService:
+def _service_without_catalog(card_persistence) -> AutomationAccessService:
     from test_automation_access import _CatalogResolver
 
     return AutomationAccessService(
         catalog_resolver=_CatalogResolver(unavailable=True),
+        card_persistence=card_persistence,
         redis=_Redis(), tenant="demo-tenant", project="demo-project",
         config=_named_services_config(), grant_store=_Store(), authority=_Authority(),
         minter=_minter, named_service_discovery=_NamedServiceDiscovery({}),
@@ -245,8 +298,8 @@ def _service_without_catalog() -> AutomationAccessService:
 
 
 @pytest.mark.asyncio
-async def test_create_fails_closed_when_the_catalog_cannot_be_resolved():
-    service = _service_without_catalog()
+async def test_create_fails_closed_when_the_catalog_cannot_be_resolved(card_persistence):
+    service = _service_without_catalog(card_persistence)
     result = await service.create_access(
         USER, label="CI bot", resource_grants={RESOURCE: GRANTS}
     )
@@ -271,44 +324,49 @@ async def test_an_unconfigured_resolver_also_fails_closed():
 
 
 @pytest.mark.asyncio
-async def test_saves_stamp_the_active_version_and_advance_the_revision():
+async def test_saves_stamp_the_active_version_and_advance_the_revision(card_persistence):
     from test_automation_access import TEST_CATALOG_VERSION
 
-    service = _service()
+    service = _service(card_persistence)
     created = await service.create_access(
         USER, label="CI bot", resource_grants={RESOURCE: GRANTS}
     )
     access_id = created["access"]["access_id"]
-    raw = json.loads(service._redis.values[service._record_key(access_id)])
-    assert raw["catalog_version"] == TEST_CATALOG_VERSION
-    assert raw["card_revision"] == 1
+    stored = await service._load_record(access_id, grantor_subject=USER["user_id"])
+    assert stored.catalog_version == TEST_CATALOG_VERSION
+    assert stored.card_revision == 1
 
     await service.update_access(
         USER, access_id=access_id, resource_grants={RESOURCE: GRANTS}, label="Renamed",
     )
-    raw = json.loads(service._redis.values[service._record_key(access_id)])
-    assert raw["card_revision"] == 2
+    stored = await service._load_record(access_id, grantor_subject=USER["user_id"])
+    assert stored.card_revision == 2
 
 
 @pytest.mark.asyncio
-async def test_a_legacy_card_becomes_explicit_on_its_next_save():
-    service = _service()
+async def test_a_legacy_card_becomes_explicit_on_its_next_save(card_persistence):
+    service = _service(card_persistence)
     created = await service.create_access(
         USER, label="CI bot", resource_grants={RESOURCE: GRANTS}
     )
     access_id = created["access"]["access_id"]
-    key = service._record_key(access_id)
 
-    raw = json.loads(service._redis.values[key])
-    raw["named_service_operations"] = {}
-    raw.pop("catalog_version", None)
-    service._redis.values[key] = json.dumps(raw)
-    assert _stored(service, access_id) == ({}, ["mail", "slack"])
+    current = await service._load_record(access_id, grantor_subject=USER["user_id"])
+    await _put(
+        service,
+        replace(
+            current,
+            named_service_operations=NamedServiceSelection.unknown(),
+            catalog_version="",
+        ),
+    )
+    assert await _stored(service, access_id) == ("<absent>", ["mail", "slack"])
 
     await service.update_access(
         USER, access_id=access_id, resource_grants={RESOURCE: GRANTS}, label="Renamed",
     )
-    selection, namespaces = _stored(service, access_id)
+    selection, namespaces = await _stored(service, access_id)
     assert selection == "*"
     assert namespaces == ["mail", "slack"]
-    assert json.loads(service._redis.values[key])["catalog_version"]
+    saved = await service._load_record(access_id, grantor_subject=USER["user_id"])
+    assert saved.catalog_version

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/tests/test_named_service_selection_persistence.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/tests/test_named_service_selection_persistence.py
@@ -1,0 +1,314 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Elena Viter
+
+"""Named-service selection persistence across delegated-card updates."""
+
+import json
+
+import pytest
+
+from test_automation_access import (
+    AutomationAccessService,
+    _CatalogResolver,
+    _Authority,
+    _minter,
+    _named_services_config,
+    _NamedServiceDiscovery,
+    _Redis,
+    _Store,
+)
+
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.automation_access import (
+    AutomationAccessRecord,
+)
+
+RESOURCE = "https://example.test/mcp/named-services"
+GRANTS = ["named_services:use", "slack:read", "slack:write"]
+USER = {"user_id": "platform-user-1", "roles": ["kdcube:role:registered"], "permissions": []}
+
+
+def _service() -> AutomationAccessService:
+    return AutomationAccessService(
+        catalog_resolver=_CatalogResolver(),
+        redis=_Redis(),
+        tenant="demo-tenant",
+        project="demo-project",
+        config=_named_services_config(),
+        grant_store=_Store(),
+        authority=_Authority(),
+        minter=_minter,
+        named_service_discovery=_NamedServiceDiscovery({}),
+    )
+
+
+def _stored(service: AutomationAccessService, access_id: str) -> tuple[object, list[str]]:
+    raw = json.loads(service._redis.values[service._record_key(access_id)])
+    namespaces = (raw.get("named_services") or {}).get("namespaces") or {}
+    return raw.get("named_service_operations", "<absent>"), sorted(namespaces)
+
+
+@pytest.mark.asyncio
+async def test_manual_clear_survives_an_unrelated_update():
+    service = _service()
+    created = await service.create_access(
+        USER, label="CI bot", resource_grants={RESOURCE: GRANTS}
+    )
+    access_id = created["access"]["access_id"]
+
+    await service.update_access(
+        USER, access_id=access_id, resource_grants={RESOURCE: GRANTS},
+        named_service_operations={},
+    )
+    assert _stored(service, access_id) == ({}, [])
+
+    renamed = await service.update_access(
+        USER, access_id=access_id, resource_grants={RESOURCE: GRANTS}, label="Renamed",
+    )
+    assert renamed["ok"] is True
+    assert _stored(service, access_id) == ({}, [])
+    assert renamed["access"]["named_service_operations"] == {}
+
+
+@pytest.mark.asyncio
+async def test_agent_clear_survives_a_replace_edit_that_omits_the_field():
+    service = _service()
+    await service.create_access(
+        USER, label="agent", client_id="kdcube-agent:app:a1",
+        resource_grants={RESOURCE: GRANTS},
+        named_service_operations={},
+    )
+    access_id = (
+        await service.create_access(
+            USER, label="agent renamed", client_id="kdcube-agent:app:a1",
+            resource_grants={RESOURCE: GRANTS}, merge_existing=False,
+        )
+    )["access"]["access_id"]
+
+    assert _stored(service, access_id) == ({}, [])
+
+
+@pytest.mark.asyncio
+async def test_oauth_refresh_does_not_widen_a_cleared_card():
+    service = _service()
+    created = await service.create_access(
+        USER, label="CI bot", resource_grants={RESOURCE: GRANTS},
+        named_service_operations={RESOURCE: {"slack": ["object.search"]}},
+    )
+    access_id = created["access"]["access_id"]
+    # Re-key the manual card as an OAuth card so the refresh path reads it.
+    raw = json.loads(service._redis.values[service._record_key(access_id)])
+    raw["source"] = "oauth"
+    oauth_id = service._redis.values.setdefault
+    from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.automation_access import (
+        oauth_access_id,
+    )
+
+    card_id = oauth_access_id("platform-user-1", "claude", RESOURCE)
+    raw["access_id"] = card_id
+    oauth_id(service._record_key(card_id), json.dumps(raw))
+
+    await service.record_oauth_grant(
+        grantor_subject="platform-user-1",
+        client_id="claude",
+        scopes=GRANTS,
+        resource=RESOURCE,
+        access_token="at",
+        refresh_token="rt",
+    )
+
+    selection, namespaces = _stored(service, card_id)
+    assert selection == {RESOURCE: {"slack": ["object.search"]}}
+    assert namespaces == ["slack"]
+
+
+@pytest.mark.asyncio
+async def test_wildcard_is_persisted_and_survives_a_rename():
+    service = _service()
+    created = await service.create_access(
+        USER, label="all ops", resource_grants={RESOURCE: GRANTS}
+    )
+    access_id = created["access"]["access_id"]
+
+    # A create that names no selection is stored explicitly, not as absence.
+    assert _stored(service, access_id) == ("*", ["mail", "slack"])
+    assert created["access"]["named_service_operations"] == "*"
+
+    await service.update_access(
+        USER, access_id=access_id, resource_grants={RESOURCE: GRANTS}, label="Renamed",
+    )
+    assert _stored(service, access_id) == ("*", ["mail", "slack"])
+
+
+@pytest.mark.asyncio
+async def test_exact_selection_survives_a_rename():
+    service = _service()
+    created = await service.create_access(
+        USER, label="search only", resource_grants={RESOURCE: GRANTS},
+        named_service_operations={RESOURCE: {"slack": ["object.search"]}},
+    )
+    access_id = created["access"]["access_id"]
+
+    await service.update_access(
+        USER, access_id=access_id, resource_grants={RESOURCE: GRANTS}, label="Renamed",
+    )
+    selection, namespaces = _stored(service, access_id)
+    assert selection == {RESOURCE: {"slack": ["object.search"]}}
+    assert namespaces == ["slack"]
+
+
+@pytest.mark.asyncio
+async def test_an_explicit_wildcard_update_reopens_a_cleared_card():
+    service = _service()
+    created = await service.create_access(
+        USER, label="CI bot", resource_grants={RESOURCE: GRANTS},
+        named_service_operations={},
+    )
+    access_id = created["access"]["access_id"]
+    assert _stored(service, access_id) == ({}, [])
+
+    await service.update_access(
+        USER, access_id=access_id, resource_grants={RESOURCE: GRANTS},
+        named_service_operations="*",
+    )
+    assert _stored(service, access_id) == ("*", ["mail", "slack"])
+
+
+def test_pre_migration_record_is_projected_as_legacy_not_as_empty():
+    """A pre-encoding card stored {} while carrying the full boundary."""
+    legacy = AutomationAccessRecord.from_mapping(
+        {
+            "schema": "connection_hub.automation_access.v1",
+            "access_id": "aut_legacy",
+            "client_id": "automation:aut_legacy",
+            "grantor_subject": "platform-user-1",
+            "delegate_subject": "integration:automation:aut_legacy",
+            "named_service_operations": {},
+            "named_services": {"namespaces": {"slack": {"tools": {}}}},
+            "resource_grants": {RESOURCE: ["slack:read"]},
+            "operations": [],
+            "expires_at": 1_780_003_600,
+        }
+    )
+    assert legacy.named_service_operations.is_unknown
+
+    closed = AutomationAccessRecord.from_mapping(
+        {
+            "schema": "connection_hub.automation_access.v1",
+            "access_id": "aut_closed",
+            "client_id": "automation:aut_closed",
+            "grantor_subject": "platform-user-1",
+            "delegate_subject": "integration:automation:aut_closed",
+            "named_service_operations": {},
+            "named_services": {"namespaces": {}},
+            "resource_grants": {RESOURCE: ["slack:read"]},
+            "operations": [],
+            "expires_at": 1_780_003_600,
+        }
+    )
+    assert closed.named_service_operations.is_none
+
+
+def test_public_projection_distinguishes_all_four_states():
+    def _public(selection_payload, named_services):
+        payload = {
+            "schema": "connection_hub.automation_access.v1",
+            "access_id": "aut_x",
+            "client_id": "automation:aut_x",
+            "grantor_subject": "platform-user-1",
+            "delegate_subject": "integration:automation:aut_x",
+            "named_services": named_services,
+            "resource_grants": {RESOURCE: ["slack:read"]},
+            "operations": [],
+            "expires_at": 1_780_003_600,
+        }
+        if selection_payload != "<absent>":
+            payload["named_service_operations"] = selection_payload
+        return AutomationAccessRecord.from_mapping(payload).to_public_dict()
+
+    assert _public("*", {})["named_service_operations"] == "*"
+    assert _public({}, {"namespaces": {}})["named_service_operations"] == {}
+    assert _public({RESOURCE: {"slack": ["object.search"]}}, {})[
+        "named_service_operations"
+    ] == {RESOURCE: {"slack": ["object.search"]}}
+    assert "named_service_operations" not in _public("<absent>", {})
+
+
+def _service_without_catalog() -> AutomationAccessService:
+    from test_automation_access import _CatalogResolver
+
+    return AutomationAccessService(
+        catalog_resolver=_CatalogResolver(unavailable=True),
+        redis=_Redis(), tenant="demo-tenant", project="demo-project",
+        config=_named_services_config(), grant_store=_Store(), authority=_Authority(),
+        minter=_minter, named_service_discovery=_NamedServiceDiscovery({}),
+    )
+
+
+@pytest.mark.asyncio
+async def test_create_fails_closed_when_the_catalog_cannot_be_resolved():
+    service = _service_without_catalog()
+    result = await service.create_access(
+        USER, label="CI bot", resource_grants={RESOURCE: GRANTS}
+    )
+    assert result["ok"] is False
+    assert result["error"] == "delegated_catalog_unavailable"
+    assert result["retryable"] is True
+    assert service._redis.values == {}
+
+
+@pytest.mark.asyncio
+async def test_an_unconfigured_resolver_also_fails_closed():
+    service = AutomationAccessService(
+        redis=_Redis(), tenant="demo-tenant", project="demo-project",
+        config=_named_services_config(), grant_store=_Store(), authority=_Authority(),
+        minter=_minter, named_service_discovery=_NamedServiceDiscovery({}),
+    )
+    result = await service.create_access(
+        USER, label="CI bot", resource_grants={RESOURCE: GRANTS}
+    )
+    assert result["ok"] is False
+    assert result["reason"] == "catalog_resolver_not_configured"
+
+
+@pytest.mark.asyncio
+async def test_saves_stamp_the_active_version_and_advance_the_revision():
+    from test_automation_access import TEST_CATALOG_VERSION
+
+    service = _service()
+    created = await service.create_access(
+        USER, label="CI bot", resource_grants={RESOURCE: GRANTS}
+    )
+    access_id = created["access"]["access_id"]
+    raw = json.loads(service._redis.values[service._record_key(access_id)])
+    assert raw["catalog_version"] == TEST_CATALOG_VERSION
+    assert raw["card_revision"] == 1
+
+    await service.update_access(
+        USER, access_id=access_id, resource_grants={RESOURCE: GRANTS}, label="Renamed",
+    )
+    raw = json.loads(service._redis.values[service._record_key(access_id)])
+    assert raw["card_revision"] == 2
+
+
+@pytest.mark.asyncio
+async def test_a_legacy_card_becomes_explicit_on_its_next_save():
+    service = _service()
+    created = await service.create_access(
+        USER, label="CI bot", resource_grants={RESOURCE: GRANTS}
+    )
+    access_id = created["access"]["access_id"]
+    key = service._record_key(access_id)
+
+    raw = json.loads(service._redis.values[key])
+    raw["named_service_operations"] = {}
+    raw.pop("catalog_version", None)
+    service._redis.values[key] = json.dumps(raw)
+    assert _stored(service, access_id) == ({}, ["mail", "slack"])
+
+    await service.update_access(
+        USER, access_id=access_id, resource_grants={RESOURCE: GRANTS}, label="Renamed",
+    )
+    selection, namespaces = _stored(service, access_id)
+    assert selection == "*"
+    assert namespaces == ["mail", "slack"]
+    assert json.loads(service._redis.values[key])["catalog_version"]

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/tests/test_named_service_selection_persistence.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/tests/test_named_service_selection_persistence.py
@@ -175,21 +175,63 @@ async def test_oauth_refresh_does_not_widen_a_cleared_card(card_persistence):
 
 
 @pytest.mark.asyncio
-async def test_wildcard_is_persisted_and_survives_a_rename(card_persistence):
+async def test_an_inherited_wildcard_is_frozen_into_what_it_already_meant(card_persistence):
+    """`"*"` is bound to the catalog version the card was saved against.
+
+    An edit that never mentions the selection carries no consent to a newer
+    catalog, so the wildcard is written out as the exact set it already
+    expanded to. The design states the rule: "the backend expands it against
+    the saved catalog version and persists the surviving exact map before
+    stamping the current version". Leaving it as `"*"` let an unrelated rename
+    widen the card, which is what the live run measured.
+    """
     service = _service(card_persistence)
     created = await service.create_access(
         USER, label="all ops", resource_grants={RESOURCE: GRANTS}
     )
     access_id = created["access"]["access_id"]
 
-    # A create that names no selection is stored explicitly, not as absence.
+    # A create that names no selection is still stored explicitly.
     assert await _stored(service, access_id) == ("*", ["mail", "slack"])
     assert created["access"]["named_service_operations"] == "*"
 
     await service.update_access(
         USER, access_id=access_id, resource_grants={RESOURCE: GRANTS}, label="Renamed",
     )
+
+    selection, namespaces = await _stored(service, access_id)
+    assert selection == {RESOURCE: {"slack": ["object.action", "object.search"]}}
+    assert namespaces == ["slack"]
+
+
+@pytest.mark.asyncio
+async def test_freezing_a_wildcard_keeps_the_claims_that_same_save_adds(card_persistence):
+    """Freezing must not narrow what the wildcard meant.
+
+    An omitted selection preserves the prior policy, and that policy is "every
+    operation of the saved catalog version this card can invoke". If the same
+    edit widens the claims, the namespaces those claims open belong to the
+    frozen set — filtering by the record's previous claims would silently drop
+    a namespace in the very request that opened it.
+    """
+    service = _service(card_persistence)
+    created = await service.create_access(
+        USER, label="all ops", resource_grants={RESOURCE: GRANTS}
+    )
+    access_id = created["access"]["access_id"]
     assert await _stored(service, access_id) == ("*", ["mail", "slack"])
+
+    await service.update_access(
+        USER,
+        access_id=access_id,
+        resource_grants={RESOURCE: GRANTS + ["mail:read"]},
+        label="Renamed",
+    )
+
+    selection, namespaces = await _stored(service, access_id)
+    assert namespaces == ["mail", "slack"]
+    assert selection[RESOURCE]["mail"] == ["object.search"]
+    assert selection[RESOURCE]["slack"] == ["object.action", "object.search"]
 
 
 @pytest.mark.asyncio
@@ -286,6 +328,58 @@ def test_public_projection_distinguishes_all_four_states():
     assert "named_service_operations" not in _public("<absent>", {})
 
 
+def test_public_projection_carries_what_a_wildcard_actually_covers():
+    """`"*"` and a pre-encoding record name no operations of their own.
+
+    Without the expanded projection a surface can only draw them as an empty
+    picker, which is exactly how an explicit `{}` draws — so the operator
+    cannot see the card's coverage, and the first box they tick narrows the
+    card instead of widening it. The design has GET return what the card
+    materialized: "The derived pre-migration set comes from what the card
+    actually materialized, not from all operations in the current catalog."
+    """
+    boundary = {
+        "namespaces": {
+            "slack": {
+                "tools": {
+                    "search": {"operation": "object.search"},
+                    "act": {"operation": "object.action"},
+                }
+            }
+        }
+    }
+
+    def _public(selection_payload, named_services):
+        payload = {
+            "schema": "connection_hub.automation_access.v1",
+            "access_id": "aut_x",
+            "client_id": "automation:aut_x",
+            "grantor_subject": "platform-user-1",
+            "delegate_subject": "integration:automation:aut_x",
+            "named_services": named_services,
+            "resource_grants": {RESOURCE: ["slack:read"]},
+            "operations": [],
+            "expires_at": 1_780_003_600,
+        }
+        if selection_payload != "<absent>":
+            payload["named_service_operations"] = selection_payload
+        return AutomationAccessRecord.from_mapping(payload).to_public_dict()
+
+    covered = {RESOURCE: {"slack": ["object.action", "object.search"]}}
+    wildcard = _public("*", boundary)
+    assert wildcard["named_service_operations"] == "*"
+    assert wildcard["effective_named_service_operations"] == covered
+
+    # A pre-encoding record reports the same coverage, and still says it is
+    # legacy by carrying no selection.
+    legacy = _public("<absent>", boundary)
+    assert "named_service_operations" not in legacy
+    assert legacy["effective_named_service_operations"] == covered
+
+    # An explicit empty boundary stays visibly empty.
+    assert "effective_named_service_operations" not in _public({}, {"namespaces": {}})
+
+
 def _service_without_catalog(card_persistence) -> AutomationAccessService:
     from test_automation_access import _CatalogResolver
 
@@ -371,3 +465,181 @@ async def test_a_legacy_card_becomes_explicit_on_its_next_save(card_persistence)
     assert namespaces == ["mail", "slack"]
     saved = await service._load_record(access_id, grantor_subject=USER["user_id"])
     assert saved.catalog_version
+
+
+@pytest.mark.asyncio
+async def test_a_wildcard_does_not_pick_up_an_operation_added_after_it_was_issued(
+    card_persistence,
+):
+    """The property the wildcard exists to have.
+
+    The design tabulates `"*"` as every operation present in the REFERENCED
+    catalog version: "Later catalog additions are not included". The live run
+    measured the opposite — an unrelated rename rebuilt the boundary from the
+    current descriptor and stamped the current version, and 9 operations became
+    10. Freezing on an omitted save is what closes it.
+    """
+    import copy as _copy
+    from types import SimpleNamespace as _NS
+
+    from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.oauth.config import (
+        oauth_delegated_config,
+    )
+
+    service = _service(card_persistence)
+    created = await service.create_access(
+        USER, label="all ops", resource_grants={RESOURCE: GRANTS}
+    )
+    access_id = created["access"]["access_id"]
+    assert await _stored(service, access_id) == ("*", ["mail", "slack"])
+
+    # The deployment adds an operation to a namespace the card already reaches,
+    # and the card's claims would authorize it.
+    advanced = _copy.deepcopy(_named_services_connections())
+    resource = advanced["delegated_credentials"]["oauth"]["resources"][0]
+    resource["named_services"]["namespaces"]["slack"]["tools"]["schema"] = {
+        "operation": "object.schema",
+        "label": "Slack schema",
+        "grants": ["slack:read"],
+    }
+    service._catalog_resolver.advance(
+        version="delegated_catalog_2026-08-19-00-00-00-000_ffffffffffff",
+        connections=advanced,
+    )
+    service._config = oauth_delegated_config(
+        _NS(state=_NS(oauth_delegated_config=advanced["delegated_credentials"]["oauth"]))
+    )
+
+    # An edit that never mentions the selection carries no consent to it.
+    await service.update_access(
+        USER, access_id=access_id, resource_grants={RESOURCE: GRANTS}, label="Renamed",
+    )
+
+    selection, _ = await _stored(service, access_id)
+    assert selection != "*", "an omitted save must not leave the wildcard re-pinned"
+    assert selection[RESOURCE]["slack"] == ["object.action", "object.search"]
+    assert "object.schema" not in selection[RESOURCE]["slack"]
+
+
+def _advance_catalog(service: AutomationAccessService) -> None:
+    """The deployment adds an operation to a namespace the card already reaches."""
+    import copy as _copy
+    from types import SimpleNamespace as _NS
+
+    from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.oauth.config import (
+        oauth_delegated_config,
+    )
+
+    advanced = _copy.deepcopy(_named_services_connections())
+    resource = advanced["delegated_credentials"]["oauth"]["resources"][0]
+    resource["named_services"]["namespaces"]["slack"]["tools"]["schema"] = {
+        "operation": "object.schema",
+        "label": "Slack schema",
+        "grants": ["slack:read"],
+    }
+    service._catalog_resolver.advance(
+        version="delegated_catalog_2026-08-19-00-00-00-000_ffffffffffff",
+        connections=advanced,
+    )
+    service._config = oauth_delegated_config(
+        _NS(state=_NS(oauth_delegated_config=advanced["delegated_credentials"]["oauth"]))
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_merging_re_consent_does_not_re_pin_a_wildcard(card_persistence):
+    """The consent screen names a door and its claims, never inner operations.
+
+    So a second one-click consent is not the reviewed explicit `"*"` the design
+    lets Save retain against a new `catalog_version`. Freezing was wired into
+    the replace branch only, and the merge branch resolved an omitted field to
+    `NamedServiceSelection.all()` — re-pinning the card to the newest catalog
+    and absorbing everything added since it was issued.
+    """
+    service = _service(card_persistence)
+    created = await service.create_access(
+        USER, label="agent", client_id="kdcube-agent:app:merge1",
+        resource_grants={RESOURCE: GRANTS},
+    )
+    access_id = created["access"]["access_id"]
+    assert await _stored(service, access_id) == ("*", ["mail", "slack"])
+
+    _advance_catalog(service)
+
+    # A second consent, for one more claim, carrying no selection.
+    again = await service.create_access(
+        USER, label="agent", client_id="kdcube-agent:app:merge1",
+        resource_grants={RESOURCE: ["mail:read"]},
+    )
+    assert again["ok"] is True
+    assert again["access"]["access_id"] == access_id
+
+    selection, namespaces = await _stored(service, access_id)
+    assert selection != "*", "a merging consent must not re-pin the wildcard"
+    assert "object.schema" not in selection[RESOURCE]["slack"]
+    assert selection[RESOURCE]["slack"] == ["object.action", "object.search"]
+    # The freeze runs after the claim merge, so the namespace this very consent
+    # opened is part of the frozen set.
+    assert namespaces == ["mail", "slack"]
+    assert selection[RESOURCE]["mail"] == ["object.search"]
+
+
+@pytest.mark.asyncio
+async def test_a_merging_re_consent_keeps_a_narrowing_the_operator_made(card_persistence):
+    """An omitted field preserves the prior policy on every entrance.
+
+    The merge branch read it as "grant everything the current catalog offers",
+    so the next one-click consent silently undid the narrowing.
+    """
+    service = _service(card_persistence)
+    created = await service.create_access(
+        USER, label="agent", client_id="kdcube-agent:app:merge2",
+        resource_grants={RESOURCE: GRANTS},
+        named_service_operations={RESOURCE: {"slack": ["object.search"]}},
+    )
+    access_id = created["access"]["access_id"]
+    assert await _stored(service, access_id) == (
+        {RESOURCE: {"slack": ["object.search"]}}, ["slack"],
+    )
+
+    await service.create_access(
+        USER, label="agent", client_id="kdcube-agent:app:merge2",
+        resource_grants={RESOURCE: GRANTS},
+    )
+
+    assert await _stored(service, access_id) == (
+        {RESOURCE: {"slack": ["object.search"]}}, ["slack"],
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_merging_extension_adds_to_the_frozen_set_instead_of_reopening(
+    card_persistence,
+):
+    """A one-click extension accumulates, but onto what the card already means.
+
+    Unioning against the stored `"*"` returned `"*"` — the wildcard side absorbs
+    the other — so submitting one new operation reopened the whole current
+    catalog. The union takes the frozen expansion instead.
+    """
+    service = _service(card_persistence)
+    created = await service.create_access(
+        USER, label="agent", client_id="kdcube-agent:app:merge3",
+        resource_grants={RESOURCE: GRANTS},
+    )
+    access_id = created["access"]["access_id"]
+    assert await _stored(service, access_id) == ("*", ["mail", "slack"])
+
+    _advance_catalog(service)
+
+    await service.create_access(
+        USER, label="agent", client_id="kdcube-agent:app:merge3",
+        resource_grants={RESOURCE: GRANTS},
+        named_service_operations={RESOURCE: {"slack": ["object.schema"]}},
+    )
+
+    selection, _ = await _stored(service, access_id)
+    assert selection != "*", "an extension must not reopen the card to everything"
+    assert sorted(selection[RESOURCE]["slack"]) == [
+        "object.action", "object.schema", "object.search",
+    ]

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/tests/test_named_service_selection_persistence.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/tests/test_named_service_selection_persistence.py
@@ -108,6 +108,41 @@ async def _put(service: AutomationAccessService, record: AutomationAccessRecord)
 
 
 @pytest.mark.asyncio
+async def test_claims_alone_select_no_operation(card_persistence):
+    """Claims and the operation selection are independent dimensions.
+
+    A claim lets an operation pass the claim gate; it does not mean the user
+    chose every operation that claim technically opens. The create-side
+    leniency the design carried for pre-field callers — "an omitted
+    `named_service_operations` value is resolved to `"*"`" — made the omission
+    the normal path for agent and OAuth consent, which name claims and never
+    operations, so cards were born reaching a whole door.
+    """
+    service = _service(card_persistence)
+    created = await service.create_access(
+        USER, label="CI bot", resource_grants={RESOURCE: GRANTS}
+    )
+    access_id = created["access"]["access_id"]
+
+    assert await _stored(service, access_id) == ({}, [])
+    assert created["access"]["named_service_operations"] == {}
+
+
+@pytest.mark.asyncio
+async def test_an_explicit_wildcard_is_still_the_whole_offered_catalog(card_persistence):
+    """`"*"` survives as the explicit choice: everything offered right now."""
+    service = _service(card_persistence)
+    created = await service.create_access(
+        USER, label="CI bot", resource_grants={RESOURCE: GRANTS},
+        named_service_operations="*",
+    )
+
+    assert await _stored(service, created["access"]["access_id"]) == (
+        "*", ["mail", "slack"],
+    )
+
+
+@pytest.mark.asyncio
 async def test_manual_clear_survives_an_unrelated_update(card_persistence):
     service = _service(card_persistence)
     created = await service.create_access(
@@ -187,7 +222,8 @@ async def test_an_inherited_wildcard_is_frozen_into_what_it_already_meant(card_p
     """
     service = _service(card_persistence)
     created = await service.create_access(
-        USER, label="all ops", resource_grants={RESOURCE: GRANTS}
+        USER, label="all ops", resource_grants={RESOURCE: GRANTS},
+        named_service_operations="*",
     )
     access_id = created["access"]["access_id"]
 
@@ -216,7 +252,8 @@ async def test_freezing_a_wildcard_keeps_the_claims_that_same_save_adds(card_per
     """
     service = _service(card_persistence)
     created = await service.create_access(
-        USER, label="all ops", resource_grants={RESOURCE: GRANTS}
+        USER, label="all ops", resource_grants={RESOURCE: GRANTS},
+        named_service_operations="*",
     )
     access_id = created["access"]["access_id"]
     assert await _stored(service, access_id) == ("*", ["mail", "slack"])
@@ -440,9 +477,17 @@ async def test_saves_stamp_the_active_version_and_advance_the_revision(card_pers
 
 @pytest.mark.asyncio
 async def test_a_legacy_card_becomes_explicit_on_its_next_save(card_persistence):
+    """A pre-encoding record names no operations, so its save derives them.
+
+    The design resolves it from the tree the card materialized — "derive the
+    prior exact set from stored named_services" — not from a wildcard: a
+    wildcard would re-read the current catalog and hand the card whatever the
+    deployment added while it was legacy.
+    """
     service = _service(card_persistence)
     created = await service.create_access(
-        USER, label="CI bot", resource_grants={RESOURCE: GRANTS}
+        USER, label="CI bot", resource_grants={RESOURCE: GRANTS},
+        named_service_operations="*",
     )
     access_id = created["access"]["access_id"]
 
@@ -461,8 +506,8 @@ async def test_a_legacy_card_becomes_explicit_on_its_next_save(card_persistence)
         USER, access_id=access_id, resource_grants={RESOURCE: GRANTS}, label="Renamed",
     )
     selection, namespaces = await _stored(service, access_id)
-    assert selection == "*"
-    assert namespaces == ["mail", "slack"]
+    assert selection == {RESOURCE: {"slack": ["object.action", "object.search"]}}
+    assert namespaces == ["slack"]
     saved = await service._load_record(access_id, grantor_subject=USER["user_id"])
     assert saved.catalog_version
 
@@ -488,7 +533,8 @@ async def test_a_wildcard_does_not_pick_up_an_operation_added_after_it_was_issue
 
     service = _service(card_persistence)
     created = await service.create_access(
-        USER, label="all ops", resource_grants={RESOURCE: GRANTS}
+        USER, label="all ops", resource_grants={RESOURCE: GRANTS},
+        named_service_operations="*",
     )
     access_id = created["access"]["access_id"]
     assert await _stored(service, access_id) == ("*", ["mail", "slack"])
@@ -560,6 +606,7 @@ async def test_a_merging_re_consent_does_not_re_pin_a_wildcard(card_persistence)
     created = await service.create_access(
         USER, label="agent", client_id="kdcube-agent:app:merge1",
         resource_grants={RESOURCE: GRANTS},
+        named_service_operations="*",
     )
     access_id = created["access"]["access_id"]
     assert await _stored(service, access_id) == ("*", ["mail", "slack"])
@@ -626,6 +673,7 @@ async def test_a_merging_extension_adds_to_the_frozen_set_instead_of_reopening(
     created = await service.create_access(
         USER, label="agent", client_id="kdcube-agent:app:merge3",
         resource_grants={RESOURCE: GRANTS},
+        named_service_operations="*",
     )
     access_id = created["access"]["access_id"]
     assert await _stored(service, access_id) == ("*", ["mail", "slack"])
@@ -643,3 +691,290 @@ async def test_a_merging_extension_adds_to_the_frozen_set_instead_of_reopening(
     assert sorted(selection[RESOURCE]["slack"]) == [
         "object.action", "object.schema", "object.search",
     ]
+
+
+@pytest.mark.asyncio
+async def test_every_family_edits_its_authority_and_keeps_its_credential(card_persistence):
+    """The source records how the credential is managed, not who may change
+    authority.
+
+    Editing ran through a manual-only path that also blanked the record's
+    credential fields, so opening it to the other families would have destroyed
+    an agent's reusable bearer and an OAuth client's token handles. The card
+    keeps them: the design's own line is that the families' mutation surfaces
+    differ while their authority semantics do not.
+    """
+    service = _service(card_persistence)
+    seed = await service.create_access(
+        USER, label="seed", resource_grants={RESOURCE: GRANTS},
+        named_service_operations="*",
+    )
+    template = await service._load_record(
+        seed["access"]["access_id"], grantor_subject=USER["user_id"]
+    )
+
+    for source, card_id in (("agent", "agent-edit-1"), ("oauth", "oauth-edit-1")):
+        await _put(service, replace(
+            template,
+            access_id=card_id,
+            source=source,
+            card_revision=0,
+            access_token=f"at-{source}",
+            refresh_token=f"rt-{source}",
+            last_issued_at=1_780_000_000,
+        ))
+
+        saved = await service.update_access(
+            USER, access_id=card_id, resource_grants={RESOURCE: GRANTS},
+            named_service_operations={RESOURCE: {"slack": ["object.search"]}},
+        )
+        assert saved["ok"] is True, saved
+
+        record = await service._load_record(card_id, grantor_subject=USER["user_id"])
+        assert record.named_service_operations.to_stored() == {
+            RESOURCE: {"slack": ["object.search"]}
+        }
+        assert record.access_token == f"at-{source}"
+        assert record.refresh_token == f"rt-{source}"
+        assert record.last_issued_at == 1_780_000_000
+        assert record.source == source
+
+
+@pytest.mark.asyncio
+async def test_an_external_client_edit_reaches_the_named_service_dimension(card_persistence):
+    """`extend_client_access` rewrote claims and account binding only.
+
+    Its card kept whatever boundary OAuth consent left, so the one entrance an
+    external client's grant is edited through could not change the dimension the
+    catalog work is about. It resolves authority through the same path as every
+    other save now, including the catalog stamp.
+    """
+    service = _service(card_persistence)
+    seed = await service.create_access(
+        USER, label="seed", resource_grants={RESOURCE: GRANTS},
+        named_service_operations="*",
+    )
+    template = await service._load_record(
+        seed["access"]["access_id"], grantor_subject=USER["user_id"]
+    )
+    card_id = oauth_access_id(USER["user_id"], "claude", RESOURCE)
+    await _put(service, replace(
+        template,
+        access_id=card_id,
+        client_id="claude",
+        source="oauth",
+        card_revision=0,
+        catalog_version="",
+        access_token="at-claude",
+        refresh_token="rt-claude",
+    ))
+
+    result = await service.extend_client_access(
+        USER,
+        client_id="claude",
+        resource=RESOURCE,
+        claims=GRANTS,
+        named_service_operations={RESOURCE: {"slack": ["object.search"]}},
+        replace=True,
+    )
+    assert result["ok"] is True, result
+
+    record = await service._load_record(card_id, grantor_subject=USER["user_id"])
+    assert record.named_service_operations.to_stored() == {
+        RESOURCE: {"slack": ["object.search"]}
+    }
+    assert sorted((record.named_services or {}).get("namespaces") or {}) == ["slack"]
+    assert record.catalog_version
+    assert record.access_token == "at-claude"
+    assert record.refresh_token == "rt-claude"
+
+
+@pytest.mark.asyncio
+async def test_an_oauth_card_is_born_with_a_selection_and_a_catalog_version(card_persistence):
+    """`record_oauth_grant` initialised its carry-forward fields for a rotation
+    and persisted them on birth, so a first consent wrote `unknown` with no
+    catalog version — a card bounded by nothing and pinned to nothing.
+    """
+    service = _service(card_persistence)
+
+    await service.record_oauth_grant(
+        grantor_subject=USER["user_id"],
+        client_id="claude",
+        scopes=GRANTS,
+        resource=RESOURCE,
+        access_token="at",
+        refresh_token="rt",
+        named_service_operations={RESOURCE: {"slack": ["object.search"]}},
+        catalog_version="delegated_catalog_2026-08-20-00-00-00-000_aaaaaaaaaaaa",
+    )
+
+    card_id = oauth_access_id(USER["user_id"], "claude", RESOURCE)
+    record = await service._load_record(card_id, grantor_subject=USER["user_id"])
+    assert record.named_service_operations.to_stored() == {
+        RESOURCE: {"slack": ["object.search"]}
+    }
+    assert sorted((record.named_services or {}).get("namespaces") or {}) == ["slack"]
+    assert record.catalog_version == "delegated_catalog_2026-08-20-00-00-00-000_aaaaaaaaaaaa"
+
+
+@pytest.mark.asyncio
+async def test_a_refresh_rotation_writes_no_authority(card_persistence):
+    """Rotation updates credential handles only."""
+    service = _service(card_persistence)
+    await service.record_oauth_grant(
+        grantor_subject=USER["user_id"],
+        client_id="claude",
+        scopes=GRANTS,
+        resource=RESOURCE,
+        access_token="at-1",
+        refresh_token="rt-1",
+        named_service_operations={RESOURCE: {"slack": ["object.search"]}},
+        catalog_version="delegated_catalog_2026-08-20-00-00-00-000_aaaaaaaaaaaa",
+    )
+    card_id = oauth_access_id(USER["user_id"], "claude", RESOURCE)
+
+    await service.record_oauth_grant(
+        grantor_subject=USER["user_id"],
+        client_id="claude",
+        scopes=GRANTS,
+        resource=RESOURCE,
+        access_token="at-2",
+        refresh_token="rt-2",
+        named_service_operations="*",
+        catalog_version="delegated_catalog_2026-08-20-11-11-11-111_bbbbbbbbbbbb",
+    )
+
+    record = await service._load_record(card_id, grantor_subject=USER["user_id"])
+    assert record.named_service_operations.to_stored() == {
+        RESOURCE: {"slack": ["object.search"]}
+    }
+    assert record.catalog_version == "delegated_catalog_2026-08-20-00-00-00-000_aaaaaaaaaaaa"
+    assert record.access_token == "at-2"
+    assert record.refresh_token == "rt-2"
+
+
+@pytest.mark.asyncio
+async def test_an_unreadable_pre_encoding_boundary_is_not_guessed(card_persistence):
+    """Deriving would produce {} — indistinguishable from an explicit nothing.
+
+    The design refuses to guess here: the server reports
+    `migration_confirmation_required` and the record is left alone until an
+    explicit selection is submitted.
+    """
+    service = _service(card_persistence)
+    created = await service.create_access(
+        USER, label="legacy", resource_grants={RESOURCE: GRANTS},
+        named_service_operations="*",
+    )
+    access_id = created["access"]["access_id"]
+    current = await service._load_record(access_id, grantor_subject=USER["user_id"])
+    await _put(service, replace(
+        current,
+        named_service_operations=NamedServiceSelection.unknown(),
+        named_services={"namespaces": {"slack": {"tools": {}}}},
+        catalog_version="",
+    ))
+
+    refused = await service.update_access(
+        USER, access_id=access_id, resource_grants={RESOURCE: GRANTS}, label="Renamed",
+    )
+
+    assert refused["ok"] is False
+    assert refused["error"] == "migration_confirmation_required"
+    assert refused["reason"] == "materialized_boundary_names_no_operation"
+    assert refused["recovery"]["retry_same_request"] is False
+    # Nothing was rewritten.
+    stored = await service._load_record(access_id, grantor_subject=USER["user_id"])
+    assert stored.named_service_operations.is_unknown
+    assert stored.card_revision == current.card_revision
+
+    # The same card saves once the operator states what it should mean.
+    saved = await service.update_access(
+        USER, access_id=access_id, resource_grants={RESOURCE: GRANTS},
+        named_service_operations={RESOURCE: {"slack": ["object.search"]}},
+    )
+    assert saved["ok"] is True
+
+
+@pytest.mark.asyncio
+async def test_a_readable_pre_encoding_record_still_migrates_silently(card_persistence):
+    """Ambiguity is the exception; an interpretable boundary needs no operator."""
+    service = _service(card_persistence)
+    created = await service.create_access(
+        USER, label="legacy", resource_grants={RESOURCE: GRANTS},
+        named_service_operations="*",
+    )
+    access_id = created["access"]["access_id"]
+    current = await service._load_record(access_id, grantor_subject=USER["user_id"])
+    await _put(service, replace(
+        current,
+        named_service_operations=NamedServiceSelection.unknown(),
+        catalog_version="",
+    ))
+
+    saved = await service.update_access(
+        USER, access_id=access_id, resource_grants={RESOURCE: GRANTS}, label="Renamed",
+    )
+
+    assert saved["ok"] is True
+    stored = await service._load_record(access_id, grantor_subject=USER["user_id"])
+    assert stored.named_service_operations.is_exact
+
+
+@pytest.mark.asyncio
+async def test_listing_reports_the_ambiguity_without_rewriting_the_card(card_persistence):
+    service = _service(card_persistence)
+    created = await service.create_access(
+        USER, label="legacy", resource_grants={RESOURCE: GRANTS},
+        named_service_operations="*",
+    )
+    access_id = created["access"]["access_id"]
+    current = await service._load_record(access_id, grantor_subject=USER["user_id"])
+    await _put(service, replace(
+        current,
+        named_service_operations=NamedServiceSelection.unknown(),
+        named_services={"namespaces": {"slack": {"tools": {}}}},
+        catalog_version="",
+    ))
+
+    listed = await service.list_access(USER)
+    item = next(row for row in listed["items"] if row["access_id"] == access_id)
+
+    assert item["migration"]["state"] == "migration_confirmation_required"
+    stored = await service._load_record(access_id, grantor_subject=USER["user_id"])
+    assert stored.card_revision == current.card_revision
+
+
+@pytest.mark.asyncio
+async def test_a_delegate_cannot_change_the_card_that_issued_it(card_persistence):
+    """Authority is the grantor's to change, on every entrance.
+
+    The delegate would find nothing under a grantor-keyed index either, but the
+    shared mutation path makes that an explicit rule rather than a side effect
+    of how cards are indexed.
+    """
+    service = _service(card_persistence)
+    created = await service.create_access(
+        USER, label="CI bot", resource_grants={RESOURCE: GRANTS},
+        named_service_operations="*",
+    )
+    access_id = created["access"]["access_id"]
+    delegate = {"user_id": f"integration:automation:{USER['user_id']}"}
+
+    for result in (
+        await service.update_access(
+            delegate, access_id=access_id, resource_grants={RESOURCE: GRANTS},
+        ),
+        await service.create_access(
+            delegate, label="x", resource_grants={RESOURCE: GRANTS},
+        ),
+        await service.revoke_access(delegate, access_id=access_id),
+        await service.extend_client_access(
+            delegate, client_id="claude", resource=RESOURCE, claims=GRANTS,
+        ),
+    ):
+        assert result["ok"] is False
+        assert result["error"] == "delegated_access_requires_grantor"
+
+    stored = await service._load_record(access_id, grantor_subject=USER["user_id"])
+    assert stored is not None and stored.card_revision == 1

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/tests/test_named_service_selection_persistence.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/tests/test_named_service_selection_persistence.py
@@ -818,9 +818,7 @@ async def test_an_oauth_card_is_born_with_a_selection_and_a_catalog_version(card
 
 
 @pytest.mark.asyncio
-async def test_a_refresh_rotation_writes_no_authority(card_persistence):
-    """Rotation updates credential handles only."""
-    service = _service(card_persistence)
+async def _first_consent(service, *, selection, version):
     await service.record_oauth_grant(
         grantor_subject=USER["user_id"],
         client_id="claude",
@@ -828,10 +826,25 @@ async def test_a_refresh_rotation_writes_no_authority(card_persistence):
         resource=RESOURCE,
         access_token="at-1",
         refresh_token="rt-1",
-        named_service_operations={RESOURCE: {"slack": ["object.search"]}},
-        catalog_version="delegated_catalog_2026-08-20-00-00-00-000_aaaaaaaaaaaa",
+        named_service_operations=selection,
+        catalog_version=version,
     )
-    card_id = oauth_access_id(USER["user_id"], "claude", RESOURCE)
+    return oauth_access_id(USER["user_id"], "claude", RESOURCE)
+
+
+async def test_a_refresh_rotation_writes_no_authority(card_persistence):
+    """Rotation updates credential handles only.
+
+    The token endpoint separates the two: `authorization_code` carries the
+    selection and the catalog version, `refresh_token` carries neither. So a
+    rotation is an absent selection, not a resubmitted one.
+    """
+    service = _service(card_persistence)
+    card_id = await _first_consent(
+        service,
+        selection={RESOURCE: {"slack": ["object.search"]}},
+        version="delegated_catalog_2026-08-20-00-00-00-000_aaaaaaaaaaaa",
+    )
 
     await service.record_oauth_grant(
         grantor_subject=USER["user_id"],
@@ -840,8 +853,6 @@ async def test_a_refresh_rotation_writes_no_authority(card_persistence):
         resource=RESOURCE,
         access_token="at-2",
         refresh_token="rt-2",
-        named_service_operations="*",
-        catalog_version="delegated_catalog_2026-08-20-11-11-11-111_bbbbbbbbbbbb",
     )
 
     record = await service._load_record(card_id, grantor_subject=USER["user_id"])
@@ -851,6 +862,39 @@ async def test_a_refresh_rotation_writes_no_authority(card_persistence):
     assert record.catalog_version == "delegated_catalog_2026-08-20-00-00-00-000_aaaaaaaaaaaa"
     assert record.access_token == "at-2"
     assert record.refresh_token == "rt-2"
+
+
+@pytest.mark.asyncio
+async def test_a_second_consent_replaces_what_the_card_held(card_persistence):
+    """Only the newest consent counts, even when an earlier one said `"*"`.
+
+    The screen shows what is being granted, so the card must end up with what
+    was submitted; carrying the wider earlier choice forward would hand the
+    client more than the user just chose.
+    """
+    service = _service(card_persistence)
+    card_id = await _first_consent(
+        service,
+        selection="*",
+        version="delegated_catalog_2026-08-20-00-00-00-000_aaaaaaaaaaaa",
+    )
+
+    await service.record_oauth_grant(
+        grantor_subject=USER["user_id"],
+        client_id="claude",
+        scopes=GRANTS,
+        resource=RESOURCE,
+        access_token="at-2",
+        refresh_token="rt-2",
+        named_service_operations={RESOURCE: {"slack": ["object.search"]}},
+        catalog_version="delegated_catalog_2026-08-20-11-11-11-111_bbbbbbbbbbbb",
+    )
+
+    record = await service._load_record(card_id, grantor_subject=USER["user_id"])
+    assert record.named_service_operations.to_stored() == {
+        RESOURCE: {"slack": ["object.search"]}
+    }
+    assert record.catalog_version == "delegated_catalog_2026-08-20-11-11-11-111_bbbbbbbbbbbb"
 
 
 @pytest.mark.asyncio

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/hub/provider_impl.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/hub/provider_impl.py
@@ -256,12 +256,21 @@ class ConnectionHubProvider(ConnectionsProviderBase):
         service = self._automation_access_factory()
         if service is None:
             return {"governed": False}
-        return await service.agent_namespace_grant_state(
-            grantor_subject=user_id,
-            client_id=client_id,
-            namespace=namespace,
-            operation=operation,
+        from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.catalog.resolver import (
+            CatalogUnavailable,
         )
+
+        try:
+            return await service.agent_namespace_grant_state(
+                grantor_subject=user_id,
+                client_id=client_id,
+                namespace=namespace,
+                operation=operation,
+            )
+        except CatalogUnavailable as exc:
+            # Unknown current authority is unavailability, and the caller must
+            # be able to tell it from "nothing to gate".
+            return {"unavailable": exc.reason or "catalog_unavailable"}
 
     async def _refresh_tokens(
         self,

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/mcp_consent.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/mcp_consent.py
@@ -81,6 +81,10 @@ class MCPConsentRequired(Exception):
         }
         if c.get("agent_client_id"):
             consent_block["agent_client_id"] = c["agent_client_id"]
+        if c.get("namespace"):
+            consent_block["namespace"] = c["namespace"]
+        if c.get("operation"):
+            consent_block["operation"] = c["operation"]
         if c.get("grant"):
             consent_block["grant"] = c["grant"]
         return {
@@ -141,6 +145,8 @@ def mcp_consent_from_denial(
     connection_hub_url: str = "",
     tool_name: str = "",
     agent_client_id: str = "",
+    namespace: str = "",
+    operation: str = "",
 ) -> MCPConsentRequired:
     """Build the `MCPConsentRequired` from a KDCube-MCP denial + the connection's
     declared claims. The claims come from the caller (the `kind: mcp` connection's
@@ -149,14 +155,21 @@ def mcp_consent_from_denial(
     ``agent_client_id`` (the calling agent's ``kdcube-agent:<app>:<agent>``
     identity) makes the demand actionable: the payload carries a ``grant`` block —
     the Connection Hub operation + args — a consent surface POSTs to grant THIS
-    agent the claims, distinct from a connect-an-account flow."""
+    agent the claims, distinct from a connect-an-account flow.
+
+    ``namespace`` / ``operation`` name the inner capability the call wanted.
+    Approval grants that operation, not every operation its claims allow."""
     claim_list = [str(c).strip() for c in (claims or []) if str(c).strip()]
     label = tool_name or resource.rsplit("/", 1)[-1] or "this tool"
     claims_str = ", ".join(claim_list) or "the required access"
+    asked = f"the operation {operation}" if operation else ""
+    if asked and claim_list:
+        asked = f"{asked} and {claims_str}"
+    asked = asked or claims_str
     agent_message = (
-        f"{label} needs the user's consent to {claims_str}. It is blocked until the "
+        f"{label} needs the user's consent to {asked}. It is blocked until the "
         f"user grants it in Connection Hub (Delegated by KDCube). Tell the user you "
-        f"need their approval for {claims_str}; do not retry until they grant it."
+        f"need their approval for {asked}; do not retry until they grant it."
     )
     consent: Dict[str, Any] = {
         "code": CONSENT_NEEDED_CODE,
@@ -168,13 +181,24 @@ def mcp_consent_from_denial(
         consent["connection_hub_url"] = connection_hub_url
     if tool_name:
         consent["tool_name"] = tool_name
+    if namespace:
+        consent["namespace"] = namespace
+    if operation:
+        consent["operation"] = operation
     if agent_client_id:
         # The one-click grant action for this demand (user grants THIS agent).
         consent["kind"] = CONSENT_KIND_AGENT_GRANT
         consent["agent_client_id"] = agent_client_id
+        grant_payload: Dict[str, Any] = {
+            "client_id": agent_client_id,
+            "resource": resource,
+            "claims": claim_list,
+        }
+        if namespace and operation:
+            grant_payload["named_service_operations"] = {namespace: [operation]}
         consent["grant"] = {
             "operation": AGENT_GRANT_CREATE_OPERATION,
-            "payload": {"client_id": agent_client_id, "resource": resource, "claims": claim_list},
+            "payload": grant_payload,
         }
     return MCPConsentRequired(
         resource=resource, claims=claim_list, consent=consent, agent_message=agent_message,

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/tests/test_connection_hub_auth_surface.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/tests/test_connection_hub_auth_surface.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 from starlette.requests import Request
 
 from kdcube_ai_app.apps.chat.sdk.solutions.connections.authenticators.models import AuthenticatedRequest
@@ -26,14 +28,36 @@ class _GrantStore:
         return self.record
 
 
+PLATFORM_CONNECTIONS = {
+    "delegated_credentials": {
+        "oauth": {
+            "enabled": True,
+            "resources": [
+                {
+                    "resource": PLATFORM_RESOURCE_PATTERN,
+                    "grants": ["devops:deploy"],
+                    "tools": {"platform_admin_redeploy": {"grants": ["devops:deploy"]}},
+                },
+            ],
+        },
+    },
+}
+
+
 class _AppState:
-    def __init__(self, grant_record=None):
+    def __init__(self, grant_record=None, connections=None):
         self.oauth_grant_store = _GrantStore(grant_record)
+        if connections is not None:
+            from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.oauth.tests.helpers import (
+                bind_delegated_catalog,
+            )
+
+            bind_delegated_catalog(SimpleNamespace(state=self), connections)
 
 
 class _App:
-    def __init__(self, grant_record=None):
-        self.state = _AppState(grant_record)
+    def __init__(self, grant_record=None, connections=None):
+        self.state = _AppState(grant_record, connections)
 
 
 def _authority(
@@ -213,7 +237,7 @@ async def test_connection_hub_surface_accepts_delegated_bearer_for_platform_reso
         _request(
             {"Authorization": "Bearer automation-token"},
             path="/api/platform/admin/redeploy",
-            app=_App(grant_record),
+            app=_App(grant_record, connections=PLATFORM_CONNECTIONS),
         ),
         RequestContext(
             client_ip="127.0.0.1",

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/named_services_providers/tests/test_agent_grant_gate.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/named_services_providers/tests/test_agent_grant_gate.py
@@ -1,0 +1,126 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Elena Viter
+
+"""The native named-service gate keeps three outcomes apart.
+
+Open when the boundary does not apply, refuse without asking for consent when
+the deployment no longer offers the capability, and refuse retryably when
+current authority cannot be established.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from kdcube_ai_app.apps.chat.sdk.infra import bundle_operations
+from kdcube_ai_app.apps.chat.sdk.runtime import comm_ctx
+from kdcube_ai_app.apps.chat.sdk.solutions.named_services_providers import tools
+
+AGENT_IDENTITY = {"user_id": "platform-user-1", "bundle_id": "app@1-0"}
+REMOVED = {
+    "ok": False,
+    "error": {
+        "code": "delegated_capability_no_longer_available",
+        "message": "gone",
+        "where": "delegated_catalog.authorization",
+        "retryable": False,
+    },
+    "ret": {"requested_capability": {"kind": "named_service_operation", "namespace": "mail"}},
+}
+
+
+def _bind_agent_turn(monkeypatch, *, agent: bool = True):
+    monkeypatch.setattr(
+        comm_ctx, "get_current_user_identity", lambda: dict(AGENT_IDENTITY) if agent else {}
+    )
+    monkeypatch.setattr(
+        comm_ctx,
+        "get_current_request_context",
+        lambda: SimpleNamespace(event=SimpleNamespace(agent_id="lg-react" if agent else "")),
+    )
+
+
+def _bind_hub(monkeypatch, answer):
+    async def _call(**_kwargs):
+        if isinstance(answer, Exception):
+            raise answer
+        return SimpleNamespace(value={"ok": True, "ret": {"object": answer}})
+
+    monkeypatch.setattr(bundle_operations, "call_bundle_named_service", _call)
+
+
+def _forbid_consent(monkeypatch):
+    from kdcube_ai_app.apps.chat.sdk.solutions.connections import mcp_consent
+
+    async def _announce(_consent):
+        raise AssertionError("a removed capability must not ask for consent")
+
+    monkeypatch.setattr(mcp_consent, "announce_agent_consent", _announce)
+
+
+@pytest.mark.asyncio
+async def test_a_non_agent_turn_is_not_gated(monkeypatch):
+    _bind_agent_turn(monkeypatch, agent=False)
+
+    assert await tools._agent_grant_gate("mail", "object.search", "search") is None
+
+
+@pytest.mark.asyncio
+async def test_a_granted_capability_opens_the_gate(monkeypatch):
+    _bind_agent_turn(monkeypatch)
+    _bind_hub(monkeypatch, {"governed": True, "granted": True, "resource": "r", "claims": []})
+
+    assert await tools._agent_grant_gate("mail", "object.search", "search") is None
+
+
+@pytest.mark.asyncio
+async def test_an_ungoverned_namespace_opens_the_gate(monkeypatch):
+    _bind_agent_turn(monkeypatch)
+    _bind_hub(monkeypatch, {"governed": False})
+
+    assert await tools._agent_grant_gate("calendar", "object.search", "search") is None
+
+
+@pytest.mark.asyncio
+async def test_a_removed_capability_is_refused_without_asking_for_consent(monkeypatch):
+    _bind_agent_turn(monkeypatch)
+    _forbid_consent(monkeypatch)
+    _bind_hub(
+        monkeypatch, {"governed": True, "granted": False, "removed": REMOVED}
+    )
+
+    result = await tools._agent_grant_gate("mail", "object.search", "search")
+
+    assert result is not None
+    assert result["error"]["code"] == "delegated_capability_no_longer_available"
+    assert result["error"]["retryable"] is False
+
+
+@pytest.mark.asyncio
+async def test_an_unavailable_catalog_refuses_retryably(monkeypatch):
+    _bind_agent_turn(monkeypatch)
+    _bind_hub(monkeypatch, {"unavailable": "active_catalog_not_registered"})
+
+    result = await tools._agent_grant_gate("mail", "object.search", "search")
+
+    assert result is not None
+    assert result["error"]["code"] == "temporarily_unavailable"
+    assert result["error"]["retryable"] is True
+    assert result["ret"]["reason"] == "active_catalog_not_registered"
+    assert result["ret"]["namespace"] == "mail"
+
+
+@pytest.mark.asyncio
+async def test_an_unreachable_hub_refuses_instead_of_failing_open(monkeypatch):
+    """The boundary applies and cannot be read: the call must not proceed on
+    the connected-account boundary alone."""
+    _bind_agent_turn(monkeypatch)
+    _bind_hub(monkeypatch, RuntimeError("hub unreachable"))
+
+    result = await tools._agent_grant_gate("mail", "object.search", "search")
+
+    assert result is not None
+    assert result["error"]["code"] == "temporarily_unavailable"
+    assert result["ret"]["reason"] == "agent_grant_check_unavailable"

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/named_services_providers/tests/test_named_service_consent_demand.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/named_services_providers/tests/test_named_service_consent_demand.py
@@ -312,3 +312,68 @@ async def test_menu_inventory_renders_even_when_coverage_hangs(monkeypatch):
     assert out["tools"][0].get("consent") is None
     assert out["tools"][0]["tools"][0].get("consent") is None
     assert any("without consent state" in msg for _lvl, msg in logged)
+
+
+@pytest.mark.asyncio
+async def test_a_boundary_refusal_asks_for_the_operation_it_was_refused(monkeypatch):
+    """The card holds the claims; only its own boundary excludes the operation.
+
+    A claims-shaped demand asks for consent that is already given, deduplicates
+    away, and leaves the agent telling the user to wait for a permission they
+    granted. The demand names the operation, and approval grants that one.
+    """
+    import kdcube_ai_app.apps.chat.sdk.infra.bundle_operations as bundle_operations
+    import kdcube_ai_app.apps.chat.sdk.runtime.comm_ctx as comm_ctx
+    import kdcube_ai_app.apps.chat.sdk.solutions.connections.mcp_consent as mcp_consent
+    from kdcube_ai_app.apps.chat.sdk.solutions.named_services_providers.tools import (
+        _agent_grant_gate,
+    )
+
+    resource = "*/kdcube-services@1-0/public/mcp/named_services*"
+    monkeypatch.setattr(
+        comm_ctx, "get_current_user_identity",
+        lambda: {"user_id": "u1", "bundle_id": "workspace@1-0", "tenant_id": "t", "project_id": "p"},
+    )
+    monkeypatch.setattr(
+        comm_ctx, "get_current_request_context",
+        lambda: SimpleNamespace(event=SimpleNamespace(agent_id="main")),
+    )
+
+    state = {
+        "governed": True,
+        "granted": False,
+        "missing_claims": [],
+        "claims": ["memories:read", "named_services:use"],
+        "resource": resource,
+        "client_id": "kdcube-agent:workspace@1-0:main",
+        "account_scope": {},
+        "not_granted": {
+            "ok": False,
+            "error": {"code": "delegated_capability_not_granted", "retryable": False},
+            "ret": {"requested_capability": {"namespace": "mem", "operation": "object.search"}},
+        },
+    }
+
+    async def fake_call(**kwargs):
+        return SimpleNamespace(value={"ok": True, "ret": {"object": state}})
+
+    monkeypatch.setattr(bundle_operations, "call_bundle_named_service", fake_call)
+
+    announced: list[Any] = []
+
+    async def fake_announce(consent):
+        announced.append(consent)
+
+    monkeypatch.setattr(mcp_consent, "announce_agent_consent", fake_announce)
+
+    result = await _agent_grant_gate("mem", "object.search", "named_services_search")
+
+    assert result["error"]["code"] == "delegated_capability_not_granted"
+    grant = result["consent"]["grant"]["payload"]
+    assert grant["named_service_operations"] == {"mem": ["object.search"]}
+    # No claim is missing, so the demand asks for the operation alone.
+    assert grant["claims"] == []
+    assert len(announced) == 1
+    assert announced[0].consent["operation"] == "object.search"
+    assert announced[0].consent["namespace"] == "mem"
+    assert "object.search" in announced[0].agent_message

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/named_services_providers/tools.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/named_services_providers/tools.py
@@ -560,6 +560,25 @@ def _endpoint(namespace: str) -> NamedServiceEndpoint | Dict[str, Any]:
     return NamedServiceEndpoint.from_provider_configs(provider_configs, namespace=base_ns)
 
 
+def _clean_text(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _gate_unavailable(reason: str, namespace: str, operation: str) -> Dict[str, Any]:
+    """Current authority could not be established: refuse, retryably.
+
+    An agent turn whose delegated boundary cannot be read must not proceed on
+    the connected-account boundary alone.
+    """
+    from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.catalog.authorization import (
+        catalog_unavailable_denial,
+    )
+
+    payload = catalog_unavailable_denial(reason)
+    payload["ret"].update({"namespace": namespace, "operation": operation})
+    return payload
+
+
 async def _agent_grant_gate(base_ns: str, operation: str, tool_name: str) -> Dict[str, Any] | None:
     """The per-agent delegated-by gate for NATIVE named-service calls.
 
@@ -569,10 +588,18 @@ async def _agent_grant_gate(base_ns: str, operation: str, tool_name: str) -> Dic
     — `kdcube-agent:<app>:<agent>`, the same client entity a hosted MCP
     consumer is — must hold the user's delegated-by grant for it. Pending →
     the consent demand rises at THIS attempt (demand-driven per tool) and the
-    agent gets the explainable consent result. Applies only in agent turns;
-    fails OPEN on operational misses (no caller bound, hub unreachable,
-    ungoverned namespace) so non-agent surfaces and legacy deployments keep
-    their existing connected-account-only boundary."""
+    agent gets the explainable consent result.
+
+    Three outcomes are kept apart:
+
+        not an agent turn, or nothing publishes the namespace  -> open
+        the catalog no longer offers the capability            -> refuse, and
+                                                                  never ask for
+                                                                  consent
+        current authority cannot be established                -> refuse,
+                                                                  retryable
+    """
+    agent_turn = False
     try:
         from kdcube_ai_app.apps.chat.sdk.runtime.comm_ctx import (
             get_current_request_context,
@@ -590,6 +617,7 @@ async def _agent_grant_gate(base_ns: str, operation: str, tool_name: str) -> Dic
             agent_id = ""
         if not user_id or not bundle_id or not agent_id:
             return None  # not an agent turn — this boundary does not apply
+        agent_turn = True
         from kdcube_ai_app.apps.chat.sdk.infra.bundle_operations import call_bundle_named_service
         from kdcube_ai_app.apps.chat.sdk.solutions.connections.connection_edges import (
             DEFAULT_CONNECTION_HUB_BUNDLE_ID,
@@ -617,8 +645,21 @@ async def _agent_grant_gate(base_ns: str, operation: str, tool_name: str) -> Dic
         value = getattr(result, "value", None)
         response = NamedServiceResponse.coerce(value) if value is not None else None
         if response is None or not response.ok:
-            return None
+            return _gate_unavailable("agent_grant_check_failed", base_ns, operation)
         state = dict(response.object or {})
+        unavailable = _clean_text(state.get("unavailable"))
+        if unavailable:
+            return _gate_unavailable(unavailable, base_ns, operation)
+        removed = state.get("removed")
+        if isinstance(removed, Mapping):
+            # The deployment no longer offers this capability. Consent cannot
+            # restore it, so no demand is raised.
+            LOGGER.warning(
+                "Named-service agent gate: capability no longer available\n"
+                "  namespace: %s\n  operation: %s\n  tool: %s",
+                base_ns, operation, tool_name,
+            )
+            return dict(removed)
         # Bind the agent's per-provider account scope for the connected-account
         # resolver — whether or not the call proceeds — so a granted native call
         # restricts to the account(s) this agent may use (parity with the MCP
@@ -713,8 +754,16 @@ async def _agent_grant_gate(base_ns: str, operation: str, tool_name: str) -> Dic
         )
         return consent.to_tool_result()
     except Exception:
-        LOGGER.info("Named-service agent gate unavailable; failing open.", exc_info=True)
-        return None
+        if not agent_turn:
+            # The boundary never applied: nothing was refused.
+            LOGGER.info("Named-service agent gate not applicable.", exc_info=True)
+            return None
+        LOGGER.warning(
+            "Named-service agent gate could not establish current authority\n"
+            "  namespace: %s\n  operation: %s",
+            base_ns, operation, exc_info=True,
+        )
+        return _gate_unavailable("agent_grant_check_unavailable", base_ns, operation)
 
 
 async def _call(

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/named_services_providers/tools.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/named_services_providers/tools.py
@@ -681,18 +681,35 @@ async def _agent_grant_gate(base_ns: str, operation: str, tool_name: str) -> Dic
         set_agent_identity(client_id=client_id, resource=str(state.get("resource") or ""))
         if not state.get("governed") or state.get("granted"):
             return None
+        not_granted = state.get("not_granted")
+        if isinstance(not_granted, Mapping):
+            # The card holds the claims and the catalog still offers this; only
+            # the card's own boundary excludes the operation. A claims demand
+            # here asks for consent that is already given, so the caller loops
+            # and the user is told to wait for a permission they granted. The
+            # remedy is a card edit, and the denial says so.
+            LOGGER.warning(
+                "Named-service agent gate: operation not covered by the card\n"
+                "  namespace: %s\n  operation: %s\n  tool: %s\n  agent_client: %s",
+                base_ns, operation, tool_name, client_id,
+            )
+            return dict(not_granted)
         # Demand ordering (operator ruling 2026-07-25): when this operation is
         # account-backed and the user has ZERO connected accounts on the
         # backing provider, the CONNECT demand leads — the guided plan ends in
         # the agent-grant hand-off. Granting the agent first would bind
         # nothing. Fail-safe: any state-read failure keeps the agent-grant
         # demand below.
+        gate_claims = [str(c) for c in (state.get("claims") or [])]
+        # What the card actually lacks, not everything the operation declares:
+        # a demand that re-asks for held claims is deduplicated away and the
+        # caller learns nothing.
+        missing_claims = [str(c) for c in (state.get("missing_claims") or [])] or gate_claims
         try:
             from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.consent_denial import (
                 connect_first_denial_for_identity,
             )
 
-            gate_claims = [str(c) for c in (state.get("claims") or [])]
             connect_first = await connect_first_denial_for_identity(
                 grantor_user_id=user_id,
                 agent_client_id=client_id,
@@ -701,7 +718,7 @@ async def _agent_grant_gate(base_ns: str, operation: str, tool_name: str) -> Dic
                 tool=tool_name,
                 operation=operation,
                 required=gate_claims,
-                missing=gate_claims,
+                missing=missing_claims,
                 tenant=str(identity.get("tenant_id") or ""),
                 project=str(identity.get("project_id") or ""),
             )
@@ -714,11 +731,12 @@ async def _agent_grant_gate(base_ns: str, operation: str, tool_name: str) -> Dic
             connect_first = None
         LOGGER.info(
             "[agent-gate] namespace=%s operation=%s user=%s tenant=%s project=%s gate_claims=%s "
-            "connect_first=%s",
+            "missing_claims=%s connect_first=%s",
             base_ns, operation, user_id or "<EMPTY>",
             str(identity.get("tenant_id") or "") or "<EMPTY>",
             str(identity.get("project_id") or "") or "<EMPTY>",
-            gate_claims, "SET" if connect_first is not None else "None(->agent-grant)",
+            gate_claims, missing_claims,
+            "SET" if connect_first is not None else "None(->agent-grant)",
         )
         if connect_first is not None:
             from kdcube_ai_app.apps.chat.sdk.solutions.named_services_providers.consent import (
@@ -742,7 +760,7 @@ async def _agent_grant_gate(base_ns: str, operation: str, tool_name: str) -> Dic
         consent = mcp_consent_from_denial(
             {"status": 403, "reason": "authority_mismatch"},
             resource=str(state.get("resource") or ""),
-            claims=[str(c) for c in (state.get("claims") or [])],
+            claims=missing_claims,
             tool_name=base_ns,
             agent_client_id=client_id,
         )

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/named_services_providers/tools.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/named_services_providers/tools.py
@@ -681,30 +681,44 @@ async def _agent_grant_gate(base_ns: str, operation: str, tool_name: str) -> Dic
         set_agent_identity(client_id=client_id, resource=str(state.get("resource") or ""))
         if not state.get("governed") or state.get("granted"):
             return None
+        gate_claims = [str(c) for c in (state.get("claims") or [])]
+        # What the card actually lacks, not everything the operation declares:
+        # a demand that re-asks for held claims is deduplicated away and the
+        # caller learns nothing.
+        missing_claims = [str(c) for c in (state.get("missing_claims") or [])] or gate_claims
         not_granted = state.get("not_granted")
         if isinstance(not_granted, Mapping):
-            # The card holds the claims and the catalog still offers this; only
-            # the card's own boundary excludes the operation. A claims demand
-            # here asks for consent that is already given, so the caller loops
-            # and the user is told to wait for a permission they granted. The
-            # remedy is a card edit, and the denial says so.
+            # Claims are held; only the card's own boundary excludes the
+            # operation. The demand names it, and approval grants that one.
+            from kdcube_ai_app.apps.chat.sdk.solutions.connections.mcp_consent import (
+                announce_agent_consent as _announce,
+                mcp_consent_from_denial as _consent_from_denial,
+            )
+
+            boundary_consent = _consent_from_denial(
+                {"status": 403, "reason": "capability_not_granted"},
+                resource=str(state.get("resource") or ""),
+                claims=[str(c) for c in (state.get("missing_claims") or [])],
+                tool_name=base_ns,
+                agent_client_id=client_id,
+                namespace=base_ns,
+                operation=operation,
+            )
+            await _announce(boundary_consent)
             LOGGER.warning(
                 "Named-service agent gate: operation not covered by the card\n"
                 "  namespace: %s\n  operation: %s\n  tool: %s\n  agent_client: %s",
                 base_ns, operation, tool_name, client_id,
             )
-            return dict(not_granted)
+            refused = dict(not_granted)
+            refused["consent"] = boundary_consent.consent
+            return refused
         # Demand ordering (operator ruling 2026-07-25): when this operation is
         # account-backed and the user has ZERO connected accounts on the
         # backing provider, the CONNECT demand leads — the guided plan ends in
         # the agent-grant hand-off. Granting the agent first would bind
         # nothing. Fail-safe: any state-read failure keeps the agent-grant
         # demand below.
-        gate_claims = [str(c) for c in (state.get("claims") or [])]
-        # What the card actually lacks, not everything the operation declares:
-        # a demand that re-asks for held claims is deduplicated away and the
-        # caller learns nothing.
-        missing_claims = [str(c) for c in (state.get("missing_claims") or [])] or gate_claims
         try:
             from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.consent_denial import (
                 connect_first_denial_for_identity,
@@ -763,6 +777,8 @@ async def _agent_grant_gate(base_ns: str, operation: str, tool_name: str) -> Dic
             claims=missing_claims,
             tool_name=base_ns,
             agent_client_id=client_id,
+            namespace=base_ns,
+            operation=operation,
         )
         await announce_agent_consent(consent)
         LOGGER.info(

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/tests/test_mcp_delegated_bearer_auth.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/tests/test_mcp_delegated_bearer_auth.py
@@ -239,9 +239,7 @@ from kdcube_ai_app.apps.chat.sdk.solutions.connections.authentication_surface im
     ConnectionHubAuthenticationSurface,
 )
 from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.oauth.config import (
-    OAuthDelegatedClientConfig,
-    OAuthDelegatedResourceConfig,
-    OAuthDelegatedToolConfig,
+    oauth_delegated_config_from_connections,
 )
 
 
@@ -316,33 +314,49 @@ _NAMED_SERVICES_PATTERN = "*/kdcube-services@1-0/public/mcp/named_services*"
 
 
 def _catalog():
-    wildcard = OAuthDelegatedResourceConfig(
-        resource="*", grants=("platform:admin",), tools=(), admin_only=True
+    """A real config, parsed by the reader the request path uses."""
+    return oauth_delegated_config_from_connections(
+        {
+            "delegated_credentials": {
+                "oauth": {
+                    "resources": [
+                        # Wildcard declared FIRST: order must not matter.
+                        {
+                            "resource": "*",
+                            "grants": ["platform:admin"],
+                            "admin_only": True,
+                        },
+                        {
+                            "resource": _NAMED_SERVICES_PATTERN,
+                            "grants": ["named_services:use"],
+                            "tools": {
+                                "named_services_list": {
+                                    "label": "List",
+                                    "grants": ["named_services:use"],
+                                },
+                                "named_services_action": {
+                                    "label": "Action",
+                                    "grants": ["named_services:use"],
+                                },
+                            },
+                        },
+                    ],
+                }
+            }
+        }
     )
-    specific = OAuthDelegatedResourceConfig(
-        resource=_NAMED_SERVICES_PATTERN,
-        grants=("named_services:use",),
-        tools=(
-            OAuthDelegatedToolConfig(name="named_services_list", label="List", grants=("named_services:use",)),
-            OAuthDelegatedToolConfig(name="named_services_action", label="Action", grants=("named_services:use",)),
-        ),
-    )
-    # Wildcard declared FIRST: order must not matter for the preference.
-    return SimpleNamespace(resources=(wildcard, specific))
 
 
 def test_specific_row_beats_wildcard():
-    cfg = _catalog()
-    row = OAuthDelegatedClientConfig.resource_config(
-        cfg, "https://host/api/integrations/bundles/t/p/kdcube-services@1-0/public/mcp/named_services"
+    row = _catalog().resource_config(
+        "https://host/api/integrations/bundles/t/p/kdcube-services@1-0/public/mcp/named_services"
     )
     assert row is not None and row.resource == _NAMED_SERVICES_PATTERN
     assert row.admin_only is False  # the specific row keeps its own semantics
 
 
 def test_wildcard_serves_only_the_unmatched():
-    cfg = _catalog()
-    row = OAuthDelegatedClientConfig.resource_config(
-        cfg, "https://host/api/integrations/bundles/t/p/press@2026-08-16/mcp/press"
+    row = _catalog().resource_config(
+        "https://host/api/integrations/bundles/t/p/press@2026-08-16/mcp/press"
     )
     assert row is not None and row.resource == "*" and row.admin_only is True


### PR DESCRIPTION
## Summary

- persist immutable delegated-card revisions and current pointers outside Redis
- publish durable versioned delegated catalogs with a rebuildable active projection
- preserve explicit empty, wildcard, exact, and legacy named-service policy states
- expose catalog drift and reconcile versioned card edits
- clamp managed delegated calls and KDCube Services listings to the active catalog
- rebuild live card and grantor-index projections from durable state

## Verification

- real-Redis focused suite: 510 passed
- Connection Hub bundle-local suite: 14 passed
- Connection Hub widget typecheck and production build: passed
- KDCube Services catalog/current-card additions: 17 passed
- diff whitespace check: passed

Known local baseline failures reproduce on current main: the generic bundle suite assumes LangGraph on the service-only Connection Hub entrypoint, and this checkout has an older MCP package without MCPServer.

## Issues

Relates to #222, #224, #225, and #230.

#225 remains open for the common per-invocation named-service admission boundary. #230 retains final deployed/live verification acceptance.