### PR TITLE
fix(redis): release the pubsub connection when nothing remains subscribed

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,6 +100,12 @@ each other and keep the platform's contracts intact.
 
 ### Verification
 
+- Before running platform-source tests, follow
+  [Run Platform Source Tests](app/ai-app/docs/procedures/platform-source-testing-README.md).
+  Use one explicit interpreter, prove the imported KDCube and Connection Hub
+  source origins, and provide the required app fixture to shared bundle tests.
+- Test a pull request from its own worktree. Fetch and compare the current PR
+  head immediately before publishing review findings.
 - Run the test suites your change touches before claiming completion; name
   any pre-existing failures you did not cause.
 - A code change is live only in a runtime that actually loaded it. Local

--- a/app/ai-app/docs/README.md
+++ b/app/ai-app/docs/README.md
@@ -4,8 +4,10 @@ title: "Platform Documentation Index"
 summary: "Curated top-level map of the KDCube documentation tree for app builders, integrators, operators, and agents."
 tags: ["docs", "index", "sdk", "service", "ops", "architecture"]
 keywords: ["documentation index", "platform architecture", "configuration guides", "service runtime docs", "app sdk docs", "execution docs", "deployment and operations docs", "app builder docs", "client widgets", "streaming", "memory", "claude code"]
-updated_at: 2026-08-30
+updated_at: 2026-08-31
 see_also:
+  - repo:kdcube-ai-app/app/ai-app/docs/procedures/README.md
+  - repo:kdcube-ai-app/app/ai-app/docs/procedures/platform-source-testing-README.md
   - repo:kdcube-ai-app/app/ai-app/docs/arch/security-and-trust-model-README.md
   - repo:kdcube-ai-app/app/ai-app/docs/arch/delegated-authority-and-admission-README.md
   - repo:kdcube-ai-app/app/ai-app/docs/what-you-can-do-with-kdcube-README.md
@@ -51,6 +53,11 @@ Curated index of platform, service, and SDK documentation.
 * Application-Hosted Website Recipe: [website-README.md](recipes/components/website-README.md)
 * How To Navigate App Docs: [how-to-navigate-kdcube-docs-README.md](sdk/bundle/build/how-to-navigate-kdcube-docs-README.md)
 * App Docs Index: [bundle-index-README.md](sdk/bundle/bundle-index-README.md)
+
+## Contributor Procedures
+
+* Contributor Procedures Index: [procedures/README.md](procedures/README.md)
+* Run Platform Source Tests: [platform-source-testing-README.md](procedures/platform-source-testing-README.md)
 
 ## Build Apps
 

--- a/app/ai-app/docs/procedures/README.md
+++ b/app/ai-app/docs/procedures/README.md
@@ -1,0 +1,23 @@
+---
+id: repo:kdcube-ai-app/app/ai-app/docs/procedures/README.md
+title: "Contributor Procedures"
+summary: "Operational procedures for contributors who change and verify KDCube platform source."
+tags: ["procedures", "contributors", "testing", "verification"]
+keywords: ["platform contributor procedures", "source testing", "test environment", "pull request verification"]
+updated_at: 2026-08-31
+see_also:
+  - repo:kdcube-ai-app/AGENTS.md
+  - repo:kdcube-ai-app/app/ai-app/docs/procedures/platform-source-testing-README.md
+---
+# Contributor Procedures
+
+These procedures are for contributors who change KDCube platform source in
+this repository. App authors and runtime operators should follow the app and
+operations procedures linked from the main [documentation index](../README.md).
+
+## Procedures
+
+- [Run Platform Source Tests](platform-source-testing-README.md) - prepare the
+  correct Python and frontend environments, prove which source is imported,
+  select the required bundle fixture, run focused and broad checks, and verify
+  the exact pull-request head.

