### PR TITLE
Delegated card authority is clamped to the active catalog

### DIFF
--- a/app/ai-app/docs/arch/delegated-authority-and-admission-README.md
+++ b/app/ai-app/docs/arch/delegated-authority-and-admission-README.md
@@ -308,10 +308,11 @@ The relay selector contains identifiers and provenance. The target owns the
 card/catalog lookup and account binding. Raw cards, catalogs, account scopes,
 and credentials stay in their owning trusted services.
 
-The Connection Hub lookup is Redis-first. Durable storage participates when a
-validated serving projection must be restored. Relay retries use one message
-id; the target records the completed outcome, redelivery returns that outcome,
-and the provider executes once per message id.
+The Connection Hub lookup for one card by `access_id` is Redis-first. Durable
+storage participates when a validated serving projection must be restored, and
+decides membership when a grantor's cards are listed. Relay retries use one
+message id; the target records the completed outcome, redelivery returns that
+outcome, and the provider executes once per message id.
 
 ## Invocation Boundaries
 

--- a/app/ai-app/docs/sdk/solutions/connections/delegated-cards/delegated-cards-README.md
+++ b/app/ai-app/docs/sdk/solutions/connections/delegated-cards/delegated-cards-README.md
@@ -648,6 +648,12 @@ records. An already-issued bearer therefore sees revoked current state on its
 next invocation. An invocation that already received its singular admission
 decision completes under that decision.
 
+If durable revocation commits but publishing its tombstone or index state
+fails, source-specific session/token invalidation still runs. The operation
+then returns a retryable `503 delegated_card_serving_state_unavailable` naming
+the committed card; it does not report that revocation failed or leave the
+credential cleanup behind the failed serving-state write.
+
 Legacy bindings without `registry_access_id` retain embedded-snapshot semantics
 for the card's own facts; the active-catalog intersection still applies to them.
 
@@ -752,7 +758,9 @@ change detection, deduplication, and integrity validation. It does not create a
 second catalog shape. Publication copies current `connections`, enters a shared
 critical section, rereads and rehashes the mapping inside that section, writes
 the immutable version, and atomically replaces complete `active.json`. The
-version name combines a sortable UTC timestamp with a content-hash suffix.
+shared-operation signature is written from that same in-section hash, not from
+the snapshot captured before the lock. The version name combines a sortable
+UTC timestamp with a content-hash suffix.
 
 Durable storage and request serving have one clear boundary:
 

--- a/app/ai-app/docs/sdk/solutions/connections/delegated-cards/delegated-cards-README.md
+++ b/app/ai-app/docs/sdk/solutions/connections/delegated-cards/delegated-cards-README.md
@@ -135,16 +135,23 @@ installs the new Redis projection. A cache miss loads the durable current
 revision and repopulates Redis only when the card is active and unexpired. The
 conditional Redis installer compares `card_revision`: delayed recovery cannot
 overwrite a newer revision, an updating marker, or a revoked tombstone. The
-mutation finalizer may replace only the marker carrying its own mutation id.
+mutation finalizer may replace the marker carrying its own mutation id, or an
+ordinary projection whose revision it strictly supersedes — a read-through
+refills the key when the marker's residency lapses before the commit completes.
+It never displaces another mutation's marker, a revoked tombstone, or an equal
+or newer revision.
 
 Expiration deletes only the Redis projection. The durable revision remains and
 `expires_at` prevents cache restoration or use. Revocation commits a new
 durable `revoked` revision before live credential cleanup; it does not delete
-history. Normal active list/open is Redis-first: it reads the expiry-scored
-grantor index and current live-card projections, then computes drift against
-Redis-cached `active.json`. The grantor index has no fixed seven-day expiry;
-expired members are pruned by score. If the index or a projection is missing,
-Connection Hub rebuilds it from durable `current.json` and the referenced
+history. Open is Redis-first: it reads the live-card projection by `access_id`
+and computes drift against Redis-cached `active.json`. List decides membership
+from durable storage on every call, because a partially lost index cannot be
+detected without reading it; the grantor index accelerates discovery and carries
+the expiry scores. It has no fixed seven-day expiry; expired members are pruned
+by score. Every candidate is resolved through the card cache/store: one that no
+longer resolves is pruned, and a durable member the index lost is re-admitted.
+A missing projection is rebuilt from durable `current.json` and the referenced
 timestamped revision, repopulating only active, unexpired cards. Retention of
 card history is an explicit administrative policy separate from authorization
 TTL.
@@ -762,10 +769,13 @@ Redis serving projection
 ```
 
 There is no process catalog cache. `on_app_deploy` already owns the effective
-`connections` object in memory. It writes the durable version and complete
-`active.json`, caches the immutable version in Redis, and atomically caches the
-complete active document. A matching durable version is not enough to declare
-deployment ready: the Redis active document must also be present. If a cache
+`connections` object in memory, and re-reads it inside the shared critical
+section before publishing, so a publisher that captured an earlier generation
+registers what is current rather than its own snapshot under a later version
+stamp. It writes the durable version and complete `active.json`, caches the
+immutable version in Redis, and atomically caches the complete active document.
+A matching durable version is not enough to declare deployment ready: the Redis
+active document must also be present. If a cache
 entry later expires, the relevant request uses the validated durable
 read-through and stores it again with the configured TTL.
 
@@ -872,6 +882,13 @@ if either the card or catalog changed after the editor loaded. Otherwise the
 server prunes stale selections, validates every survivor against the active
 catalog, rebuilds `operations` and `named_services`, increments
 `card_revision`, and stamps the active `catalog_version` atomically.
+
+Create and Save write the durable revision before the projection, the grantor
+index, and the credential handles. A failure in any of those three returns
+`503 delegated_card_serving_state_unavailable` and names the `access_id`: the
+committed revision is the authority and a read that misses its projection
+reloads it, but the caller's own step did not complete, so a client holding
+credential material it never received can name the card that exists without it.
 
 Runtime applies the same ceiling before Save:
 

--- a/app/ai-app/docs/sdk/solutions/connections/delegated-cards/delegated-cards-README.md
+++ b/app/ai-app/docs/sdk/solutions/connections/delegated-cards/delegated-cards-README.md
@@ -899,6 +899,19 @@ effective named operations      = stored selections intersect active namespace o
 effective account-backed access = stored account_scope checked against current requirements
 ```
 
+What each row bounds, when its block is empty or absent:
+
+| Dimension | Rule |
+| --- | --- |
+| Resource claims | Bounded by the row's `grants`, which the parser derives from its tools and namespace operations when they are not written. A row that publishes no claim publishes none. |
+| Outer operations | The all-resource row `*` carries no ceiling: its operations come from endpoint policy, not the catalog, and it answers only a card whose own selector is `*`. Every other row is bounded by the tools it publishes, and a block that was emptied or deleted publishes none. |
+| Named-service operations | Bounded by the published namespaces always. An absent or empty block publishes nothing; unlike outer tools there is no second source for an inner operation. |
+
+Emptying a block and deleting it are one withdrawal written two ways, and the
+guard answers them identically. Drift reads each dimension the same way the
+guard does, so a capability the deployment withdrew is both refused at the call
+and shown on the card as repairable.
+
 A governed request returns different structured outcomes for policy change and
 catalog failure:
 

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/proc/app_deployment/coordinator.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/proc/app_deployment/coordinator.py
@@ -10,7 +10,7 @@ import inspect
 import json
 import pathlib
 from datetime import datetime, timezone