--- a/app/ai-app/docs/procedures/platform-source-testing-README.md
+++ b/app/ai-app/docs/procedures/platform-source-testing-README.md
@@ -1,0 +1,278 @@
+---
+id: repo:kdcube-ai-app/app/ai-app/docs/procedures/platform-source-testing-README.md
+title: "Run Platform Source Tests"
+summary: "Contributor procedure for selecting the correct checkout, Python environment, extracted package sources, bundle fixture, and verification depth when testing KDCube platform code."
+tags: ["procedures", "contributors", "testing", "pytest", "frontend", "pull-requests"]
+keywords: ["platform source tests", "python interpreter", "PYTHONPATH", "connection hub source overlay", "bundle under test", "bundle path", "regression test", "pull request head"]
+updated_at: 2026-08-31
+see_also:
+  - repo:kdcube-ai-app/AGENTS.md
+  - repo:kdcube-ai-app/app/ai-app/docs/sdk/bundle/build/how-to-test-bundle-README.md
+  - repo:kdcube-ai-app/app/ai-app/docs/recipes/operations/operate-runtime-README.md
+  - repo:kdcube-ai-app/app/ai-app/src/kdcube-ai-app/requirements-chat-processor.txt
+---
+# Run Platform Source Tests
+
+Use this procedure when changing or reviewing KDCube platform code under
+`app/ai-app/src/kdcube-ai-app`, platform UI code, deployment code, or public
+platform documentation.
+
+The test result is meaningful only when all four inputs are explicit:
+
+1. the KDCube checkout or pull-request worktree being tested;
+2. the Python interpreter and installed service dependencies;
+3. any intentionally overlaid source package, such as Connection Hub;
+4. the app fixture required by shared bundle tests.
+
+## 1. Select the checkout and interpreter
+
+Set paths from the checkout that contains the code under test:
+
+```bash
+export KDCUBE_REPO=/abs/path/to/kdcube
+export KDCUBE_SRC="$KDCUBE_REPO/app/ai-app/src/kdcube-ai-app"
+export PY=/abs/path/to/a/compatible/python
+```
+
+For a pull request, create a separate Git worktree and set `KDCUBE_REPO` to
+that worktree. Do not point `PYTHONPATH` at the primary checkout while testing
+files from a review worktree.
+
+Use the prepared virtual environment for the service whose code is being
+tested. The interpreter may live outside the review worktree, including in a
+compatible prepared environment from the primary checkout. The imported
+KDCube source must still resolve to `KDCUBE_SRC` in the review worktree.
+
+For example, a standard source checkout may already provide:
+
+```bash
+export PY=/abs/path/to/kdcube/app/venvs/ai-app/chat-processor/bin/python
+```
+
+If a compatible environment does not exist, create one and install the
+matching service requirement file. Chat processor, SDK, harness, and shared
+bundle tests use `requirements-chat-processor.txt`, which includes the test
+tools and the published `connection-hub` dependency:
+
+```bash
+python3.11 -m venv "$KDCUBE_REPO/.venv-platform-tests"
+export PY="$KDCUBE_REPO/.venv-platform-tests/bin/python"
+"$PY" -m pip install -r "$KDCUBE_SRC/requirements-chat-processor.txt"
+```
+
+Use the corresponding `requirements-<service>.txt` for another service. Add
+`pytest` and `pytest-asyncio` to a service environment when its requirement
+file does not include test tools.
+
+Prove the interpreter before interpreting a test result:
+
+```bash
+"$PY" -c 'import sys; print(sys.executable)'
+"$PY" -m pytest --version
+"$PY" -m pip show pytest-asyncio
+```
+
+Use `"$PY" -m pytest`, not an unqualified `pytest`. This keeps collection and
+execution in the same environment.
+
+## 2. Select installed or extracted Connection Hub code
+
+KDCube service requirement files declare the released `connection-hub`
+package. A normal source test uses that installed dependency.
+
+When a change intentionally spans KDCube and an unreleased Connection Hub
+checkout, add the extracted package's `src` directory to `PYTHONPATH`:
+
+```bash
+export APP_ECOSYSTEM_REPO=/abs/path/to/app-ecosystem
+export CONNECTION_HUB_SRC="$APP_ECOSYSTEM_REPO/packages/connection-hub/src"
+export PYTHONPATH="$KDCUBE_SRC:$CONNECTION_HUB_SRC${PYTHONPATH:+:$PYTHONPATH}"
+```
+
+For tests that do not overlay extracted Connection Hub source:
+
+```bash
+export PYTHONPATH="$KDCUBE_SRC${PYTHONPATH:+:$PYTHONPATH}"
+```
+
+The source overlay is for coordinated repository testing. It does not replace
+the released version constraint used by runtime images and service installs.
+Record the Connection Hub commit when an overlaid checkout affects the result.
+
+Prove import origins before collection:
+
+```bash
+"$PY" - <<'PY'
+from pathlib import Path
+
+import connection_hub
+import kdcube_ai_app
+
+print("kdcube_ai_app:", Path(kdcube_ai_app.__file__).resolve())
+print("connection_hub:", Path(connection_hub.__file__).resolve())
+PY
+```
+
+The first path must be inside `KDCUBE_SRC`. The second must be either the
+installed package selected for the test or the explicit
+`CONNECTION_HUB_SRC` checkout. A missing import or an unexpected origin is a
+test-environment failure. Correct the environment before assessing product
+behavior.
+
+## 3. Run the exact regression first
+
+Start with the smallest test that reproduces the changed behavior:
+
+```bash
+"$PY" -m pytest -q -rs \
+  "$KDCUBE_SRC/kdcube_ai_app/path/to/tests/test_feature.py::test_exact_case"
+```
+
+A bug fix needs a negative assertion that fails on the pre-fix behavior. A
+green neighboring suite does not replace that regression test.
+
+Then run the complete test file and the nearest owning test directory:
+
+```bash
+"$PY" -m pytest -q -rs \
+  "$KDCUBE_SRC/kdcube_ai_app/path/to/tests/test_feature.py"
+
+"$PY" -m pytest -q -rs \
+  "$KDCUBE_SRC/kdcube_ai_app/path/to/tests"
+```
+
+Run known-similar subsystem tests when the changed class or contract has more
+than one construction site, process role, transport, or runtime owner.
+
+## 4. Supply the app fixture to shared bundle tests
+
+Tests under `kdcube_ai_app/apps/chat/sdk/tests/bundle` require an app folder.
+Pass it with `--bundle-path` or `BUNDLE_UNDER_TEST`. A missing app folder is a
+pytest invocation error, not a platform failure.
+
+For a focused shared-suite test against the reference LangGraph app:
+
+```bash
+export REFERENCE_BUNDLE="$KDCUBE_SRC/kdcube_ai_app/apps/chat/sdk/examples/bundles/ported-langgraph-agents@2026-07-13"
+
+"$PY" -m pytest -q -rs \
+  "$KDCUBE_SRC/kdcube_ai_app/apps/chat/sdk/tests/bundle/test_event_streaming.py" \
+  --bundle-path="$REFERENCE_BUNDLE"
+```
+
+For the supported shared-suite runner:
+
+```bash
+"$PY" -m kdcube_ai_app.apps.chat.sdk.tests.bundle.run_bundle_suite \
+  --bundle-path "$REFERENCE_BUNDLE" \
+  -q -rs
+```
+
+Choose an app that declares the capability being exercised. Always retain
+`-rs` in reported runs. A skip such as `Bundle has no event filter` describes
+the selected fixture and is not a passing behavioral assertion.
+
+## 5. Run the broader backend checks
+
+After focused and neighboring tests pass, run the package test tree with an
+explicit app fixture:
+
+```bash
+export BUNDLE_UNDER_TEST="$REFERENCE_BUNDLE"
+
+"$PY" -m pytest -q -rs \
+  "$KDCUBE_SRC/kdcube_ai_app"
+```
+
+The ReAct v2 and v3 tool tests currently contain matching module basenames.
+When collection reports an import mismatch, exclude both directories from the
+broad pass and then run each directory in its own pytest invocation. Together,
+the three commands still cover the complete backend tree:
+
+```bash
+export REACT_V2_TOOLS="$KDCUBE_SRC/kdcube_ai_app/apps/chat/sdk/solutions/react/v2/tools/tests"
+export REACT_V3_TOOLS="$KDCUBE_SRC/kdcube_ai_app/apps/chat/sdk/solutions/react/v3/tools/tests"
+
+"$PY" -m pytest -q -rs \
+  "$KDCUBE_SRC/kdcube_ai_app" \
+  --ignore="$REACT_V2_TOOLS" \
+  --ignore="$REACT_V3_TOOLS"
+
+"$PY" -m pytest -q -rs \
+  "$REACT_V2_TOOLS"
+
+"$PY" -m pytest -q -rs \
+  "$REACT_V3_TOOLS"
+```
+
+Some integration tests use Redis, Postgres, Docker, browser, or provider
+fixtures. Bring up the required local service before interpreting those
+failures. Name unavailable integration layers and skipped tests in the final
+verification report.
+
+## 6. Run frontend checks for every changed UI
+
+For the main chat frontend:
+
+```bash
+cd "$KDCUBE_REPO/app/ai-app/ui/chat-web-app"
+npm ci
+npm run lint
+npm run build
+```
+
+For another widget or frontend package, run the scripts declared in that
+package's `package.json`. Verify responsive and interaction changes in a
+running browser after lint and build pass.
+
+## 7. Verify the staged runtime when behavior crosses a service boundary
+
+Unit and integration tests execute source from the checkout. A local KDCube
+runtime executes its staged platform copy. Refresh from the intended source
+checkout before live verification:
+
+```bash
+kdcube refresh \
+  --tenant <tenant> \
+  --project <project> \
+  --path "$KDCUBE_REPO" \
+  --build
+```
+
+Then verify the behavior through the real transport and inspect the service
+logs. See [Operate A Runtime](../recipes/operations/operate-runtime-README.md)
+for runtime evidence and restart semantics.
+
+## 8. Recheck a moving pull request before publishing a review
+
+Immediately before posting review findings:
+
+1. fetch the pull-request ref;
+2. compare its head object ID with the object ID tested;
+3. re-read the diff and rerun affected checks when the ID changed;
+4. state the tested object ID and exact test result.
+
+Example:
+
+```bash
+git fetch origin pull/<number>/head:refs/remotes/origin/pr-<number>
+git rev-parse refs/remotes/origin/pr-<number>
+```
+
+Do not describe a previous commit as the current head.
+
+## 9. Report verification precisely
+
+The completion report records:
+
+- checkout or pull-request object ID;
+- Python executable and relevant import origins;
+- source overlays and their object IDs;
+- exact test commands and pass, fail, error, and skip counts;
+- bundle fixture used by shared tests;
+- unavailable infrastructure or tests not run;
+- live runtime source selector and transport checks when applicable.
+
+`git diff --check`, import success, collection success, unit tests, shared app
+contract tests, and live runtime checks prove different things. Report each as
+the evidence it actually provides.

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/emitters.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/emitters.py
@@ -390,7 +390,7 @@ class ChatRelayCommunicator:
         session-release path called that. So every finished turn leaked exactly one
         pooled connection, permanently, until the pool was exhausted and every
         Redis call in the process began failing with "Too many connections" --
-        including the stale-turn takeover meant to recover from it. See issue #243.
+        including the stale-turn takeover meant to recover from it. See issue #245.
 
         The listener must be STOPPED, not worked around: closing the pubsub while
         the listener task is iterating listen() makes that iteration raise, and the

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/emitters.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/emitters.py
@@ -381,6 +381,51 @@ class ChatRelayCommunicator:
             except Exception:
                 logger.exception("Relay callback failed")
 
+    async def _release_transport_if_idle(self) -> None:
+        """Return the pubsub's pooled Redis connection once nothing is subscribed.
+
+        A redis-py PubSub checks a DEDICATED connection out of the shared pool and
+        holds it until it is explicitly closed. Unsubscribing every channel does
+        not return it -- only stop_listener() closes it, and nothing on the
+        session-release path called that. So every finished turn leaked exactly one
+        pooled connection, permanently, until the pool was exhausted and every
+        Redis call in the process began failing with "Too many connections" --
+        including the stale-turn takeover meant to recover from it. See issue #243.
+
+        The listener must be STOPPED, not worked around: closing the pubsub while
+        the listener task is iterating listen() makes that iteration raise, and the
+        listener's own error handler calls _reconnect_pubsub(), which immediately
+        checks out a REPLACEMENT connection. Releasing "only when no listener is
+        running" is therefore not a safe subset of this fix -- it is a no-op, because
+        on this path a listener is always running.
+
+        This lives at the refcount owner rather than inside
+        ServiceCommunicator.unsubscribe_some() because only this object knows that
+        no further channel is expected. unsubscribe_some() is a channel-level
+        operation and has non-relay callers that manage their listener explicitly.
+
+        Re-subscribing after teardown is safe: acquire_*/reconcile_* call
+        subscribe_add() -- which recreates the pubsub when it is None -- before
+        _ensure_listener(), which restarts the listener task when it is not alive.
+        """
+        if self._session_refcounts or self._project_refcounts:
+            return
+        has_subs = getattr(self._comm, "_has_active_subscriptions", None)
+        stop = getattr(self._comm, "stop_listener", None)
+        if not callable(has_subs) or not callable(stop):
+            # Duck-typed/stub communicator (tests, alternate transports): it does
+            # not own a pooled pubsub connection, so there is nothing to release.
+            return
+        if has_subs():
+            return
+        await stop()
+        self._listener_started = False
+        logger.info(
+            "[ChatRelayCommunicator] relay transport idle; released pubsub "
+            "relay_id=%s comm_id=%s",
+            id(self), id(self._comm),
+        )
+
     async def acquire_session_channel(self, session_id: str, tenant: str, project: str, *, callback=None):
         if not session_id:
             return