-from typing import Any, Mapping
+from typing import Any, Awaitable, Callable, Mapping
 
 from kdcube_ai_app.apps.chat.proc.app_deployment.models import (
     AppStaticSurfaceManifest,
@@ -192,6 +192,7 @@ async def _invoke_on_app_deploy(
     pg_pool: Any,
     redis: Any,
     logger: AgentLogger,
+    reread_props: Callable[[], Awaitable[dict[str, Any]]] | None = None,
 ) -> None:
     hook = getattr(workflow, "on_app_deploy", None)
     if not callable(hook):
@@ -210,6 +211,7 @@ async def _invoke_on_app_deploy(
         "pg_pool": pg_pool,
         "redis": redis,
         "logger": logger,
+        "reread_props": reread_props,
     }
     await hook(**_select_hook_kwargs(hook, kwargs))
 
@@ -323,6 +325,20 @@ async def deploy_loaded_bundle_app_resources(
         int(settings.PLATFORM.APPLICATIONS.BUNDLES_PRELOAD_BUNDLE_LOCK_TTL_SECONDS),
     )
 
+    async def _reread_effective_props() -> dict[str, Any]:
+        """The effective props as the authority holds them right now.
+
+        Offered to hooks that publish shared state under a lock: the props may
+        have moved between this reconcile reading them and the hook acquiring
+        that lock.
+        """
+        fresh = await get_bundle_props_from_authority(
+            tenant=tenant,
+            project=project,
+            bundle_id=bundle_id,
+        ) or {}
+        return _apply_effective_props(workflow, fresh)
+
     async def _deploy_app_resources() -> None:
         await _invoke_on_app_deploy(
             workflow=workflow,
@@ -336,6 +352,7 @@ async def deploy_loaded_bundle_app_resources(
             pg_pool=pg_pool,
             redis=redis,
             logger=logger,
+            reread_props=_reread_effective_props,
         )
 
     await run_once_for_shared_bundle_storage(

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/examples/bundles/connection-hub@1-0/entrypoint.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/examples/bundles/connection-hub@1-0/entrypoint.py
@@ -1453,10 +1453,16 @@ class ConnectionHubEntrypoint(BaseEntrypoint):
             tenant, project = _runtime_tenant_project(self)
 
         connections = connections_from_props(props)
+        reread_props = kwargs.get("reread_props")
+
+        async def _reread_connections() -> Mapping[str, Any]:
+            return connections_from_props(await reread_props())
+
         result = await ensure_delegated_catalog(
             connections=connections,
             store=BundleStorageDelegatedCatalogStore(storage_root),
             cache=DelegatedCatalogRuntimeCache(redis, tenant=tenant, project=project),
+            reread=_reread_connections if callable(reread_props) else None,
             settings=DelegatedCacheSettings.from_connections(connections),
             reason=str(kwargs.get("reason") or "app_deploy"),
         )

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/automation_access.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/automation_access.py
@@ -2498,7 +2498,14 @@ class AutomationAccessService:
         grants: Iterable[str],
         config: Any = None,
     ) -> dict[str, Any]:
-        """The boundary tree a selection expands to for one resource."""
+        """The boundary tree a selection expands to for one resource.
+
+        The selection is looked up under the caller's ``resource``, which is the
+        key the card stores it under. The configured row is still resolved by
+        pattern, but its selector is not that key: an OAuth consent records the
+        concrete request URL, so looking up under ``cfg.resource`` misses and
+        narrows the boundary to nothing.
+        """
         source = config or self._config
         cfg = source.resource_config(resource) if resource else None
         if cfg is None or not isinstance(getattr(cfg, "named_services", None), Mapping):
@@ -2506,7 +2513,7 @@ class AutomationAccessService:
         try:
             return named_service_policy_for_resource(
                 named_services=cfg.named_services,
-                resource=cfg.resource,
+                resource=resource,
                 selection=_selection_policy_argument(selection),
                 grants=list(grants),
             )

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/automation_access.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/automation_access.py
@@ -102,6 +102,7 @@ from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.car
 )
 from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.catalog.authorization import (
     CAPABILITY_NAMED_SERVICE_OPERATION,
+    CAPABILITY_RESOURCE_CLAIM,
     ActiveCatalogCapabilities,
     CapabilityRequest,
     CardProvenance,
@@ -806,6 +807,48 @@ def record_from_card(
         access_token=held.access_token,
         last_issued_at=authority.last_issued_at,
     )
+
+
+def _card_holds_resource(record: Any, configured_resource: str) -> bool:
+    """Whether a card's stored resources reach a configured row."""
+    grants = getattr(record, "resource_grants", None) or {}
+    if configured_resource in grants:
+        return True
+    from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.credential_view import (
+        resource_matches,
+    )
+
+    return any(
+        resource_matches(configured_resource, str(stored or ""))
+        or resource_matches(str(stored or ""), configured_resource)
+        for stored in grants
+    )
+
+
+def _card_claims_for_resource(record: Any, configured_resource: str) -> set[str]:
+    """The card's claims that apply to a configured resource row.
+
+    A card keys `resource_grants` by what its issuance saw: an agent or manual
+    card by the configured selector, an OAuth card by the concrete request URL.
+    An exact lookup by the row's selector therefore reads empty for the URL
+    shape and reports every required claim as missing. Matching is the same
+    wildcard match the guard uses to decide which row governs the request.
+    """
+    from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.credential_view import (
+        resource_matches,
+    )
+
+    grants = getattr(record, "resource_grants", None) or {}
+    exact = grants.get(configured_resource)
+    if exact is not None:
+        return {_clean(item) for item in exact if _clean(item)}
+    out: set[str] = set()
+    for stored, held in grants.items():
+        if resource_matches(configured_resource, str(stored or "")) or resource_matches(
+            str(stored or ""), configured_resource
+        ):
+            out.update(_clean(item) for item in (held or ()) if _clean(item))
+    return out
 
 
 class AutomationAccessService:
@@ -2263,9 +2306,11 @@ class AutomationAccessService:
         active = await self._active_catalog()
         catalog = ActiveCatalogCapabilities(active)
         for cfg in oauth_delegated_config_from_connections(active.connections).resources:
-            if (
-                exact_record is not None
-                and cfg.resource not in exact_record.resource_grants
+            # Which row an exact card reaches. Membership by key alone reads
+            # empty for a card whose grants are keyed by the request URL, so the
+            # row that governs it is found the same way the guard finds it.
+            if exact_record is not None and not _card_holds_resource(
+                exact_record, cfg.resource
             ):
                 continue
             named = cfg.named_services if isinstance(cfg.named_services, Mapping) else None
@@ -2331,11 +2376,33 @@ class AutomationAccessService:
             )
             if removed is not None:
                 return {"governed": True, "granted": False, "removed": removed}
+            # The claim the operation costs is subject to the same ceiling as the
+            # operation itself. A claim the card holds and the catalog no longer
+            # publishes is a removal, not a missing grant: it answers `removed`
+            # rather than `missing_claims`, or the caller is told to ask for
+            # consent that nobody can give.
+            for claim in sorted(required):
+                removed = authorize_current_capability(
+                    catalog=catalog,
+                    provenance=CardProvenance(
+                        access_id=record.access_id if record is not None else "",
+                        card_revision=record.card_revision if record is not None else 0,
+                        catalog_version=record.catalog_version if record is not None else "",
+                    ),
+                    request=CapabilityRequest(
+                        kind=CAPABILITY_RESOURCE_CLAIM,
+                        resource=cfg.resource,
+                        surface="named_service",
+                        claim=claim,
+                    ),
+                )
+                if removed is not None:
+                    return {"governed": True, "granted": False, "removed": removed}
             granted = False
             missing_claims: list[str] = sorted(required)
             not_granted: dict[str, Any] | None = None
             if record is not None:
-                held = set(record.resource_grants.get(cfg.resource, ()))
+                held = _card_claims_for_resource(record, cfg.resource)
                 missing_claims = sorted(required - held)
                 granted = not missing_claims
                 if granted:

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/automation_access.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/automation_access.py
@@ -3202,7 +3202,22 @@ class AutomationAccessService:
             return {"ok": False, "error": "delegated_access_cross_user_access_denied"}
         # The revoked revision commits before any credential cleanup, so a
         # failure below cannot leave the card usable.
-        await self._forget_record(record)
+        serving_error: CardServingUnavailable | None = None
+        try:
+            await self._forget_record(record)
+        except CardServingUnavailable as exc:
+            # Durable revocation already won. Continue invalidating the
+            # source-specific credential so a stale serving projection cannot
+            # preserve access while Redis is being reconstructed.
+            serving_error = exc
+        except (CardUnavailable, CardConflict, CardCommitFailed) as exc:
+            return {
+                "ok": False,
+                "error": "delegated_card_not_committed",
+                "reason": getattr(exc, "reason", ""),
+                "retryable": True,
+                "status": 503,
+            }
         removed_session = False
         if record.session_id:
             from kdcube_ai_app.auth.bundle import get_bundle_session_authority
@@ -3218,6 +3233,8 @@ class AutomationAccessService:
         if record.access_token:
             await self._store.revoke_access_grant(record.access_token)
         await self.notify_change(grantor_subject, action="revoked", access_id=access_id_value)
+        if serving_error is not None:
+            return _serving_state_unavailable(serving_error)
         return {
             "ok": True,
             "removed": True,

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/automation_access.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/automation_access.py
@@ -83,6 +83,7 @@ from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.car
 from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.cards.service import (
     CardCommitFailed,
     CardConflict,
+    CardServingUnavailable,
 )
 from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.catalog.resolver import (
     CatalogUnavailable,
@@ -462,6 +463,23 @@ async def read_agent_grant_record(
     if record.expires_at and record.expires_at <= int(time.time()):
         return None
     return record
+
+
+def _serving_state_unavailable(exc: CardServingUnavailable) -> dict[str, Any]:
+    """The revision is committed; its serving state is not.
+
+    Names the card so a caller that minted credential material it never
+    received can point at it. Retrying creates a second card when the id is
+    random, so the answer says which one already exists.
+    """
+    return {
+        "ok": False,
+        "error": "delegated_card_serving_state_unavailable",
+        "reason": exc.reason,
+        "access_id": exc.access_id,
+        "retryable": True,
+        "status": 503,
+    }
 
 
 def _selection_policy_argument(
@@ -1740,6 +1758,8 @@ class AutomationAccessService:
         )
         try:
             await self._persist_record(record, expected_revision=committed_revision)
+        except CardServingUnavailable as exc:
+            return _serving_state_unavailable(exc)
         except (CardUnavailable, CardConflict, CardCommitFailed) as exc:
             return {
                 "ok": False,
@@ -1942,8 +1962,9 @@ class AutomationAccessService:
                     "endpoints that differ on separate cards."
                 ),
             })
-        # Recompute the boundary tree here: the descriptor is available in this
-        # process, the guard's is not.
+        # Materialize the boundary tree from the same active catalog the rows
+        # came from, so the stored tree and the version stamped on the card
+        # describe one generation.
         named_services: dict[str, Any] = {}
         for resource_value, cfg in resource_pairs:
             if not isinstance(cfg.named_services, Mapping):
@@ -2130,6 +2151,8 @@ class AutomationAccessService:
         del remaining
         try:
             await self._persist_record(updated, expected_revision=existing.card_revision)
+        except CardServingUnavailable as exc:
+            return _serving_state_unavailable(exc)
         except (CardUnavailable, CardConflict, CardCommitFailed) as exc:
             return {
                 "ok": False,
@@ -3053,6 +3076,8 @@ class AutomationAccessService:
         )
         try:
             await self._persist_record(updated, expected_revision=record.card_revision)
+        except CardServingUnavailable as exc:
+            return _serving_state_unavailable(exc)
         except (CardUnavailable, CardConflict, CardCommitFailed) as exc:
             return {
                 "ok": False,

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/cards/cache.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/cards/cache.py
@@ -15,7 +15,8 @@ short residency and never act as authority.
 
 Every install is a compare-and-transition: a delayed read-through may not
 displace a newer revision, an updating marker, or a revoked tombstone, and a
-mutation finalizer may replace only the marker carrying its own mutation id.
+mutation finalizer may replace only the marker carrying its own mutation id or
+an ordinary projection whose revision it strictly supersedes.
 """
 
 from __future__ import annotations
@@ -67,8 +68,12 @@ redis.call('SET', KEYS[1], ARGV[1], 'EX', ARGV[3])
 return 1
 """
 
-# Finalize a mutation. Replaces only this mutation's own marker, or an absent
-# key left behind when that marker expired.
+# Finalize a mutation. Replaces this mutation's own marker, an absent key, or —
+# when ARGV[4] carries a revision — an ordinary projection strictly older than
+# it: a read-through refills the key with the superseded revision when the
+# marker expires before finalization. Refuses another mutation's marker, a
+# revoked tombstone, and an equal or newer revision, so a stale finalizer
+# carrying an older number does not install.
 _FINALIZE_LUA = """
 local existing = redis.call('GET', KEYS[1])
 if existing then
@@ -76,8 +81,14 @@ if existing then
   if not ok or type(decoded) ~= 'table' then
     return 0
   end
-  if decoded['kind'] ~= 'updating' or decoded['mutation_id'] ~= ARGV[2] then
-    return 0
+  local owned = decoded['kind'] == 'updating'
+            and decoded['mutation_id'] == ARGV[2]
+  if not owned then
+    local incoming = tonumber(ARGV[4]) or 0
+    local live = tonumber(decoded['card_revision']) or 0
+    if incoming <= 0 or decoded['kind'] ~= 'card' or live >= incoming then
+      return 0
+    end
   end
 end
 if ARGV[1] == '' then
@@ -222,7 +233,8 @@ class DelegatedCardRuntimeCache:
         mutation_id: str,
         ttl_seconds: int,
     ) -> bool:
-        """Replace this mutation's marker with the committed live projection."""
+        """Install the committed live projection over this mutation's marker, or
+        over the revision it supersedes if a read-through refilled the key."""
         if ttl_seconds <= 0:
             return await self.finalize_removal(
                 authority.access_id, mutation_id=mutation_id
@@ -238,6 +250,7 @@ class DelegatedCardRuntimeCache:
             encode_cache_value(payload),
             str(mutation_id),
             str(max(1, int(ttl_seconds))),
+            str(int(authority.card_revision)),
         )
 
     async def commit_tombstone(
@@ -248,7 +261,8 @@ class DelegatedCardRuntimeCache:
         mutation_id: str,
         ttl_seconds: int,
     ) -> bool:
-        """Replace this mutation's marker with the short revoked tombstone."""
+        """Install the short revoked tombstone over this mutation's marker, or
+        over the revision it supersedes if a read-through refilled the key."""
         payload = {
             "kind": CARD_CACHE_KIND_REVOKED,
             "card_revision": int(card_revision),
@@ -259,11 +273,18 @@ class DelegatedCardRuntimeCache:
             encode_cache_value(payload),
             str(mutation_id),
             str(max(1, int(ttl_seconds))),
+            str(int(card_revision)),
         )
 
     async def finalize_removal(self, access_id: str, *, mutation_id: str) -> bool:
-        """Drop this mutation's marker without leaving a live projection."""
-        return await self._eval_bool(_FINALIZE_LUA, access_id, "", str(mutation_id), "1")
+        """Drop this mutation's marker without leaving a live projection.
+
+        Passes no revision: the caller's durable commit failed, so a projection
+        refilled meanwhile carries the revision that still stands.
+        """
+        return await self._eval_bool(
+            _FINALIZE_LUA, access_id, "", str(mutation_id), "1", "0"
+        )
 
     async def restore_projection(
         self, authority: CardAuthority, *, ttl_seconds: int

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/cards/persistence.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/cards/persistence.py
@@ -40,6 +40,7 @@ from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.car
 )
 from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.cards.service import (
     CardConflict,
+    CardServingUnavailable,
     DelegatedCardService,
 )
 from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.cards.store import (
@@ -120,7 +121,15 @@ class DurableCardPersistence:
             expected_revision=expected_revision,
             now=now,
         )
-        await self._handles.write(handles, ttl_seconds=max(0, authority.expires_at - now))
+        try:
+            await self._handles.write(
+                handles, ttl_seconds=max(0, authority.expires_at - now)
+            )
+        except Exception as exc:
+            # The revision is committed; the handles it references are not.
+            raise CardServingUnavailable(
+                "credential_handles_unavailable", access_id=authority.access_id
+            ) from exc
 
     async def forget(self, authority: CardAuthority, *, subject_hash: str) -> None:
         await self._cards.revoke(

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/cards/resolver.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/cards/resolver.py
@@ -127,21 +127,33 @@ class DelegatedCardResolver:
     ) -> list[CardAuthority]:
         """Active, unexpired cards for one grantor.
 
-        The index only accelerates discovery: every member is resolved through
-        the card cache/store, and a member that no longer resolves is pruned.
-        Losing the index cannot hide a live durable card.
+        Durable membership decides who is listed; the index only accelerates
+        discovery and carries expiry scores. Every candidate is resolved through
+        the card cache/store: one that no longer resolves is pruned, and one the
+        index lost is re-admitted. Losing the index, whole or in part, cannot
+        hide a live durable card.
+
+        The durable listing costs one directory read per call. Divergence
+        between the index and durable membership cannot be detected without it,
+        so the alternative is a card that stays invisible to its own grantor.
         """
         moment = int(now if now is not None else time.time())
         try:
             members = await self._cache.index_members(subject_hash=subject_hash, now=moment)
         except Exception as exc:
             raise CardUnavailable("cache_unavailable") from exc
+        try:
+            durable_ids = await self._store.list_card_ids(subject_hash=subject_hash)
+        except Exception as exc:
+            raise CardUnavailable("durable_card_unreadable") from exc
 
-        if not members:
-            members = await self._rebuild_index(subject_hash=subject_hash, moment=moment)
+        indexed = set(members)
+        candidates = list(members) + [
+            access_id for access_id in durable_ids if access_id not in indexed
+        ]
 
         found: list[CardAuthority] = []
-        for access_id in members:
+        for access_id in candidates:
             try:
                 authority = await self.resolve(
                     subject_hash=subject_hash, access_id=access_id, now=moment
@@ -151,41 +163,26 @@ class DelegatedCardResolver:
             if authority is None:
                 await self._forget(subject_hash=subject_hash, access_id=access_id)
                 continue
+            if access_id not in indexed:
+                await self._readmit(subject_hash=subject_hash, authority=authority)
             found.append(authority)
         found.sort(key=lambda item: item.created_at, reverse=True)
         return found
 
-    async def _rebuild_index(self, *, subject_hash: str, moment: int) -> list[str]:
+    async def _readmit(self, *, subject_hash: str, authority: CardAuthority) -> None:
+        """Return a resolved card the index lost. Never blocks the listing."""
         try:
-            card_ids = await self._store.list_card_ids(subject_hash=subject_hash)
-        except Exception as exc:
-            raise CardUnavailable("durable_card_unreadable") from exc
-
-        restored: list[str] = []
-        for access_id in card_ids:
-            try:
-                current = await self._store.read_current_authority(
-                    subject_hash=subject_hash, access_id=access_id
-                )
-            except Exception:
-                _LOGGER.warning(
-                    "[connection-hub.delegated-cards] index rebuild skipped card=%s",
-                    access_id,
-                    exc_info=True,
-                )
-                continue
-            if current is None:
-                continue
-            _, authority = current
-            if not authority_is_usable(authority, moment):
-                continue
             await self._cache.index_add(
                 subject_hash=subject_hash,
-                access_id=access_id,
+                access_id=authority.access_id,
                 expires_at=authority.expires_at,
             )
-            restored.append(access_id)
-        return restored
+        except Exception:
+            _LOGGER.warning(
+                "[connection-hub.delegated-cards] index readmit failed card=%s",
+                authority.access_id,
+                exc_info=True,
+            )
 
     async def _forget(self, *, subject_hash: str, access_id: str) -> None:
         try:

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/cards/service.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/cards/service.py
@@ -69,6 +69,20 @@ class CardCommitFailed(RuntimeError):
         self.reason = reason
 
 
+class CardServingUnavailable(RuntimeError):
+    """The revision committed durably; its serving state did not.
+
+    The committed revision is the authority; a read that misses the projection
+    reloads it. Carries ``access_id`` so the caller can name the card it holds
+    no credential for.
+    """
+
+    def __init__(self, reason: str, *, access_id: str = "") -> None:
+        super().__init__(reason)
+        self.reason = reason
+        self.access_id = access_id
+
+
 class DelegatedCardService:
     def __init__(
         self,
@@ -123,14 +137,25 @@ class DelegatedCardService:
                 pointer = await self._commit_durable(
                     authority=authority, subject_hash=subject_hash, mutation_id=mutation_id
                 )
-                await self._cache.commit_projection(
-                    authority,
-                    mutation_id=mutation_id,
-                    ttl_seconds=max(0, authority.expires_at - moment),
-                )
-                await self._index(
-                    authority=authority, subject_hash=subject_hash, moment=moment
-                )
+                try:
+                    installed = await self._cache.commit_projection(
+                        authority,
+                        mutation_id=mutation_id,
+                        ttl_seconds=max(0, authority.expires_at - moment),
+                    )
+                    if not installed:
+                        self._report_uninstalled(
+                            access_id=authority.access_id,
+                            card_revision=authority.card_revision,
+                            transition="projection",
+                        )
+                    await self._index(
+                        authority=authority, subject_hash=subject_hash, moment=moment
+                    )
+                except Exception as exc:
+                    raise CardServingUnavailable(
+                        "serving_state_unavailable", access_id=authority.access_id
+                    ) from exc
                 return pointer
         except ObservedFileLockTimeout as exc:
             raise CardConflict("card_mutation_lock_timeout") from exc
@@ -177,15 +202,26 @@ class DelegatedCardService:
                 pointer = await self._commit_durable(
                     authority=revoked, subject_hash=subject_hash, mutation_id=mutation_id
                 )
-                await self._cache.commit_tombstone(
-                    access_id,
-                    card_revision=revoked.card_revision,
-                    mutation_id=mutation_id,
-                    ttl_seconds=self._settings.revoked_tombstone_seconds,
-                )
-                await self._cache.index_remove(
-                    subject_hash=subject_hash, access_id=access_id
-                )
+                try:
+                    installed = await self._cache.commit_tombstone(
+                        access_id,
+                        card_revision=revoked.card_revision,
+                        mutation_id=mutation_id,
+                        ttl_seconds=self._settings.revoked_tombstone_seconds,
+                    )
+                    if not installed:
+                        self._report_uninstalled(
+                            access_id=access_id,
+                            card_revision=revoked.card_revision,
+                            transition="tombstone",
+                        )
+                    await self._cache.index_remove(
+                        subject_hash=subject_hash, access_id=access_id
+                    )
+                except Exception as exc:
+                    raise CardServingUnavailable(
+                        "serving_state_unavailable", access_id=access_id
+                    ) from exc
                 return pointer
         except ObservedFileLockTimeout as exc:
             raise CardConflict("card_mutation_lock_timeout") from exc
@@ -245,6 +281,25 @@ class DelegatedCardService:
             raise CardCommitFailed("durable_commit_failed") from exc
         return pointer
 
+    @staticmethod
+    def _report_uninstalled(
+        *, access_id: str, card_revision: int, transition: str
+    ) -> None:
+        """The durable revision committed; the serving projection refused it.
+
+        Every surviving refusal leaves a live entry that is not stale-permissive
+        — an equal or newer revision, a revoked tombstone, another mutation's
+        marker, or an unusable value that denies and reloads from durable.
+        Logged because the return value is otherwise unobserved.
+        """
+        _LOGGER.warning(
+            "[connection-hub.delegated-cards] %s not installed card=%s revision=%s; "
+            "live projection is equal or newer",
+            transition,
+            access_id,
+            card_revision,
+        )
+
     async def _release(self, access_id: str, *, mutation_id: str) -> None:
         try:
             await self._cache.finalize_removal(access_id, mutation_id=mutation_id)
@@ -299,6 +354,7 @@ __all__ = [
     "CARD_LOCK_WAIT_SECONDS",
     "CardCommitFailed",
     "CardConflict",
+    "CardServingUnavailable",
     "DelegatedCardService",
     "replace_state",
 ]

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/catalog/authorization.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/catalog/authorization.py
@@ -168,9 +168,20 @@ class ActiveCatalogCapabilities:
     def permits(self, request: CapabilityRequest) -> bool:
         """Whether the active catalog still offers this capability.
 
-        Claims and outer operations: an unenumerated dimension carries no
-        ceiling. Named services: membership in the published namespaces
-        decides, and an absent or empty block publishes nothing.
+        Each dimension is read as the code reads it, not as a general rule:
+
+        - claims: bounded by the row's ``grants``, which the parser derives from
+          its tools and namespaces when they are not written. A row that
+          publishes no claim publishes none, and ``resource_claims`` — the other
+          reader of this ceiling, which the guard reduces stored claims through
+          — must agree with this branch;
+        - outer operations: the all-resource row ``*`` carries no ceiling,
+          because its operations come from endpoint policy rather than the
+          catalog. Every other row is bounded by the tools it publishes, and a
+          block that was emptied or deleted publishes none;
+        - named services: bounded by the published namespaces always. An absent
+          or empty block publishes nothing; unlike outer tools there is no
+          second source for an inner operation.
         """
         resource_cfg = self.resource_config(request)
         if resource_cfg is None:
@@ -179,15 +190,13 @@ class ActiveCatalogCapabilities:
             return True
         if request.kind == CAPABILITY_RESOURCE_CLAIM:
             configured = {_clean(grant) for grant in (resource_cfg.grants or ())}
-            if not configured:
-                return True
             return _clean(request.claim) in configured
         if request.kind == CAPABILITY_OUTER_OPERATION:
+            if _clean(getattr(resource_cfg, "resource", "")).rstrip("/") == "*":
+                return True
             configured = {
                 _clean(getattr(tool, "name", "")) for tool in (resource_cfg.tools or ())
             }
-            if not configured:
-                return True
             return _clean(request.outer_operation) in configured
         namespaces = configured_named_service_operations(resource_cfg.named_services)
         namespace = _clean(request.namespace).lower().rstrip(":")

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/catalog/authorization.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/catalog/authorization.py
@@ -168,9 +168,9 @@ class ActiveCatalogCapabilities:
     def permits(self, request: CapabilityRequest) -> bool:
         """Whether the active catalog still offers this capability.
 
-        A dimension the resource does not enumerate carries no ceiling and is
-        not a denial. A dimension it enumerates is authoritative even when what
-        it enumerates is empty — that is a removal, not an absent section.
+        Claims and outer operations: an unenumerated dimension carries no
+        ceiling. Named services: membership in the published namespaces
+        decides, and an absent or empty block publishes nothing.
         """
         resource_cfg = self.resource_config(request)
         if resource_cfg is None:
@@ -189,10 +189,7 @@ class ActiveCatalogCapabilities:
             if not configured:
                 return True
             return _clean(request.outer_operation) in configured
-        named_services = resource_cfg.named_services
-        if not isinstance(named_services, Mapping) or not named_services:
-            return True
-        namespaces = configured_named_service_operations(named_services)
+        namespaces = configured_named_service_operations(resource_cfg.named_services)
         namespace = _clean(request.namespace).lower().rstrip(":")
         if request.kind == CAPABILITY_NAMED_SERVICE_NAMESPACE:
             return bool(namespace) and namespace in namespaces

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/catalog/drift.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/catalog/drift.py
@@ -64,13 +64,21 @@ class _CatalogView:
         return configured or None
 
     def outer_operations(self, resource: str) -> set[str] | None:
+        """What the resource publishes; ``None`` only for the all-resource row.
+
+        The all-resource row takes its operations from endpoint policy, not from
+        the catalog, so it carries no ceiling and nothing about it drifts. Every
+        other row is bounded by what it publishes, and an emptied or deleted
+        block publishes nothing — which the guard answers the same way.
+        """
         cfg = self.resource(resource)
         if cfg is None:
             return set()
-        configured = {
+        if _clean(getattr(cfg, "resource", "")).rstrip("/") == "*":
+            return None
+        return {
             _clean(getattr(tool, "name", "")) for tool in (cfg.tools or ())
         } - {""}
-        return configured or None
 
     def named_service_operations(self, resource: str) -> dict[str, set[str]]:
         """What the resource publishes; empty when it publishes nothing.

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/catalog/drift.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/catalog/drift.py
@@ -72,15 +72,17 @@ class _CatalogView:
         } - {""}
         return configured or None
 
-    def named_service_operations(self, resource: str) -> dict[str, set[str]] | None:
-        """``None`` when the resource declares no named-service block."""
+    def named_service_operations(self, resource: str) -> dict[str, set[str]]:
+        """What the resource publishes; empty when it publishes nothing.
+
+        Unlike claims and outer operations this never reports "no ceiling":
+        an absent or empty block offers no inner operation, which the guard
+        answers the same way.
+        """
         cfg = self.resource(resource)
         if cfg is None:
             return {}
-        block = getattr(cfg, "named_services", None)
-        if not isinstance(block, Mapping) or not block:
-            return None
-        return configured_named_service_operations(block)
+        return configured_named_service_operations(getattr(cfg, "named_services", None))
 
 
 def selected_named_service_operations(card: Any) -> dict[str, dict[str, set[str]]]:
@@ -162,8 +164,6 @@ def _removed(
                 )
 
         offered_inner = active.named_service_operations(resource)
-        if offered_inner is None:
-            continue
         for namespace, operations in sorted(selected_inner.get(resource, {}).items()):
             for operation in sorted(operations - offered_inner.get(namespace, set())):
                 named_service_operations.append(

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/catalog/publisher.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/catalog/publisher.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from typing import Any, Mapping
+from typing import Any, Awaitable, Callable, Mapping
 
 from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.cache_settings import (
     DelegatedCacheSettings,
@@ -61,6 +61,7 @@ async def ensure_delegated_catalog(
     connections: Mapping[str, Any],
     store: BundleStorageDelegatedCatalogStore,
     cache: DelegatedCatalogRuntimeCache,
+    reread: Callable[[], Awaitable[Mapping[str, Any]]] | None = None,
     reason: str = "",
     settings: DelegatedCacheSettings | None = None,
     logger: Any = None,
@@ -70,6 +71,14 @@ async def ensure_delegated_catalog(
     ``reason`` is audit metadata only; it does not affect hashing, comparison,
     or control flow. The critical section serializes concurrent publishers onto
     one immutable version.
+
+    ``reread`` re-derives the effective connections inside the critical section.
+    A publisher that captured its input before another generation was published
+    would otherwise register that older content under a later version stamp,
+    which no version comparison can refuse: the stamp is minted at publication,
+    not carried by the content. With it, a document stamped later never holds
+    older content, which is what the serving-entry comparison assumes. Without
+    it the captured value is published as-is.
     """
     residency = (settings or DelegatedCacheSettings()).catalog
     try:
@@ -78,9 +87,29 @@ async def ensure_delegated_catalog(
         raise CatalogPublicationError("connections_not_hashable") from exc
 
     outcome: dict[str, Any] = {}
+    # Both closures read this: `_publish` may replace it, and the readiness
+    # check that follows the action must judge what was published, not what
+    # was captured.
+    registered = {"connections": connections, "hash": expected_hash}
 
     async def _publish() -> None:
-        document = CatalogDocument.build(connections)
+        if reread is not None:
+            fresh = await reread()
+            try:
+                fresh_hash = connections_content_hash(fresh)
+            except (TypeError, ValueError) as exc:
+                raise CatalogPublicationError("connections_not_hashable") from exc
+            if fresh_hash != registered["hash"]:
+                _LOGGER.info(
+                    "[connection-hub.delegated-catalog] effective connections moved "
+                    "while entering the section: captured=%s current=%s reason=%s",
+                    registered["hash"][:12],
+                    fresh_hash[:12],
+                    reason,
+                )
+            registered["connections"] = fresh
+            registered["hash"] = fresh_hash
+        document = CatalogDocument.build(registered["connections"])
         active = await store.read_active()
         created = True
         if active is not None and active.content_hash == document.content_hash:
@@ -114,7 +143,7 @@ async def ensure_delegated_catalog(
 
     async def _ready() -> bool:
         active = await store.read_active()
-        if active is None or active.content_hash != expected_hash:
+        if active is None or active.content_hash != registered["hash"]:
             return False
         if not await store.version_exists(active.version):
             return False

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/catalog/publisher.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/catalog/publisher.py
@@ -157,6 +157,7 @@ async def ensure_delegated_catalog(
         signature=expected_hash,
         ready=_ready,
         action=_publish,
+        signature_after_action=lambda: str(registered["hash"]),
         logger=logger,
         owner_metadata={"kind": "delegated-catalog", "reason": reason},
         log_prefix="[connection-hub.delegated-catalog]",

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/oauth/surface_guard.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/oauth/surface_guard.py
@@ -37,6 +37,7 @@ from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.cat
     CapabilityRequest,
     CardProvenance,
     authorize_current_capability,
+    card_boundary_denial,
     catalog_unavailable_denial,
 )
 from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.catalog.resolver import (
@@ -311,11 +312,20 @@ def _oauth_challenge_headers(request: Request, auth: Mapping[str, Any] | None) -
 
 
 def _rpc_tool_error(rpc_id: Any, message: str) -> JSONResponse:
+    """A refused tool call, shaped as the SDK's own `CallToolResult`.
+
+    The guard answers before the MCP application runs, so this envelope is built
+    here rather than by the server. `mcp_types.CallToolResult` carries
+    `result_type` with a `"complete"` default, and a client that validates
+    against that model rejects an envelope without it — never reaching the body,
+    whatever the body says.
+    """
     return JSONResponse(
         {
             "jsonrpc": "2.0",
             "id": rpc_id,
             "result": {
+                "resultType": "complete",
                 "isError": True,
                 "content": [{"type": "text", "text": message}],
             },
@@ -367,20 +377,44 @@ def delegated_request_resource(request: Request) -> str:
     return _request_resource(request)
 
 
-def _connection_hub_tool_policies(request: Request) -> dict[str, ManagedMcpToolPolicy]:
-    from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.oauth.config import (
-        oauth_delegated_config,
-    )
+def _catalog_tool_policies(
+    *,
+    catalog: ActiveCatalogCapabilities,
+    resource: str,
+    request_resource: str,
+    declared: Mapping[str, ManagedMcpToolPolicy] | None,
+) -> dict[str, ManagedMcpToolPolicy]:
+    """Per-tool policy for this request, with claims taken from the catalog.
 
-    cfg = oauth_delegated_config(request)
-    tools = cfg.resource_tool_catalog(_request_resource(request))
+    Effective props are an input to publication, not to governed authorization,
+    so the claim a tool costs is read from the registered catalog rather than
+    from request-local Hub config. That config is bound only by the platform
+    authentication surface and Connection Hub's own routes, so a door served
+    through a bundle route saw an empty map and skipped the whole per-tool
+    block, including both claim checks.
+
+    ``roles`` and ``permissions`` stay with the surface declaration: a catalog
+    row does not carry them, and dropping the declaration would remove a
+    control instead of moving it.
+    """
+    row = catalog.resource_config(
+        CapabilityRequest(
+            kind=CAPABILITY_RESOURCE,
+            resource=resource,
+            request_resource=request_resource,
+        )
+    )
+    declared = dict(declared or {})
     out: dict[str, ManagedMcpToolPolicy] = {}
-    for tool in tools:
+    for tool in (getattr(row, "tools", None) or ()):
         name = str(getattr(tool, "name", "") or "").strip()
         if not name:
             continue
+        surface = declared.get(name)
         out[name] = ManagedMcpToolPolicy(
             grants=_as_list(getattr(tool, "grants", ())),
+            roles=getattr(surface, "roles", ()) or (),
+            permissions=getattr(surface, "permissions", ()) or (),
         )
     return out
 
@@ -1195,9 +1229,12 @@ async def authorize_delegated_mcp_request(
     granted_operations = None
     if isinstance(grant_record, Mapping):
         granted_operations = set(_as_list(grant_record.get("operations")))
-    tool_policies = _connection_hub_tool_policies(request)
-    if not tool_policies:
-        tool_policies = dict(policy.tool_policies or {})
+    tool_policies = _catalog_tool_policies(
+        catalog=catalog,
+        resource=matched_resource,
+        request_resource=request_resource,
+        declared=policy.tool_policies,
+    )
 
     for rpc_id, tool_name in tool_calls:
         removed = _capability_denial(
@@ -1230,14 +1267,36 @@ async def authorize_delegated_mcp_request(
                     request_resource,
                 )
                 return _rpc_capability_error(rpc_id, removed)
-            if tool_policy.grants and not available_grants.issuperset(tool_policy.grants):
-                return _rpc_tool_error(rpc_id, f"required delegated grant is missing for tool: {tool_name}")
+            missing = sorted(set(tool_policy.grants or ()) - available_grants)
+            if missing:
+                return _rpc_capability_error(
+                    rpc_id,
+                    card_boundary_denial(
+                        provenance=_card_provenance(grant_record),
+                        request=CapabilityRequest(
+                            kind=CAPABILITY_RESOURCE_CLAIM,
+                            resource=matched_resource,
+                            request_resource=request_resource,
+                            surface="mcp",
+                            claim=missing[0],
+                        ),
+                    ),
+                )
 
         if policy.selected_tool_grants:
             if granted_operations is None or tool_name not in granted_operations:
-                return _rpc_tool_error(
+                return _rpc_capability_error(
                     rpc_id,
-                    f"tool not consented for this connection: {tool_name}",
+                    card_boundary_denial(
+                        provenance=_card_provenance(grant_record),
+                        request=CapabilityRequest(
+                            kind=CAPABILITY_OUTER_OPERATION,
+                            resource=matched_resource,
+                            request_resource=request_resource,
+                            surface="mcp",
+                            outer_operation=tool_name,
+                        ),
+                    ),
                 )
 
     try:

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/oauth/surface_guard.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/oauth/surface_guard.py
@@ -416,6 +416,19 @@ def _catalog_tool_policies(
             roles=getattr(surface, "roles", ()) or (),
             permissions=getattr(surface, "permissions", ()) or (),
         )
+    if _normalize_resource(getattr(row, "resource", "")) == "*":
+        # The all-resource administrator row deliberately has no catalog tool
+        # ceiling: its outer operations come from the endpoint declaration.
+        # Preserve that declaration's non-claim controls instead of dropping
+        # the entire policy merely because the catalog has no tool rows.
+        for name, surface in declared.items():
+            clean_name = str(name or "").strip()
+            if not clean_name or clean_name in out:
+                continue
+            out[clean_name] = ManagedMcpToolPolicy(
+                roles=getattr(surface, "roles", ()) or (),
+                permissions=getattr(surface, "permissions", ()) or (),
+            )
     return out
 
 

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/oauth/tests/test_surface_guard.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/oauth/tests/test_surface_guard.py
@@ -1597,6 +1597,40 @@ def test_an_administrator_card_still_reaches_the_wildcard_row(monkeypatch):
     assert response.json()["ok"] is True
 
 
+@pytest.mark.parametrize(
+    ("constraint", "required", "message"),
+    [
+        ("roles", ["kdcube:role:nobody"], "required role is missing"),
+        ("permissions", ["kdcube:nobody"], "required permission is missing"),
+    ],
+)
+def test_the_administrator_wildcard_keeps_surface_tool_constraints(
+    monkeypatch, constraint, required, message,
+):
+    """The wildcard delegates endpoint-owned operations, not an escape from
+    the endpoint's declared role and permission checks."""
+    authority = _authority(scopes=["kdcube:role:super-admin"])
+    authority["attrs"]["resource_grants"] = {"*": ["kdcube:role:super-admin"]}
+    client = _client(
+        monkeypatch,
+        connections=_connections_with_admin_wildcard(keep_guard_resource=False),
+        auth={
+            "mode": "managed",
+            "authority_id": "delegated_client",
+            "tools": {"records_export": {constraint: required}},
+            "selected_tool_grants": True,
+        },
+        grant_record={"operations": ["records_export"], "credential": authority},
+    )
+
+    response = client.post(
+        "/guard", json=_rpc_tool_call(), headers={"Authorization": "Bearer reader"},
+    )
+
+    assert response.status_code == 200
+    assert message in response.json()["result"]["content"][0]["text"]
+
+
 def test_a_surviving_resource_is_unaffected_by_the_wildcard_row(monkeypatch):
     """A specific row still answers its own requests when both exist."""
     client = _client(

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/oauth/tests/test_surface_guard.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/oauth/tests/test_surface_guard.py
@@ -511,7 +511,9 @@ def test_managed_mcp_guard_applies_live_operation_narrowing(monkeypatch):
     assert response.status_code == 200
     result = response.json()["result"]
     assert result["isError"] is True
-    assert "not consented" in result["content"][0]["text"]
+    body = json.loads(result["content"][0]["text"])
+    assert body["error"]["code"] == "delegated_capability_not_granted"
+    assert body["ret"]["requested_capability"]["kind"] == "outer_operation"
 
 
 def test_managed_guard_uses_connection_hub_resource_policy(monkeypatch):
@@ -963,7 +965,7 @@ def test_managed_guard_enforces_grants_per_called_tool(monkeypatch):
     assert response.status_code == 200
     result = response.json()["result"]
     assert result["isError"] is True
-    assert "required delegated grant is missing for tool: memory_delete" in result["content"][0]["text"]
+    assert "delegated_capability_not_granted" in result["content"][0]["text"]
 
 
 def test_managed_guard_fails_closed_when_tool_not_consented(monkeypatch):
@@ -984,7 +986,9 @@ def test_managed_guard_fails_closed_when_tool_not_consented(monkeypatch):
     assert response.status_code == 200
     result = response.json()["result"]
     assert result["isError"] is True
-    assert "not consented" in result["content"][0]["text"]
+    body = json.loads(result["content"][0]["text"])
+    assert body["error"]["code"] == "delegated_capability_not_granted"
+    assert body["ret"]["requested_capability"]["kind"] == "outer_operation"
 
 
 def test_managed_guard_rejects_resource_mismatch(monkeypatch):
@@ -1247,6 +1251,108 @@ def test_a_claim_removed_from_the_catalog_denies_the_rest_operation(monkeypatch)
     assert path["claim"] == "records:read"
 
 
+# -- the per-tool claim check reads the catalog, not request-local Hub config ---
+#
+# Effective props are an input to publication, not to governed authorization. The
+# per-tool map used to be built from request-local Connection Hub config, which
+# only the platform authentication surface and the Hub's own routes bind — so a
+# door served through a bundle route saw an empty map and skipped the whole
+# per-tool block, claim checks included. These pin the claim to the catalog and
+# keep the surface declaration as the source of roles and permissions.
+
+
+def test_a_claim_removed_from_the_catalog_denies_the_mcp_tool(monkeypatch):
+    """The mirror of the REST case, on a door that declares no tool policy."""
+    client = _client(
+        monkeypatch,
+        connections=_connections_without(claim="records:read"),
+        auth={
+            "mode": "managed",
+            "authority_id": "delegated_client",
+            "selected_tool_grants": True,
+        },
+        grant_record={"operations": ["records_export"], "credential": _authority()},
+    )
+
+    response = client.post(
+        "/guard", json=_rpc_tool_call(), headers={"Authorization": "Bearer reader"},
+    )
+
+    assert response.status_code == 200
+    body = json.loads(response.json()["result"]["content"][0]["text"])
+    assert body["error"]["code"] == "delegated_capability_no_longer_available"
+    path = body["ret"]["requested_capability"]
+    assert path["kind"] == "resource_claim"
+    assert path["claim"] == "records:read"
+
+
+def test_the_surface_declaration_still_supplies_roles(monkeypatch):
+    """Grants move to the catalog; roles and permissions do not, because a
+    catalog row does not carry them."""
+    client = _client(
+        monkeypatch,
+        auth={
+            "mode": "managed",
+            "authority_id": "delegated_client",
+            "tools": {"records_export": {"roles": ["kdcube:role:nobody"]}},
+            "selected_tool_grants": True,
+        },
+        grant_record={"operations": ["records_export"], "credential": _authority()},
+    )
+
+    response = client.post(
+        "/guard", json=_rpc_tool_call(), headers={"Authorization": "Bearer reader"},
+    )
+
+    assert response.status_code == 200
+    assert "required role is missing" in response.json()["result"]["content"][0]["text"]
+
+
+def test_a_refused_tool_call_is_shaped_like_a_call_tool_result(monkeypatch):
+    """The guard answers before the MCP application runs, so it builds this
+    envelope itself. `mcp_types.CallToolResult` carries `resultType`, and a
+    client validating against that model discards an envelope without it —
+    never reaching the body, whatever the body says."""
+    client = _client(
+        monkeypatch,
+        connections=_connections_without(tool="records_export"),
+        grant_record={"operations": ["records_export"], "credential": _authority()},
+    )
+
+    response = client.post(
+        "/guard", json=_rpc_tool_call(), headers={"Authorization": "Bearer reader"},
+    )
+
+    result = response.json()["result"]
+    assert result["resultType"] == "complete"
+    assert result["isError"] is True
+
+
+def test_every_refusal_carries_a_structured_body(monkeypatch):
+    """A capability the card never held and one the catalog withdrew are
+    different answers, and both are objects: a bare sentence cannot say which
+    side refused, nor name the card or the operation."""
+    withdrawn = _client(
+        monkeypatch,
+        connections=_connections_without(tool="records_export"),
+        grant_record={"operations": ["records_export"], "credential": _authority()},
+    ).post("/guard", json=_rpc_tool_call(), headers={"Authorization": "Bearer reader"})
+    not_held = _client(
+        monkeypatch,
+        grant_record={"operations": [], "credential": _authority()},
+    ).post("/guard", json=_rpc_tool_call(), headers={"Authorization": "Bearer reader"})
+
+    for response, code in (
+        (withdrawn, "delegated_capability_no_longer_available"),
+        (not_held, "delegated_capability_not_granted"),
+    ):
+        body = json.loads(response.json()["result"]["content"][0]["text"])
+        assert body["error"]["code"] == code
+        path = body["ret"]["requested_capability"]
+        assert path["kind"] == "outer_operation"
+        assert path["outer_operation"] == "records_export"
+
+
 def test_a_card_that_still_matches_the_catalog_is_admitted(monkeypatch):
     client = _client(
         monkeypatch,
@@ -1407,7 +1513,9 @@ def test_a_capability_the_catalog_still_offers_keeps_the_consent_path(monkeypatc
     result = response.json()["result"]
     assert result["isError"] is True
     text = result["content"][0]["text"]
-    assert "not consented" in text
+    body = json.loads(text)
+    assert body["error"]["code"] == "delegated_capability_not_granted"
+    assert body["ret"]["requested_capability"]["kind"] == "outer_operation"
     assert "delegated_capability_no_longer_available" not in text
 
 

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/tests/test_automation_access.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/tests/test_automation_access.py
@@ -18,6 +18,7 @@ from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.car
 )
 from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.cards.store import (
     BundleStorageDelegatedCardStore,
+    subject_hash_for,
 )
 from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.catalog.resolver import (
     CatalogUnavailable,
@@ -844,6 +845,66 @@ async def test_oauth_grant_registers_lists_and_revokes(card_persistence):
     assert store.revoked_refresh == ["refresh-2"]
     assert store.revoked_access == ["kst1.oauth.token2"]
     assert (await service.list_access(user))["items"] == []
+
+
+@pytest.mark.asyncio
+async def test_revoke_reports_post_commit_serving_failure_and_still_kills_oauth_tokens(
+    card_persistence, monkeypatch,
+):
+    """A failed tombstone projection must not turn a committed revocation into
+    a 500 or skip the credential cleanup that closes a stale projection."""
+    redis = _Redis()
+    store = _OAuthStore()
+    user = {
+        "sub": "platform-user-1",
+        "roles": ["kdcube:role:registered"],
+        "permissions": [],
+    }
+    service = AutomationAccessService(
+        catalog_resolver=_CatalogResolver(connections=_connections()),
+        card_persistence=card_persistence,
+        redis=redis,
+        tenant="demo-tenant",
+        project="demo-project",
+        config=_config(),
+        grant_store=store,
+        authority=_Authority(),
+        minter=_minter,
+    )
+    record = await service.record_oauth_grant(
+        grantor_subject="platform-user-1",
+        client_id="dcr-claude",
+        client_label="Claude",
+        scopes=["records:read"],
+        operations=["records_export"],
+        resource="https://example.test/mcp",
+        access_token="kst1.oauth.token",
+        refresh_token="refresh-1",
+    )
+    assert record is not None
+
+    async def _fail_tombstone(*args, **kwargs):
+        raise RuntimeError("redis unavailable")
+
+    monkeypatch.setattr(
+        card_persistence._cards._cache, "commit_tombstone", _fail_tombstone,
+    )
+
+    revoked = await service.revoke_access(user, access_id=record.access_id)
+
+    assert revoked == {
+        "ok": False,
+        "error": "delegated_card_serving_state_unavailable",
+        "reason": "serving_state_unavailable",
+        "access_id": record.access_id,
+        "retryable": True,
+        "status": 503,
+    }
+    assert await card_persistence.current_revision(
+        record.access_id, subject_hash=subject_hash_for(record.grantor_subject),
+    ) == 2
+    assert store.revoked_refresh == ["refresh-1"]
+    assert store.revoked_access == ["kst1.oauth.token"]
 
 
 async def test_live_sessions_receive_delegated_access_changes():

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/tests/test_automation_access.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/tests/test_automation_access.py
@@ -1053,50 +1053,53 @@ async def test_agent_regrant_with_merge_existing_false_REPLACES_the_record(card_
     assert len((await service.list_access(writer))["items"]) == 1
 
 
-def _named_services_agent_service(card_persistence):
-    from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.oauth.config import (
-        oauth_delegated_config,
-    )
-    state = SimpleNamespace(
-        oauth_delegated_config={
-            "enabled": True,
-            "tenant": "demo-tenant",
-            "project": "demo-project",
-            "capabilities": [
-                {"grant": g, "label": g, "delegable_roles": ["kdcube:role:registered"]}
-                for g in ("named_services:use", "mail:read", "mail:send")
-            ],
-            "resources": [
-                {
-                    "resource": "*/kdcube-services@1-0/public/mcp/named_services*",
-                    "label": "Named services MCP",
-                    # The resource's scope ceiling: the entry grant AND every
-                    # namespace grant it publishes (the deployment contract).
-                    "grants": ["named_services:use", "mail:read", "mail:send"],
-                    # The generic entry tools carry the common MCP entry grant.
-                    "tools": {
-                        "named_services_call": {"label": "Named service call", "grants": ["named_services:use"]},
-                    },
-                    "named_services": {
-                        "namespaces": {
-                            "mail": {
-                                "label": "Mail",
-                                "tools": {
-                                    "search": {"operation": "object.search", "grants": ["mail:read"]},
-                                    "action": {
-                                        "operation": "object.action",
-                                        "operations": {
-                                            "object.action": {"grants": ["mail:read", "mail:send"]},
-                                        },
-                                    },
+_AGENT_NS_OAUTH = {
+    "enabled": True,
+    "tenant": "demo-tenant",
+    "project": "demo-project",
+    "capabilities": [
+        {"grant": g, "label": g, "delegable_roles": ["kdcube:role:registered"]}
+        for g in ("named_services:use", "mail:read", "mail:send")
+    ],
+    "resources": [
+        {
+            "resource": "*/kdcube-services@1-0/public/mcp/named_services*",
+            "label": "Named services MCP",
+            # The resource's scope ceiling: the entry grant AND every
+            # namespace grant it publishes (the deployment contract).
+            "grants": ["named_services:use", "mail:read", "mail:send"],
+            # The generic entry tools carry the common MCP entry grant.
+            "tools": {
+                "named_services_call": {"label": "Named service call", "grants": ["named_services:use"]},
+            },
+            "named_services": {
+                "namespaces": {
+                    "mail": {
+                        "label": "Mail",
+                        "tools": {
+                            "search": {"operation": "object.search", "grants": ["mail:read"]},
+                            "action": {
+                                "operation": "object.action",
+                                "operations": {
+                                    "object.action": {"grants": ["mail:read", "mail:send"]},
                                 },
                             },
                         },
                     },
                 },
-            ],
-        }
+            },
+        },
+    ],
+}
+
+
+def _named_services_agent_service(card_persistence):
+    import copy as _copy
+
+    from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.oauth.config import (
+        oauth_delegated_config,
     )
+    state = SimpleNamespace(oauth_delegated_config=_copy.deepcopy(_AGENT_NS_OAUTH))
     # The native gate reads the registered catalog, so the fixture publishes the
     # same block it configures.
     connections = {"delegated_credentials": {"oauth": state.oauth_delegated_config}}
@@ -1152,6 +1155,111 @@ async def test_agent_namespace_grant_state_governs_and_grants(card_persistence):
         grantor_subject="platform-user-1", client_id=_AGENT_CLIENT,
         namespace="calendar", operation="object.search",
     )) == {"governed": False}
+
+
+# -- the claim ceiling reaches the named-service path too ----------------------
+#
+# The managed door reduces stored claims through the catalog before checking a
+# tool's cost. The native/relayed path compared the operation's required claims
+# against the card alone, so a claim the deployment had withdrawn still paid for
+# the operation. A withdrawal answers `removed`, not `missing_claims`: consent
+# cannot restore what the catalog no longer publishes.
+
+
+def _agent_service_with_row_grants(card_persistence, grants):
+    """The same deployment, with the resource row's claim ceiling replaced."""
+    import copy as _copy
+
+    from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.oauth.config import (
+        oauth_delegated_config,
+    )
+
+    raw = _copy.deepcopy(_AGENT_NS_OAUTH)
+    raw["resources"][0]["grants"] = list(grants)
+    state = SimpleNamespace(oauth_delegated_config=raw)
+    return AutomationAccessService(
+        catalog_resolver=_CatalogResolver(
+            connections={"delegated_credentials": {"oauth": raw}}
+        ),
+        card_persistence=card_persistence,
+        redis=_Redis(), tenant="demo-tenant", project="demo-project",
+        config=oauth_delegated_config(state),
+        grant_store=_Store(), authority=_Authority(), minter=_minter,
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_claim_the_catalog_withdrew_answers_removed_not_missing(card_persistence):
+    service = _named_services_agent_service(card_persistence)
+    ns_resource = "*/kdcube-services@1-0/public/mcp/named_services*"
+    created = await service.create_access(
+        _AGENT_USER, label="agent", client_id=_AGENT_CLIENT,
+        resource_grants={ns_resource: ["named_services:use", "mail:read"]},
+        named_service_operations={ns_resource: {"mail": ["object.search"]}},
+    )
+    assert created["ok"] is True
+
+    withdrawn = _agent_service_with_row_grants(
+        card_persistence, ["named_services:use"]
+    )
+    state = await withdrawn.agent_namespace_grant_state(
+        grantor_subject="platform-user-1", client_id=_AGENT_CLIENT,
+        namespace="mail", operation="object.search",
+    )
+
+    assert state["granted"] is False
+    removed = state.get("removed")
+    assert removed is not None, "a withdrawn claim must answer removed"
+    assert removed["error"]["code"] == "delegated_capability_no_longer_available"
+    path = removed["ret"]["requested_capability"]
+    assert path["kind"] == "resource_claim"
+    assert path["claim"] == "mail:read"
+
+
+@pytest.mark.asyncio
+async def test_a_claim_the_card_lacks_is_still_reported_as_missing(card_persistence):
+    """The other side of the refusal keeps its own answer: the catalog offers
+    the claim, the card does not hold it, so consent is the remedy."""
+    service = _named_services_agent_service(card_persistence)
+    ns_resource = "*/kdcube-services@1-0/public/mcp/named_services*"
+    created = await service.create_access(
+        _AGENT_USER, label="agent", client_id=_AGENT_CLIENT,
+        resource_grants={ns_resource: ["named_services:use"]},
+    )
+    assert created["ok"] is True
+
+    state = await service.agent_namespace_grant_state(
+        grantor_subject="platform-user-1", client_id=_AGENT_CLIENT,
+        namespace="mail", operation="object.search",
+    )
+
+    assert state["granted"] is False
+    assert state.get("removed") is None
+    assert state["missing_claims"] == ["mail:read"]
+
+
+@pytest.mark.asyncio
+async def test_a_card_keyed_by_the_request_url_reports_its_claims(card_persistence):
+    """An OAuth card keys `resource_grants` by the concrete request URL. Reading
+    them by the row's selector alone would report every claim missing."""
+    service = _named_services_agent_service(card_persistence)
+    ns_resource = "*/kdcube-services@1-0/public/mcp/named_services*"
+    url = "https://kdcube.example/kdcube-services@1-0/public/mcp/named_services"
+    created = await service.create_access(
+        _AGENT_USER, label="agent", client_id=_AGENT_CLIENT,
+        resource_grants={url: ["named_services:use", "mail:read"]},
+        named_service_operations={url: {"mail": ["object.search"]}},
+    )
+    assert created["ok"] is True
+
+    state = await service.agent_namespace_grant_state(
+        grantor_subject="platform-user-1", client_id=_AGENT_CLIENT,
+        access_id=created["access"]["access_id"],
+        namespace="mail", operation="object.search",
+    )
+
+    assert state["missing_claims"] == []
+    assert state["granted"] is True
 
 
 @pytest.mark.asyncio

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/tests/test_card_service.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/tests/test_card_service.py
@@ -29,6 +29,7 @@ from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.car
 from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.cards.service import (
     CardCommitFailed,
     CardConflict,
+    CardServingUnavailable,
     DelegatedCardService,
 )
 from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.cards.store import (
@@ -448,10 +449,14 @@ async def test_a_committed_revision_is_restored_after_the_projection_write_fails
         raise ConnectionError("projection write failed")
 
     monkeypatch.setattr(cache, "commit_projection", _boom)
-    with pytest.raises(ConnectionError):
+    with pytest.raises(CardServingUnavailable) as exc:
         await service.commit(
             _authority(revision=2), subject_hash=SUBJECT_HASH, expected_revision=1, now=NOW
         )
+    # Typed so the caller can answer with the card it committed; the transport
+    # failure stays as the cause.
+    assert exc.value.access_id == ACCESS_ID
+    assert isinstance(exc.value.__cause__, ConnectionError)
     monkeypatch.undo()
 
     current = await store.read_current_authority(

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/tests/test_catalog_authorization.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/tests/test_catalog_authorization.py
@@ -296,9 +296,19 @@ def test_a_namespace_block_emptied_of_namespaces_is_a_removal_not_an_absent_sect
     assert _authorize(request_, connections=emptied) is not None
 
 
-def test_a_resource_that_enumerates_no_named_services_carries_no_inner_ceiling():
-    without_block = copy.deepcopy(CONNECTIONS)
-    without_block["delegated_credentials"]["oauth"]["resources"][0].pop("named_services")
+@pytest.mark.parametrize(
+    "withdraw",
+    [
+        pytest.param(lambda r: r.pop("named_services"), id="block-deleted"),
+        pytest.param(lambda r: r.__setitem__("named_services", {}), id="block-emptied"),
+    ],
+)
+def test_a_resource_that_publishes_no_named_services_offers_no_inner_operation(withdraw):
+    # The named-service dimension is the offer itself: a row that publishes no
+    # namespace offers no inner operation. Claims and outer operations keep
+    # reading an unenumerated dimension as no ceiling.
+    withdrawn = copy.deepcopy(CONNECTIONS)
+    withdraw(withdrawn["delegated_credentials"]["oauth"]["resources"][0])
 
     request_ = CapabilityRequest(
         kind=CAPABILITY_NAMED_SERVICE_OPERATION,
@@ -308,7 +318,7 @@ def test_a_resource_that_enumerates_no_named_services_carries_no_inner_ceiling()
         namespace="mail",
         operation="object.schema",
     )
-    assert _authorize(request_, connections=without_block) is None
+    assert _authorize(request_, connections=withdrawn) is not None
 
 
 def test_a_resource_that_enumerates_no_tools_carries_no_outer_ceiling():

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/tests/test_catalog_authorization.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/tests/test_catalog_authorization.py
@@ -398,3 +398,146 @@ def test_unavailability_is_retryable_and_distinct_from_removal():
     assert payload["error"]["retryable"] is True
     assert payload["error"]["code"] != DENIAL_CODE
     assert payload["ret"]["reason"] == "cache_unavailable"
+
+
+# -- the outer dimension and the all-resource admin row ------------------------
+#
+# Two rows read the same absent `tools` block and must not answer the same way.
+# A door that stopped publishing its outer tools has withdrawn them. The
+# all-resource admin row never published any, and is reachable only by a card
+# whose own selector is `*` (config.card_selector_config).
+
+ADMIN_SELECTOR = "*"
+UNLISTED_URL = (
+    "https://kdcube.example/api/integrations/bundles/acme/prod/"
+    "unlisted@1-0/public/mcp/anything"
+)
+
+
+_WITHDRAWALS = [
+    pytest.param(lambda r: r.pop("tools"), id="block-deleted"),
+    pytest.param(lambda r: r.__setitem__("tools", {}), id="block-emptied"),
+]
+
+
+def _without_outer_tools(withdraw=lambda r: r.__setitem__("tools", {})) -> dict:
+    trimmed = copy.deepcopy(CONNECTIONS)
+    withdraw(trimmed["delegated_credentials"]["oauth"]["resources"][0])
+    return trimmed
+
+
+def _with_admin_row(connections=None) -> dict:
+    extended = copy.deepcopy(connections if connections is not None else CONNECTIONS)
+    extended["delegated_credentials"]["oauth"]["resources"].append(
+        {
+            "resource": ADMIN_SELECTOR,
+            "label": "All KDCube resources",
+            "admin_only": True,
+            "grants": ["kdcube:admin"],
+        }
+    )
+    return extended
+
+
+@pytest.mark.parametrize("withdraw", _WITHDRAWALS)
+def test_an_outer_operation_the_catalog_withdrew_is_denied(withdraw):
+    # Deleting the block and emptying it are the same withdrawal: a door that
+    # publishes no tool offers none.
+    request_ = CapabilityRequest(
+        kind=CAPABILITY_OUTER_OPERATION,
+        resource=SELECTOR,
+        request_resource=REQUEST_URL,
+        surface="mcp",
+        outer_operation="named_services_search",
+    )
+    denial = _authorize(request_, connections=_without_outer_tools(withdraw))
+
+    assert denial is not None
+    assert denial["error"]["code"] == DENIAL_CODE
+    assert denial["ret"]["requested_capability"]["outer_operation"] == "named_services_search"
+
+
+def test_the_all_resource_admin_row_carries_no_outer_ceiling():
+    request_ = CapabilityRequest(
+        kind=CAPABILITY_OUTER_OPERATION,
+        resource=ADMIN_SELECTOR,
+        request_resource=UNLISTED_URL,
+        surface="mcp",
+        outer_operation="anything_at_all",
+    )
+    assert _authorize(request_, connections=_with_admin_row()) is None
+
+
+# -- the claim ceiling is the row's grants, written or derived -----------------
+#
+# `resources[].grants` is the door's claim ceiling; when it is not written it is
+# derived from the grants its tools and namespaces require. There is no third
+# state in which a door carries no claim ceiling, and no source describes one for
+# the all-resource row either — unlike outer tools, a claim has no second source:
+# the guard reduces stored claims through `resource_claims` alone.
+
+
+def _claim_request(claim: str = "mail:read") -> CapabilityRequest:
+    return CapabilityRequest(
+        kind=CAPABILITY_RESOURCE_CLAIM,
+        resource=SELECTOR,
+        request_resource=REQUEST_URL,
+        surface="mcp",
+        claim=claim,
+    )
+
+
+def _with_row(row: dict) -> dict:
+    return {"delegated_credentials": {"oauth": {"enabled": True, "resources": [row]}}}
+
+
+_CLAIM_CEILINGS = [
+    pytest.param({"resource": SELECTOR, "grants": ["mail:read", "x:y"]}, True, id="declared-present"),
+    pytest.param({"resource": SELECTOR, "grants": ["x:y"]}, False, id="declared-removed"),
+    pytest.param({"resource": SELECTOR, "grants": []}, False, id="emptied"),
+    pytest.param({"resource": SELECTOR}, False, id="deleted"),
+    pytest.param({"resource": "*", "grants": []}, False, id="all-resource-row-emptied"),
+]
+
+
+@pytest.mark.parametrize("row,allowed", _CLAIM_CEILINGS)
+def test_a_claim_the_catalog_no_longer_offers_is_denied(row, allowed):
+    denial = _authorize(_claim_request(), connections=_with_row(row))
+    assert (denial is None) is allowed
+
+
+@pytest.mark.parametrize("row,_allowed", _CLAIM_CEILINGS)
+def test_both_readers_of_the_claim_ceiling_agree(row, _allowed):
+    """`permits` and `resource_claims` read one dimension from one row.
+
+    They disagreed while an empty ceiling read as no ceiling in one and as
+    nothing available in the other, and the guard consults both: the loop that
+    finds a withdrawn claim is keyed on `resource_claims`, then asks `permits` to
+    build the denial. A disagreement there yields no denial body at all.
+    """
+    catalog = _catalog(_with_row(row))
+    request_ = _claim_request()
+
+    assert catalog.permits(request_) is (
+        _clean_claim(request_.claim) in catalog.resource_claims(request_)
+    )
+
+
+def _clean_claim(value: str) -> str:
+    return str(value or "").strip()
+
+
+def test_a_withdrawn_door_is_not_rescued_by_the_admin_row():
+    request_ = CapabilityRequest(
+        kind=CAPABILITY_OUTER_OPERATION,
+        resource=SELECTOR,
+        request_resource=REQUEST_URL,
+        surface="mcp",
+        outer_operation="named_services_search",
+    )
+    denial = _authorize(
+        request_, connections=_with_admin_row(_without_outer_tools())
+    )
+
+    assert denial is not None
+    assert denial["error"]["code"] == DENIAL_CODE

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/tests/test_catalog_drift.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/tests/test_catalog_drift.py
@@ -239,13 +239,25 @@ def test_a_card_that_selected_nothing_reports_no_inner_removals():
     assert drift["removed"]["named_service_operations"] == []
 
 
-def test_a_resource_that_enumerates_no_named_services_reports_no_inner_removals():
-    without_block = copy.deepcopy(CONNECTIONS)
-    without_block["delegated_credentials"]["oauth"]["resources"][0].pop("named_services")
+@pytest.mark.parametrize(
+    "withdraw",
+    [
+        pytest.param(lambda r: r.pop("named_services"), id="block-deleted"),
+        pytest.param(lambda r: r.__setitem__("named_services", {}), id="block-emptied"),
+    ],
+)
+def test_a_resource_that_publishes_no_named_services_reports_every_selection_removed(withdraw):
+    # The guard denies these operations, so the owner has to see what to repair.
+    withdrawn = copy.deepcopy(CONNECTIONS)
+    withdraw(withdrawn["delegated_credentials"]["oauth"]["resources"][0])
 
-    drift = card_drift(card=_card(), active=_document(without_block), baseline=_document())
+    drift = card_drift(card=_card(), active=_document(withdrawn), baseline=_document())
 
-    assert drift["removed"]["named_service_operations"] == []
+    assert drift["status"] == DRIFT_CHANGED
+    assert [
+        (row["namespace"], row["operation"])
+        for row in drift["removed"]["named_service_operations"]
+    ] == [("mail", "object.schema"), ("mail", "object.search")]
 
 
 # -- additions ------------------------------------------------------------------

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/tests/test_catalog_drift.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/tests/test_catalog_drift.py
@@ -263,6 +263,54 @@ def test_a_resource_that_publishes_no_named_services_reports_every_selection_rem
 # -- additions ------------------------------------------------------------------
 
 
+@pytest.mark.parametrize(
+    "withdraw",
+    [
+        pytest.param(lambda r: r.pop("tools"), id="block-deleted"),
+        pytest.param(lambda r: r.__setitem__("tools", {}), id="block-emptied"),
+    ],
+)
+def test_a_resource_that_publishes_no_outer_operations_reports_every_selection_removed(
+    withdraw,
+):
+    # The guard denies these tools, so the owner has to see what to repair.
+    # Both spellings are the same withdrawal.
+    withdrawn = copy.deepcopy(CONNECTIONS)
+    withdraw(withdrawn["delegated_credentials"]["oauth"]["resources"][0])
+
+    drift = card_drift(card=_card(), active=_document(withdrawn), baseline=_document())
+
+    assert drift["status"] == DRIFT_CHANGED
+    assert [row["operation"] for row in drift["removed"]["outer_operations"]] == [
+        "named_services_schema",
+        "named_services_search",
+    ]
+
+
+def test_the_wildcard_row_publishes_no_outer_ceiling_and_never_drifts():
+    """The all-resource row takes its operations from endpoint policy, so an
+    administrator card holding them reads as current, not as removed."""
+    catalog = copy.deepcopy(CONNECTIONS)
+    catalog["delegated_credentials"]["oauth"]["resources"].append(
+        {
+            "resource": "*",
+            "label": "All platform and application APIs",
+            "admin_only": True,
+            "grants": ["kdcube:role:super-admin"],
+        }
+    )
+    document = _document(catalog)
+    card = _card(
+        resource_grants={"*": ("kdcube:role:super-admin",)},
+        operations=("records_export",),
+        named_service_operations=NamedServiceSelection.none(),
+    )
+
+    drift = card_drift(card=card, active=document, baseline=document)
+
+    assert drift["removed"]["outer_operations"] == []
+
+
 def test_a_new_named_service_operation_is_offered_unselected():
     active = _document(_trim(add_named_service_tool="comments"))
 

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/tests/test_catalog_publisher.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/tests/test_catalog_publisher.py
@@ -14,6 +14,7 @@ import pytest
 
 from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.catalog.publisher import (
     CatalogPublicationError,
+    SIGNATURE_FILENAME,
     ensure_delegated_catalog,
 )
 from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.catalog.resolver import (
@@ -228,6 +229,7 @@ async def test_the_reread_value_is_published_not_the_captured_one(tmp_path, cach
     assert result.created is True
     assert active.connections == moved
     assert result.content_hash == active.content_hash
+    assert (store.root / SIGNATURE_FILENAME).read_text(encoding="utf-8").strip() == active.content_hash
 
 
 @pytest.mark.asyncio

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/tests/test_catalog_publisher.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/tests/test_catalog_publisher.py
@@ -176,3 +176,94 @@ async def test_published_catalog_is_resolvable_for_request_serving(tmp_path, cac
     active = await resolver.resolve_active()
     assert active.version == published.version
     assert (await resolver.resolve_version(published.version)).connections == CONNECTIONS
+
+
+# -- publishing what is current, not what was captured ------------------------
+#
+# A publisher that read its props before another generation was published would
+# otherwise register that older content under a later version stamp. No version
+# comparison can refuse it: the stamp is minted at publication, so the stale
+# document looks newer on both the durable and the serving side.
+
+
+def _changed(**resource_overrides) -> dict:
+    body = copy.deepcopy(CONNECTIONS)
+    body["delegated_credentials"]["oauth"]["resources"][0].update(resource_overrides)
+    return body
+
+
+@pytest.mark.asyncio
+async def test_a_stale_publisher_registers_current_connections(tmp_path, cache):
+    store = BundleStorageDelegatedCatalogStore(tmp_path)
+    current = _changed(grants=["named_services:use", "slack:read", "slack:write"])
+    published = await _ensure(current, store, cache)
+
+    async def _reread():
+        return current
+
+    # This publisher captured CONNECTIONS before `current` was published.
+    stale = await _ensure(CONNECTIONS, store, cache, reread=_reread)
+
+    assert stale.version == published.version
+    assert stale.created is False
+    assert (await store.read_active()).connections == current
+    assert (await cache.read_active()).connections == current
+
+
+@pytest.mark.asyncio
+async def test_the_reread_value_is_published_not_the_captured_one(tmp_path, cache):
+    store = BundleStorageDelegatedCatalogStore(tmp_path)
+    await _ensure(CONNECTIONS, store, cache)
+    captured = _changed(grants=["named_services:use"])
+    moved = _changed(grants=["named_services:use", "slack:read", "mail:read"])
+
+    async def _reread():
+        return moved
+
+    # `captured` differs from what is registered, so the publisher enters the
+    # section rather than taking the signature fast path.
+    result = await _ensure(captured, store, cache, reread=_reread)
+
+    active = await store.read_active()
+    assert result.created is True
+    assert active.connections == moved
+    assert result.content_hash == active.content_hash
+
+
+@pytest.mark.asyncio
+async def test_a_publisher_whose_capture_is_registered_skips_before_the_section(tmp_path, cache):
+    store = BundleStorageDelegatedCatalogStore(tmp_path)
+    first = await _ensure(CONNECTIONS, store, cache)
+    reread_calls = 0
+
+    async def _reread():
+        nonlocal reread_calls
+        reread_calls += 1
+        return CONNECTIONS
+
+    second = await _ensure(CONNECTIONS, store, cache, reread=_reread)
+
+    assert second.version == first.version
+    assert reread_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_without_a_reread_the_captured_value_is_published(tmp_path, cache):
+    store = BundleStorageDelegatedCatalogStore(tmp_path)
+    result = await _ensure(CONNECTIONS, store, cache)
+
+    assert (await store.read_active()).connections == CONNECTIONS
+    assert result.created is True
+
+
+@pytest.mark.asyncio
+async def test_an_unhashable_reread_is_a_publication_error(tmp_path, cache):
+    store = BundleStorageDelegatedCatalogStore(tmp_path)
+
+    async def _reread():
+        return {"resources": {object()}}
+
+    with pytest.raises(CatalogPublicationError) as exc:
+        await _ensure(CONNECTIONS, store, cache, reread=_reread)
+    assert exc.value.reason == "connections_not_hashable"
+    assert await store.read_active() is None

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/tests/test_delegated_cache_transitions.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/tests/test_delegated_cache_transitions.py
@@ -13,6 +13,7 @@ import copy
 import hashlib
 import os
 import uuid
+from dataclasses import replace
 from datetime import datetime, timedelta, timezone
 
 import pytest
@@ -320,6 +321,74 @@ async def test_restore_installs_over_a_strictly_older_projection(card_cache):
     assert (await card_cache.read(ACCESS_ID)).card_revision == 8
 
 
+# -- finalizing after the marker's residency lapsed ---------------------------
+#
+# A read-through refills the key with the superseded revision once the marker
+# expires. Without a revision comparison the committed revision never reaches
+# the projection, and the old card serves for its full remaining lifetime.
+
+
+@pytest.mark.asyncio
+async def test_commit_installs_over_the_revision_it_supersedes(card_cache, redis_client):
+    await card_cache.claim_transition(
+        ACCESS_ID, mutation_id="m1", expected_revision=7, ttl_seconds=15
+    )
+    await redis_client.delete(card_cache.card_key(ACCESS_ID))  # marker TTL lapses
+    assert await card_cache.restore_projection(_authority(revision=7), ttl_seconds=300) is True
+
+    assert await card_cache.commit_projection(
+        _authority(revision=8), mutation_id="m1", ttl_seconds=300
+    ) is True
+    assert (await card_cache.read(ACCESS_ID)).card_revision == 8
+
+
+@pytest.mark.asyncio
+async def test_tombstone_installs_over_the_revision_it_supersedes(card_cache):
+    await card_cache.restore_projection(_authority(revision=7), ttl_seconds=300)
+
+    assert await card_cache.commit_tombstone(
+        ACCESS_ID, card_revision=8, mutation_id="m1", ttl_seconds=60
+    ) is True
+    assert (await card_cache.read(ACCESS_ID)).is_revoked
+
+
+@pytest.mark.asyncio
+async def test_a_stale_finalizer_does_not_install_over_a_newer_projection(card_cache):
+    await card_cache.restore_projection(_authority(revision=9), ttl_seconds=300)
+
+    assert await card_cache.commit_projection(
+        _authority(revision=8), mutation_id="m1", ttl_seconds=300
+    ) is False
+    assert await card_cache.commit_projection(
+        _authority(revision=9), mutation_id="m1", ttl_seconds=300
+    ) is False
+    assert (await card_cache.read(ACCESS_ID)).card_revision == 9
+
+
+@pytest.mark.asyncio
+async def test_finalizing_never_displaces_a_tombstone(card_cache):
+    await card_cache.commit_tombstone(
+        ACCESS_ID, card_revision=8, mutation_id="m1", ttl_seconds=60
+    )
+    assert await card_cache.commit_projection(
+        _authority(revision=9), mutation_id="m2", ttl_seconds=300
+    ) is False
+    assert (await card_cache.read(ACCESS_ID)).is_revoked
+
+
+@pytest.mark.asyncio
+async def test_release_leaves_a_refilled_projection_alone(card_cache, redis_client):
+    await card_cache.claim_transition(
+        ACCESS_ID, mutation_id="m1", expected_revision=7, ttl_seconds=15
+    )
+    await redis_client.delete(card_cache.card_key(ACCESS_ID))  # marker TTL lapses
+    await card_cache.restore_projection(_authority(revision=7), ttl_seconds=300)
+
+    # The durable commit failed, so revision 7 still stands.
+    assert await card_cache.finalize_removal(ACCESS_ID, mutation_id="m1") is False
+    assert (await card_cache.read(ACCESS_ID)).card_revision == 7
+
+
 # -- per-grantor index --------------------------------------------------------
 
 
@@ -419,3 +488,91 @@ async def test_list_rebuilds_an_evicted_index_from_durable_records(card_cache, t
 
     assert [item.access_id for item in listed] == [ACCESS_ID]
     assert await card_cache.index_members(subject_hash=SUBJECT_HASH, now=now) == [ACCESS_ID]
+
+
+@pytest.mark.asyncio
+async def test_list_readmits_one_card_the_index_lost(card_cache, tmp_path):
+    # The index write is the last step of a commit. When it alone fails, the
+    # card serves while its grantor cannot see or revoke it, and the whole-index
+    # rebuild never runs because other members are present.
+    store = BundleStorageDelegatedCardStore(tmp_path)
+    now = 1_780_000_000
+    resolver = DelegatedCardResolver(cache=card_cache, store=store)
+
+    for access_id in ("aut_alpha", "aut_bravo"):
+        authority = _authority(revision=1, expires_at=now + 180 * 24 * 3600)
+        authority = replace(authority, access_id=access_id)
+        pointer = await store.write_revision(
+            subject_hash=SUBJECT_HASH, authority=authority, updated_at=datetime.now(timezone.utc)
+        )
+        await store.advance_current(subject_hash=SUBJECT_HASH, pointer=pointer)
+        await card_cache.index_add(
+            subject_hash=SUBJECT_HASH, access_id=access_id, expires_at=authority.expires_at
+        )
+
+    await card_cache.index_remove(subject_hash=SUBJECT_HASH, access_id="aut_bravo")
+
+    listed = await resolver.list_active(subject_hash=SUBJECT_HASH, now=now)
+
+    assert sorted(item.access_id for item in listed) == ["aut_alpha", "aut_bravo"]
+    assert sorted(
+        await card_cache.index_members(subject_hash=SUBJECT_HASH, now=now)
+    ) == ["aut_alpha", "aut_bravo"]
+
+
+@pytest.mark.asyncio
+async def test_list_does_not_readmit_a_revoked_card_present_only_in_durable(card_cache, tmp_path):
+    store = BundleStorageDelegatedCardStore(tmp_path)
+    now = 1_780_000_000
+    resolver = DelegatedCardResolver(cache=card_cache, store=store)
+
+    for revision, state in ((1, CARD_STATE_ACTIVE), (2, CARD_STATE_REVOKED)):
+        authority = _authority(revision=revision, expires_at=now + 3600, state=state)
+        pointer = await store.write_revision(
+            subject_hash=SUBJECT_HASH, authority=authority, updated_at=datetime.now(timezone.utc)
+        )
+        await store.advance_current(subject_hash=SUBJECT_HASH, pointer=pointer)
+
+    listed = await resolver.list_active(subject_hash=SUBJECT_HASH, now=now)
+
+    assert listed == []
+    assert await card_cache.index_members(subject_hash=SUBJECT_HASH, now=now) == []
+
+
+# -- serving state that fails after the durable commit ------------------------
+
+
+class _IndexBlip(DelegatedCardRuntimeCache):
+    """Redis serves the commit and fails on its last step."""
+
+    async def index_add(self, **kwargs):
+        raise ConnectionError("redis went away")
+
+
+@pytest.mark.asyncio
+async def test_a_serving_failure_after_commit_is_typed_and_names_the_card(
+    redis_client, namespace, tmp_path
+):
+    from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.cards.service import (
+        CardServingUnavailable,
+        DelegatedCardService,
+    )
+
+    tenant, project = namespace
+    store = BundleStorageDelegatedCardStore(tmp_path)
+    service = DelegatedCardService(
+        cache=_IndexBlip(redis_client, tenant=tenant, project=project), store=store
+    )
+    authority = _authority(revision=1, expires_at=1_780_003_600)
+
+    with pytest.raises(CardServingUnavailable) as exc:
+        await service.commit(
+            authority, subject_hash=SUBJECT_HASH, expected_revision=0, now=1_780_000_000
+        )
+
+    assert exc.value.access_id == ACCESS_ID
+    # The revision is the authority; only its serving state is missing.
+    current = await store.read_current_authority(
+        subject_hash=SUBJECT_HASH, access_id=ACCESS_ID
+    )
+    assert current is not None and current[1].card_revision == 1

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/tests/test_named_service_selection_persistence.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/delegated_credentials/tests/test_named_service_selection_persistence.py
@@ -9,8 +9,11 @@ import uuid
 
 import pytest
 
+from types import SimpleNamespace
+
 from test_automation_access import (
     AutomationAccessService,
+    NAMED_SERVICES_OAUTH,
     _CatalogResolver,
     _Authority,
     _minter,
@@ -19,6 +22,10 @@ from test_automation_access import (
     _NamedServiceDiscovery,
     _Redis,
     _Store,
+)
+
+from kdcube_ai_app.apps.chat.sdk.solutions.connections.delegated_credentials.oauth.config import (
+    oauth_delegated_config,
 )
 
 from dataclasses import replace
@@ -1022,3 +1029,89 @@ async def test_a_delegate_cannot_change_the_card_that_issued_it(card_persistence
 
     stored = await service._load_record(access_id, grantor_subject=USER["user_id"])
     assert stored is not None and stored.card_revision == 1
+
+
+# -- the selection is read under the key it was written with --------------------
+#
+# An OAuth consent records its selection under the CONCRETE request URL, while a
+# catalog row is normally a pattern. Materializing the boundary under the row's
+# selector instead of the card's own key misses, and "resource absent" means
+# "narrowed to nothing" — so every OAuth card silently carried an empty
+# named-service boundary while its stored selection said otherwise. The manual
+# create and save paths already materialize under the card's key.
+
+
+def _patterned_catalog() -> dict:
+    """The same deployment, with its resource row written as a pattern."""
+    import copy as _copy
+
+    oauth = _copy.deepcopy(NAMED_SERVICES_OAUTH)
+    for row in oauth["resources"]:
+        if row.get("resource") == RESOURCE:
+            row["resource"] = "*/mcp/named-services"
+    return oauth
+
+
+def _service_with_patterned_row(card_persistence) -> AutomationAccessService:
+    oauth = _patterned_catalog()
+    return AutomationAccessService(
+        catalog_resolver=_CatalogResolver(
+            connections={"delegated_credentials": {"oauth": oauth}}
+        ),
+        card_persistence=card_persistence,
+        redis=_Redis(),
+        tenant="demo-tenant",
+        project="demo-project",
+        config=oauth_delegated_config(
+            SimpleNamespace(state=SimpleNamespace(oauth_delegated_config=oauth))
+        ),
+        grant_store=_Store(),
+        authority=_Authority(),
+        minter=_minter,
+        named_service_discovery=_NamedServiceDiscovery({}),
+    )
+
+
+@pytest.mark.asyncio
+async def test_an_oauth_consent_materializes_under_a_patterned_row(card_persistence):
+    service = _service_with_patterned_row(card_persistence)
+
+    await service.record_oauth_grant(
+        grantor_subject=USER["user_id"],
+        client_id="claude",
+        scopes=GRANTS,
+        resource=RESOURCE,
+        access_token="at",
+        refresh_token="rt",
+        named_service_operations={RESOURCE: {"slack": ["object.search"]}},
+        catalog_version="delegated_catalog_2026-08-28-00-00-00-000_aaaabbbbcccc",
+    )
+
+    card_id = oauth_access_id(USER["user_id"], "claude", RESOURCE)
+    selection, namespaces = await _stored(service, card_id)
+
+    assert selection == {RESOURCE: {"slack": ["object.search"]}}
+    assert namespaces == ["slack"]
+
+
+@pytest.mark.asyncio
+async def test_an_oauth_consent_still_materializes_under_a_literal_row(card_persistence):
+    """The mirror: when the row is written as the URL itself, nothing changes."""
+    service = _service(card_persistence)
+
+    await service.record_oauth_grant(
+        grantor_subject=USER["user_id"],
+        client_id="claude",
+        scopes=GRANTS,
+        resource=RESOURCE,
+        access_token="at",
+        refresh_token="rt",
+        named_service_operations={RESOURCE: {"slack": ["object.search"]}},
+        catalog_version="delegated_catalog_2026-08-28-00-00-00-000_aaaabbbbcccc",
+    )
+
+    card_id = oauth_access_id(USER["user_id"], "claude", RESOURCE)
+    selection, namespaces = await _stored(service, card_id)
+
+    assert selection == {RESOURCE: {"slack": ["object.search"]}}
+    assert namespaces == ["slack"]

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/mcp_result.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/mcp_result.py
@@ -72,6 +72,7 @@ async def announce_result_consent(parsed: Dict[str, Any]) -> Dict[str, Any] | No
             return None
         block = _consent_block(parsed)
         namespace = str(block.get("namespace") or parsed.get("namespace") or "").strip()
+        operation = str(block.get("operation") or parsed.get("operation") or "").strip()
 
         if code == NEEDS_CONNECTED_ACCOUNT_CONSENT:
             from kdcube_ai_app.apps.chat.sdk.solutions.named_services_providers.consent import (
@@ -109,8 +110,9 @@ async def announce_result_consent(parsed: Dict[str, Any]) -> Dict[str, Any] | No
         )
 
         logger.info(
-            "[mcp-result] agent-grant consent -> banner: client=%s resource=%s claims=%s namespace=%s",
-            client_id, resource, claims, namespace,
+            "[mcp-result] agent-grant consent -> banner: client=%s resource=%s "
+            "claims=%s namespace=%s operation=%s",
+            client_id, resource, claims, namespace, operation,
         )
         consent = mcp_consent_from_denial(
             {"status": 403, "reason": "authority_mismatch"},
@@ -118,6 +120,8 @@ async def announce_result_consent(parsed: Dict[str, Any]) -> Dict[str, Any] | No
             claims=claims,
             tool_name=str(block.get("tool_name") or namespace),
             agent_client_id=client_id,
+            namespace=namespace,
+            operation=operation,
         )
         await announce_agent_consent(consent)
         return consent.to_tool_result()

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/tests/test_mcp_result.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/connections/tests/test_mcp_result.py
@@ -31,17 +31,20 @@ def _tool(result):
 
 
 def test_agent_grant_consent_announced_from_self_describing_block(monkeypatch):
-    # The block carries agent_client_id + resource + claims + namespace — the
-    # post-processor reads them directly; NO fallback resource, NO parsing.
+    # The block carries agent_client_id + resource + claims + namespace +
+    # operation — the post-processor reads them directly; NO fallback resource,
+    # NO tool-name parsing.
     client = "kdcube-agent:app@v1:main"
     resource = "*/kdcube-services@1-0/public/mcp/named_services*"
     denial = json.dumps({
         "ok": False, "error": "delegated_consent_required",
-        "namespace": "slack", "missing_grants": ["slack:read"],
+        "namespace": "slack", "operation": "object.search",
+        "missing_grants": ["slack:read"],
         "consent": {
             "kind": "delegated_agent_grant", "agent_client_id": client,
             "resource": resource, "claims": ["slack:read"],
             "tool_name": "slack", "namespace": "slack",
+            "operation": "object.search",
         },
     })
     announced = []
@@ -61,7 +64,10 @@ def test_agent_grant_consent_announced_from_self_describing_block(monkeypatch):
     out = json.loads(content)
     assert out["consent"]["grant"]["payload"] == {
         "client_id": client, "resource": resource, "claims": ["slack:read"],
+        "named_service_operations": {"slack": ["object.search"]},
     }
+    assert out["consent"]["namespace"] == "slack"
+    assert out["consent"]["operation"] == "object.search"
 
 
 def test_agent_grant_consent_announced_from_normalized_mcp_content_envelope(monkeypatch, caplog):

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/named_services_providers/admission.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/named_services_providers/admission.py
@@ -212,7 +212,16 @@ class NamedServiceAdmission:
 
     def validate(self, request: NamedServiceRequest) -> None:
         if not isinstance(request, NamedServiceRequest):
-            raise TypeError("Named-service admission validates a decoded NamedServiceRequest")
+            # A caller loaded by path holds its own generation of this package,
+            # so its decoded request is a different class object with the same
+            # shape. `coerce` accepts that and still refuses anything it cannot
+            # decode, which is what the type check is for.
+            try:
+                request = NamedServiceRequest.coerce(request)
+            except TypeError as exc:
+                raise TypeError(
+                    "Named-service admission validates a decoded NamedServiceRequest"
+                ) from exc
         if not _clean(request.namespace):
             raise ValueError("Named-service admission requires a request namespace")
         if not effective_named_service_operation(request):

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/named_services_providers/tests/test_admission.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/named_services_providers/tests/test_admission.py
@@ -246,3 +246,60 @@ def test_production_dispatch_calls_name_their_admission():
                 missing.append(f"{path.relative_to(sdk_root)}:{node.lineno}")
 
     assert missing == []
+
+
+# -- a caller loaded by path holds its own generation of this package ---------
+#
+# `tool_subsystem` loads a tools module referenced by PATH through
+# `load_dynamic_module_for_path`, which builds a synthetic package. The module's
+# relative imports then resolve inside it, so the request reaching admission is
+# a same-shaped class from another generation while admission holds this one.
+
+
+def _foreign_generation_request():
+    """A decoded request as a second generation of this package would build it."""
+
+    namespace = {}
+    exec(  # noqa: S102 - a deliberate second class object with the same shape
+        "class NamedServiceRequest:\n"
+        "    def __init__(self, namespace, operation):\n"
+        "        self.namespace = namespace\n"
+        "        self.operation = operation\n"
+        "        self.action = None\n"
+        "    def to_dict(self):\n"
+        "        return {'namespace': self.namespace, 'operation': self.operation}\n",
+        namespace,
+    )
+    return namespace["NamedServiceRequest"](namespace="mail", operation="object.search")
+
+
+def test_a_request_from_another_generation_of_this_package_is_admitted():
+    foreign = _foreign_generation_request()
+    assert not isinstance(foreign, NamedServiceRequest)
+
+    admission = NamedServiceAdmission.application(source="test")
+    admission.validate(foreign)  # must not raise
+
+
+def test_something_that_is_not_a_request_is_still_refused():
+    admission = NamedServiceAdmission.application(source="test")
+    with pytest.raises(TypeError):
+        admission.validate(object())
+
+
+@pytest.mark.asyncio
+async def test_a_foreign_generation_request_reaches_the_provider(monkeypatch):
+    seen = {}
+
+    async def _module_call(endpoint, request):
+        seen["operation"] = request.operation
+        return NamedServiceResponse.ok_response(namespace=request.namespace)
+
+    monkeypatch.setattr(api_client, "_call_module_endpoint", _module_call)
+    response = await call_named_service_endpoint(
+        _endpoint(),
+        _foreign_generation_request(),
+        admission=NamedServiceAdmission.application(source="test"),
+    )
+    assert response.ok is True
+    assert seen["operation"] == "object.search"

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/infra/plugin/bundle_once.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/infra/plugin/bundle_once.py
@@ -170,6 +170,7 @@ async def run_once_for_shared_bundle_storage(
     signature: str,
     ready: Callable[[], bool | Awaitable[bool]],
     action: Callable[[], Awaitable[Any]],
+    signature_after_action: Callable[[], str] | None = None,
     logger: Optional[Any] = None,
     owner_metadata: Optional[dict[str, Any]] = None,
     lock_wait_seconds: float = 600.0,
@@ -188,6 +189,11 @@ async def run_once_for_shared_bundle_storage(
     The action is considered current when both are true:
     - signature_path contains `signature`
     - ready() returns True; it may be synchronous or awaitable
+
+    ``signature_after_action`` supports actions that discover their committed
+    identity only inside the lock. The initial ``signature`` still controls
+    admission to the action; after a successful action the callback's value is
+    written while the lock is held.
 
     The lock is a directory under `<storage_root>/.kdcube.once/`, which works for
     local filesystems and shared mounts such as EFS. Filesystem operations run
@@ -304,7 +310,12 @@ async def run_once_for_shared_bundle_storage(
         await _run_action(action)
         if not await _run_ready(ready):
             raise RuntimeError(f"{op} action completed but ready() is false for storage={root}")
-        await asyncio.to_thread(_write_signature, sig_path, signature)
+        committed_signature = (
+            signature_after_action() if signature_after_action is not None else signature
+        )
+        if not isinstance(committed_signature, str):
+            raise TypeError("signature_after_action must return a string")
+        await asyncio.to_thread(_write_signature, sig_path, committed_signature)
         _logger_log(logger, f"{log_prefix} done: op={op} storage={root}", "INFO")
         return SharedStorageOnceResult("ran", root, op, lock_path, sig_path, ran=True)
     finally:

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/infra/plugin/tests/test_bundle_once.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/infra/plugin/tests/test_bundle_once.py
@@ -43,6 +43,33 @@ def test_run_once_for_shared_bundle_storage_runs_action_and_writes_signature(tmp
     assert signature_path.read_text(encoding="utf-8").strip() == "sig-1"
 
 
+def test_run_once_writes_the_signature_discovered_inside_the_action(tmp_path):
+    storage_root = tmp_path / "storage"
+    signature_path = storage_root / ".demo.signature"
+    output_path = storage_root / "output.txt"
+    committed = {"signature": "sig-1"}
+
+    async def _action():
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text("ok", encoding="utf-8")
+        committed["signature"] = "sig-2"
+
+    result = asyncio.run(
+        run_once_for_shared_bundle_storage(
+            storage_root=storage_root,
+            operation="demo",
+            signature_path=signature_path,
+            signature="sig-1",
+            ready=output_path.exists,
+            action=_action,
+            signature_after_action=lambda: committed["signature"],
+        )
+    )
+
+    assert result.status == "ran"
+    assert signature_path.read_text(encoding="utf-8").strip() == "sig-2"
+
+
 def test_run_once_for_shared_bundle_storage_skips_when_current(tmp_path):
     storage_root = tmp_path / "storage"
     storage_root.mkdir()

--- a/app/ai-app/src/kdcube-ai-app/npm/packages/components-core/src/chat/connectionsConsent.ts
+++ b/app/ai-app/src/kdcube-ai-app/npm/packages/components-core/src/chat/connectionsConsent.ts
@@ -100,6 +100,8 @@ export function agentGrantConsentOpen(args: {
   agentClientId: string
   resource: string
   claims: string[]
+  namespace?: string
+  operation?: string
   accountId?: string
   accountClaim?: string
   url?: string
@@ -111,6 +113,12 @@ export function agentGrantConsentOpen(args: {
   if (resource) params.resource = resource
   const claims = (args.claims || []).map((item) => String(item || '').trim()).filter(Boolean)
   if (claims.length) params.claims = claims.join(',')
+  // The demand names one inner operation; the panel seeds its picker from these
+  // two, so omitting them opens the grant with nothing selected.
+  const namespace = String(args.namespace || '').trim()
+  if (namespace) params.namespace = namespace
+  const operation = String(args.operation || '').trim()
+  if (operation) params.operation = operation
   const accountId = String(args.accountId || '').trim()
   if (accountId) params.account_id = accountId
   const accountClaim = String(args.accountClaim || '').trim()

--- a/app/ai-app/src/kdcube-ai-app/npm/packages/components-core/src/chat/reducers.ts
+++ b/app/ai-app/src/kdcube-ai-app/npm/packages/components-core/src/chat/reducers.ts
@@ -267,6 +267,10 @@ function connectedAccountConsentBanner(data: Record<string, unknown> | undefined
   const agentClientId = firstString(consent.agent_client_id, grantPayload?.client_id, urlParams.agent_client_id)
   if (agentClientId) {
     const resource = firstString(consent.resource, grantPayload?.resource, urlParams.resource)
+    // The inner operation the demand is about. The panel seeds its picker from
+    // these, so dropping them opens the grant with nothing selected.
+    const grantNamespace = firstString(consent.namespace, urlParams.namespace)
+    const grantOperation = firstString(consent.operation, urlParams.operation)
     const explicitGrantClaims = firstStringList(grant?.claims, grantPayload?.claims, urlParams.claims)
     const grantClaims = explicitGrantClaims.length ? explicitGrantClaims : (accountClaim ? [] : claims)
     const displayClaims = accountClaim ? [accountClaim] : grantClaims
@@ -280,7 +284,16 @@ function connectedAccountConsentBanner(data: Record<string, unknown> | undefined
       text: text || `Grant this agent access to ${resource || 'your data'}.`,
       actionLabel: actionLabel || 'Grant access',
       actionUrl: url,
-      consent: agentGrantConsentOpen({ agentClientId, resource, claims: grantClaims, accountId, accountClaim, url }),
+      consent: agentGrantConsentOpen({
+        agentClientId,
+        resource,
+        claims: grantClaims,
+        namespace: grantNamespace,
+        operation: grantOperation,
+        accountId,
+        accountClaim,
+        url,
+      }),
       // The supersession prefix runs through the FIRST '|': keep agent AND
       // resource before it, so one agent's demands on different resources
       // coexist as separate banners (memories next to the named-services

--- a/app/ai-app/src/kdcube-ai-app/npm/packages/components-core/tests/chat-connections-consent.test.mjs
+++ b/app/ai-app/src/kdcube-ai-app/npm/packages/components-core/tests/chat-connections-consent.test.mjs
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict'
 import { test } from 'node:test'
-import { connectionsConsentOpen, consentOpenForClaims, consentTiersForClaims } from '../dist/chat/index.js'
+import { agentGrantConsentOpen, connectionsConsentOpen, consentOpenForClaims, consentTiersForClaims } from '../dist/chat/index.js'
 
 // Surfaced live case: the backend consent deep link points at the
 // Delegated-to-KDCube consent plan; the hub-open payload must carry that tab
@@ -77,4 +77,30 @@ test('a picker consent affordance seeds the plan with exactly the named claims',
   // No served URL of its own: a host without the scene contract falls back
   // to the widget's served-URL path.
   assert.equal(open.url, '')
+})
+
+// The structured scene payload and the served deep link must agree: the URL
+// fallback already carries these two, so a host with the scene contract must
+// not receive less.
+test('an agent grant open carries the inner operation when the demand names one', () => {
+  const open = agentGrantConsentOpen({
+    agentClientId: 'kdcube-agent:app:main',
+    resource: 'https://h/api/mcp/named_services',
+    claims: ['named_services:use'],
+    namespace: 'task',
+    operation: 'object.search',
+  })
+  assert.equal(open.tab, 'delegated_by_kdcube')
+  assert.equal(open.params.namespace, 'task')
+  assert.equal(open.params.operation, 'object.search')
+})
+
+test('an agent grant open omits the inner operation when the demand names none', () => {
+  const open = agentGrantConsentOpen({
+    agentClientId: 'kdcube-agent:app:main',
+    resource: 'https://h/api/mcp/mem',
+    claims: ['memories:read'],
+  })
+  assert.equal('namespace' in open.params, false)
+  assert.equal('operation' in open.params, false)
 })

--- a/app/ai-app/src/kdcube-ai-app/npm/packages/components-core/tests/chat-consent-banner.test.mjs
+++ b/app/ai-app/src/kdcube-ai-app/npm/packages/components-core/tests/chat-consent-banner.test.mjs
@@ -314,3 +314,39 @@ test('one agent, two pending resources -> TWO coexisting banners (surfaced live:
   const again = applyChatStep(state, agentDemand('*/user-memories@2026-06-26/public/mcp/memories*', ['memories:read'], 'memories'))
   assert.equal(again.banners.length, 2)
 })
+
+// A named-service demand names ONE inner operation. The panel seeds its picker
+// from namespace/operation, so a banner that drops them opens the grant with
+// nothing selected and the user has to find the operation themselves.
+test('a named-service grant demand carries its namespace and operation to the panel', () => {
+  const env = {
+    type: 'chat.step',
+    timestamp: '2026-07-07T12:00:00.000Z',
+    service: { request_id: 'req:turn-1' },
+    conversation: { session_id: 'session-1', conversation_id: 'conv-1', turn_id: 'turn-1' },
+    event: { step: 'delegated_to_kdcube.consent', status: 'completed', title: 'Consent', agent: null },
+    data: {
+      error: { code: 'delegated_consent_required', message: 'named_services_search needs consent.' },
+      consent: {
+        kind: 'delegated_agent_grant',
+        claims: ['named_services:use'],
+        resource: 'https://h/api/mcp/named_services',
+        agent_client_id: 'kdcube-agent:app:lg-react',
+        namespace: 'task',
+        operation: 'object.search',
+        grant: {
+          operation: 'delegated_agent_grant_create',
+          payload: {
+            client_id: 'kdcube-agent:app:lg-react',
+            resource: 'https://h/api/mcp/named_services',
+            claims: ['named_services:use'],
+            named_service_operations: { task: ['object.search'] },
+          },
+        },
+      },
+    },
+  }
+  const banner = applyChatStep(baseState(), env).banners[0]
+  assert.equal(banner.consent.params.namespace, 'task')
+  assert.equal(banner.consent.params.operation, 'object.search')
+})

--- a/app/ai-app/src/kdcube-ai-app/npm/packages/components-core/tests/chat-consent-banner.test.mjs
+++ b/app/ai-app/src/kdcube-ai-app/npm/packages/components-core/tests/chat-consent-banner.test.mjs
@@ -326,7 +326,9 @@ test('a named-service grant demand carries its namespace and operation to the pa
     conversation: { session_id: 'session-1', conversation_id: 'conv-1', turn_id: 'turn-1' },
     event: { step: 'delegated_to_kdcube.consent', status: 'completed', title: 'Consent', agent: null },
     data: {
-      error: { code: 'delegated_consent_required', message: 'named_services_search needs consent.' },
+      // MCPConsentRequired.chat_event_payload normalizes both consent families
+      // onto the shared connected-account banner event code.
+      error: { code: 'needs_connected_account_consent', message: 'named_services_search needs consent.' },
       consent: {
         kind: 'delegated_agent_grant',
         claims: ['named_services:use'],


### PR DESCRIPTION
## Delegated card authority is clamped to the active catalog

Fifteen repairs across three commits, produced by running the `#225` acceptance
against a live stand. Every governed call now intersects the card with what the
deployment currently publishes — in every dimension, on every path a card is
used, and for every card family.

`main` as shipped does not pass that acceptance. Two of its behaviours
contradict named criteria outright; the rest surfaced only when each dimension
was isolated against each family, which is the shape the issue asks for and
which had never been run.

### `ee751436b` — the serving state answers for the revision that committed

- **Mutation finalizer.** It installed only over its own marker, and nothing
  holds a marker for the length of a commit — once its residency lapsed a
  read-through refilled the key, the finalizer met an ordinary projection and
  refused, and both call sites discarded the result. Durable storage held the
  new revision while Redis served the old one for the card's whole remaining
  lifetime. Revocation is the case that matters. Reproduced on Redis; the
  transition is now monotonic by revision.
- **Withdrawn named-service dimension** read as "no ceiling", leaving the card's
  frozen boundary as the only limit, with drift silent on the same branch.
- **Publication** re-reads its effective connections inside the critical section
  and stamps at publication, so a stale snapshot is neither skipped nor silently
  registered; readiness moves with it.
- **Grantor listing** unions the index with durable card ids, because the index
  write is a commit's last step and its isolated failure left a card serving
  that its owner could neither see nor revoke.
- **Post-durable failures** are typed and name their card instead of escaping as
  an untyped `500` that claims the card was not committed.
- **Grant demands** carry their namespace and operation to the panel.

### `b7ed4dff5` — bound every dimension by what the catalog publishes

- **Outer operations** are bounded by the tools their row publishes. Two other
  discriminations were measured and rejected first: plain membership breaks the
  all-resource row, and keying on whether a row enumerated a block closes only
  one of the two ways an operator can spell a removal.
- **The claim ceiling has one reading.** `permits` and `resource_claims`
  disagreed, and the guard consults both — it found a withdrawn claim through
  one and asked the other for the denial body, receiving `None`.
- **An OAuth consent's selection is read under the key it was written with.**
  One call site, no stored-format change, no migration.
- **Admission decodes a request from a second generation of its own package.**

### `bba4f8a07` — every dimension is bounded on every path a card is used

Found by the matrix, after six cells had passed and the remaining nine looked
like paperwork:

- **The managed door's per-tool block had never run.** Both claim checks, and
  the role and permission checks beside them, sit under `if tool_policy is not
  None`; that map had two sources and both are empty on a real deployment. Its
  three messages appear zero times in the stand's entire log history, while the
  guard tests supply the policy explicitly — the branch was covered exactly
  where production does not go. It is now built from the catalog the guard
  already holds.
- **The named-service path had no claim ceiling.** It compared the operation's
  required claims against the card and intersected neither with the catalog.
  A withdrawal now answers `removed`, not `missing_claims`: consent cannot
  restore what the deployment no longer publishes.
- **A card keyed by its request URL fell out of governance.** Selecting the
  governing row was an exact key membership test, false for the OAuth shape.
- **A refused tool call is shaped like the SDK's own `CallToolResult`**, and
  every refusal carries a structured body. A withdrawal had been reaching an
  external MCP client as a malformed result, so the operator was shown a broken
  server where the system had answered precisely.

### Acceptance

All six of the issue's criteria are verified on a stand, none by test alone.
The five dimensions were withdrawn separately against manual, hosted-agent and
OAuth cards — fourteen of fifteen cells are meaningful, and all fourteen pass.
The fifteenth does not exist: a hosted agent calls named services natively and
never crosses the outer MCP guard.

`143 passed` on the focused acceptance pack, up from `138`. `734 passed, 1
skipped` across the connections suite and the KDCube Services bundle.