@@ -418,6 +463,7 @@ class ChatRelayCommunicator:
             if count <= 1:
                 self._session_refcounts.pop(key, None)
                 await self._comm.unsubscribe_some(self._session_channel(session_id, tenant=tenant, project=project))
+                await self._release_transport_if_idle()
             else:
                 self._session_refcounts[key] = count - 1
 
@@ -439,6 +485,7 @@ class ChatRelayCommunicator:
             if count <= 1:
                 self._project_refcounts.pop(key, None)
                 await self._comm.unsubscribe_some(self._project_channel(tenant=tenant, project=project))
+                await self._release_transport_if_idle()
             else:
                 self._project_refcounts[key] = count - 1
 
@@ -473,6 +520,8 @@ class ChatRelayCommunicator:
             for tenant, project, session_id in stale:
                 await self._comm.unsubscribe_some(self._session_channel(session_id, tenant=tenant, project=project))
                 self._session_refcounts.pop((tenant, project, session_id), None)
+            if stale:
+                await self._release_transport_if_idle()
 
         if session_counts:
             await self._ensure_listener()
@@ -502,6 +551,8 @@ class ChatRelayCommunicator:
             for tenant, project in stale:
                 await self._comm.unsubscribe_some(self._project_channel(tenant=tenant, project=project))
                 self._project_refcounts.pop((tenant, project), None)
+            if stale:
+                await self._release_transport_if_idle()
 
         if project_counts:
             await self._ensure_listener()

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/tests/test_relay_pubsub_lifecycle.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/tests/test_relay_pubsub_lifecycle.py
@@ -1,0 +1,228 @@
+import asyncio
+
+import pytest
+
+from kdcube_ai_app.apps.chat.emitters import ChatRelayCommunicator
+from kdcube_ai_app.infra.orchestration.app import communicator as communicator_module
+from kdcube_ai_app.infra.orchestration.app.communicator import ServiceCommunicator
+
+
+_LISTENER_STOP = object()
+
+
+class _FakePubSub:
+    def __init__(self, owner: "_FakeRedis") -> None:
+        self.owner = owner
+        self.messages: asyncio.Queue[object] = asyncio.Queue()
+        self.subscribed: set[str] = set()
+        self.patterns: set[str] = set()
+        self.closed = False
+
+    async def subscribe(self, *channels: str) -> None:
+        self.subscribed.update(channels)
+
+    async def psubscribe(self, *channels: str) -> None:
+        self.patterns.update(channels)
+
+    async def unsubscribe(self, *channels: str) -> None:
+        self.subscribed.difference_update(channels)
+
+    async def punsubscribe(self, *channels: str) -> None:
+        self.patterns.difference_update(channels)
+
+    async def listen(self):
+        while True:
+            message = await self.messages.get()
+            if message is _LISTENER_STOP:
+                return
+            yield message
+
+    async def emit(self, payload: dict) -> None:
+        await self.messages.put({"type": "message", "data": payload})
+
+    async def close(self) -> None:
+        if self.closed:
+            return
+        self.closed = True
+        self.owner.active_count -= 1
+        await self.messages.put(_LISTENER_STOP)
+
+
+class _FakeRedis:
+    _kdcube_shared = True
+
+    def __init__(self) -> None:
+        self.pubsubs: list[_FakePubSub] = []
+        self.active_count = 0
+        self.max_active_count = 0
+
+    def pubsub(self) -> _FakePubSub:
+        pubsub = _FakePubSub(self)
+        self.pubsubs.append(pubsub)
+        self.active_count += 1
+        self.max_active_count = max(self.max_active_count, self.active_count)
+        return pubsub
+
+
+@pytest.fixture
+async def relay_transport(monkeypatch):
+    redis = _FakeRedis()
+    monkeypatch.setattr(
+        communicator_module,
+        "get_async_redis_client",
+        lambda _redis_url: redis,
+    )
+    comm = ServiceCommunicator(
+        redis_url="redis://unused",
+        orchestrator_identity="test.relay",
+    )
+    relay = ChatRelayCommunicator(comm=comm)
+    try:
+        yield relay, comm, redis
+    finally:
+        await relay.unsubscribe()
+
+
+@pytest.mark.asyncio
+async def test_final_session_release_stops_listener_and_closes_pubsub(relay_transport):
+    relay, comm, redis = relay_transport
+
+    await relay.acquire_session_channel("s1", tenant="t", project="p")
+    pubsub = redis.pubsubs[-1]
+    listener = comm._listen_task
+
+    assert listener is not None
+    assert comm.listener_alive()
+    assert redis.active_count == 1
+
+    await relay.release_session_channel("s1", tenant="t", project="p")
+
+    assert listener.done()
+    assert comm._listen_task is None
+    assert comm._pubsub is None
+    assert pubsub.closed
+    assert redis.active_count == 0
+    assert len(redis.pubsubs) == 1
+    assert relay._listener_started is False
+
+
+@pytest.mark.asyncio
+async def test_repeated_acquire_release_cycles_do_not_accumulate_pubsubs(relay_transport):
+    relay, _comm, redis = relay_transport
+
+    for index in range(5):
+        session_id = f"s{index}"
+        await relay.acquire_session_channel(session_id, tenant="t", project="p")
+        assert redis.active_count == 1
+
+        await relay.release_session_channel(session_id, tenant="t", project="p")
+        assert redis.active_count == 0
+
+    assert len(redis.pubsubs) == 5
+    assert all(pubsub.closed for pubsub in redis.pubsubs)
+    assert redis.max_active_count == 1
+
+
+@pytest.mark.asyncio
+async def test_acquire_after_teardown_restarts_listener_and_delivers(relay_transport):
+    relay, comm, redis = relay_transport
+
+    await relay.acquire_session_channel("s1", tenant="t", project="p")
+    first_pubsub = redis.pubsubs[-1]
+    await relay.release_session_channel("s1", tenant="t", project="p")
+
+    received: list[dict] = []
+    delivered = asyncio.Event()
+
+    async def on_message(message: dict) -> None:
+        received.append(message)
+        delivered.set()
+
+    await relay.acquire_session_channel(
+        "s2",
+        tenant="t",
+        project="p",
+        callback=on_message,
+    )
+    second_pubsub = redis.pubsubs[-1]
+
+    assert second_pubsub is not first_pubsub
+    assert not second_pubsub.closed
+    assert comm.listener_alive()
+
+    payload = {"event": "chat_step", "data": {"text": "after restart"}}
+    await second_pubsub.emit(payload)
+    await asyncio.wait_for(delivered.wait(), timeout=1.0)
+
+    assert received == [payload]
+
+    await relay.release_session_channel("s2", tenant="t", project="p")
+    assert second_pubsub.closed
+    assert redis.active_count == 0
+
+
+@pytest.mark.asyncio
+async def test_transport_stays_open_until_session_and_project_refs_are_released(relay_transport):
+    relay, comm, redis = relay_transport
+
+    await relay.acquire_session_channel("s1", tenant="t", project="p")
+    await relay.acquire_session_channel("s2", tenant="t", project="p")
+    await relay.acquire_project_channel(tenant="t", project="p")
+    pubsub = redis.pubsubs[-1]
+
+    await relay.release_session_channel("s1", tenant="t", project="p")
+    assert not pubsub.closed
+    assert comm.listener_alive()
+
+    await relay.release_session_channel("s2", tenant="t", project="p")
+    assert not pubsub.closed
+    assert comm.listener_alive()
+
+    await relay.release_project_channel(tenant="t", project="p")
+    assert pubsub.closed
+    assert redis.active_count == 0
+
+
+@pytest.mark.asyncio
+async def test_legacy_subscription_keeps_transport_open(relay_transport):
+    relay, comm, redis = relay_transport
+
+    async def on_message(_message: dict) -> None:
+        return None
+
+    await relay.subscribe(on_message)
+    await relay.acquire_session_channel("s1", tenant="t", project="p")
+    pubsub = redis.pubsubs[-1]
+
+    await relay.release_session_channel("s1", tenant="t", project="p")
+
+    assert not pubsub.closed
+    assert comm.listener_alive()
+    assert comm._subscribed_channels == ["test.relay.chat.events"]
+
+    await relay.unsubscribe()
+    assert pubsub.closed
+    assert redis.active_count == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("scope", ["session", "project"])
+async def test_reconcile_to_empty_releases_transport(relay_transport, scope):
+    relay, comm, redis = relay_transport
+
+    if scope == "session":
+        await relay.acquire_session_channel("s1", tenant="t", project="p")
+    else:
+        await relay.acquire_project_channel(tenant="t", project="p")
+    pubsub = redis.pubsubs[-1]
+
+    if scope == "session":
+        await relay.reconcile_sessions({}, reason="test")
+    else:
+        await relay.reconcile_project_channels({}, reason="test")
+
+    assert pubsub.closed
+    assert comm._pubsub is None
+    assert not comm.listener_alive()
+    assert redis.active_count == 0
+    assert len(redis.pubsubs) == 1

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/infra/orchestration/app/communicator.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/infra/orchestration/app/communicator.py
@@ -264,6 +264,37 @@ class ServiceCommunicator:
             id(self), id(self._pubsub), to_remove, self._subscribed_channels
         )
 
+        # A redis-py PubSub holds a dedicated connection checked out of the shared
+        # pool until it is explicitly closed; unsubscribing every channel does NOT
+        # return it. On the session-release path (ChatRelayCommunicator ->
+        # apps/chat/emitters.py) this method is the only cleanup that runs --
+        # stop_listener(), which does close the pubsub, is never called there --
+        # so each released session leaked one pooled connection permanently.
+        #
+        # Once the pool was exhausted every Redis call in the process failed with
+        # "Too many connections", including _legacy_requeue_stale_inflight_tasks,
+        # the stale-turn takeover meant to recover from stuck turns: the recovery
+        # path depended on the resource whose exhaustion it recovers from, so the
+        # process could not self-heal.
+        #
+        # Nothing is subscribed any more, so release it. A later subscribe() or
+        # subscribe_add() recreates it. Guarded on the listener task so we never
+        # close the pubsub out from under an active listen().
+        if (
+            not self._subscribed_channels
+            and not self._subscribed_patterns
+            and self._listen_task is None
+            and self._pubsub is not None
+        ):
+            with contextlib.suppress(Exception):
+                await self._pubsub.close()
+            logger.info(
+                "[ServiceCommunicator] released idle pubsub self_id=%s pubsub_id=%s "
+                "(no channels remain; connection returned to the pool)",
+                id(self), id(self._pubsub),
+            )
+            self._pubsub = None
+
 
     async def listen(self) -> AsyncIterator[dict]:
         """

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/infra/orchestration/app/communicator.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/infra/orchestration/app/communicator.py
@@ -264,37 +264,6 @@ class ServiceCommunicator:
             id(self), id(self._pubsub), to_remove, self._subscribed_channels
         )
 
-        # A redis-py PubSub holds a dedicated connection checked out of the shared
-        # pool until it is explicitly closed; unsubscribing every channel does NOT
-        # return it. On the session-release path (ChatRelayCommunicator ->
-        # apps/chat/emitters.py) this method is the only cleanup that runs --
-        # stop_listener(), which does close the pubsub, is never called there --
-        # so each released session leaked one pooled connection permanently.
-        #
-        # Once the pool was exhausted every Redis call in the process failed with
-        # "Too many connections", including _legacy_requeue_stale_inflight_tasks,
-        # the stale-turn takeover meant to recover from stuck turns: the recovery
-        # path depended on the resource whose exhaustion it recovers from, so the
-        # process could not self-heal.
-        #
-        # Nothing is subscribed any more, so release it. A later subscribe() or
-        # subscribe_add() recreates it. Guarded on the listener task so we never
-        # close the pubsub out from under an active listen().
-        if (
-            not self._subscribed_channels
-            and not self._subscribed_patterns
-            and self._listen_task is None
-            and self._pubsub is not None
-        ):
-            with contextlib.suppress(Exception):
-                await self._pubsub.close()
-            logger.info(
-                "[ServiceCommunicator] released idle pubsub self_id=%s pubsub_id=%s "
-                "(no channels remain; connection returned to the pool)",
-                id(self), id(self._pubsub),
-            )
-            self._pubsub = None
-
 
     async def listen(self) -> AsyncIterator[dict]:
         """


### PR DESCRIPTION
Fixes #245.

## Problem

A redis-py `PubSub` keeps a dedicated Redis connection checked out of the shared pool until the PubSub is closed. Removing its last channel or pattern does not return that connection.

The chat relay released its per-session and per-project subscriptions, but after the final reference disappeared it left the listener and PubSub alive. Repeated relay lifecycles could therefore exhaust the Redis pool. Once exhausted, publishing and stale-turn recovery both fail with `redis.exceptions.ConnectionError: Too many connections`.

## Fix

`ChatRelayCommunicator`, which owns the session and project reference counts, now releases the transport after a final release or reconcile-to-empty when:

- no session references remain;
- no project references remain; and
- the communicator has no other active channel or pattern subscriptions.

It stops the listener before closing the PubSub, preventing the listener's reconnect path from immediately checking out a replacement connection. A later acquire recreates the PubSub through `subscribe_add()` and restarts the listener through `_ensure_listener()`.

Legacy/global subscriptions and remaining session or project references keep the transport open.

## Regression coverage

Added `test_relay_pubsub_lifecycle.py`, covering:

- final session release stops the listener and closes the PubSub;
- repeated acquire/release cycles never retain more than one active PubSub;
- reacquiring after teardown recreates the transport and still delivers messages;
- mixed session/project references keep the transport alive until the last release;
- a legacy/global subscription prevents idle teardown; and
- session and project reconcile-to-empty paths both release the transport.

The final-release test fails on the pre-fix implementation because the listener remains pending.

Verification on this head:

```text
test_relay_pubsub_lifecycle.py: 7 passed
test_event_streaming.py:        39 passed, 5 skipped
```

The five skips are the existing `Bundle has no event filter` cases.
