### PR TITLE
Retain public OAuth client metadata during DCR

### DIFF
--- a/app/ai-app/docs/sdk/solutions/connections/delegated-credentials/oauth-delegated-credential-protocol-adapter-README.md
+++ b/app/ai-app/docs/sdk/solutions/connections/delegated-credentials/oauth-delegated-credential-protocol-adapter-README.md
@@ -4,8 +4,8 @@ title: "OAuth Delegated Credential Protocol Adapter"
 summary: "Points from KDCube's OAuth host routes to Connection Hub's canonical delegated-credential protocol contract."
 status: active
 tags: ["sdk", "connections", "connection-hub", "oauth", "delegated-credentials"]
-keywords: ["OAuth2 authorization server", "PKCE", "CIMD", "dynamic client registration", "Connection Hub"]
-updated_at: 2026-08-29
+keywords: ["OAuth2 authorization server", "PKCE", "CIMD", "dynamic client registration", "client metadata", "Connection Hub"]
+updated_at: 2026-09-09
 see_also:
   - https://github.com/elenaviter/app-ecosystem/blob/main/docs/connection-hub/package/oauth-delegated-credential-protocol.md
   - repo:kdcube-ai-app/app/ai-app/docs/service/auth/auth-README.md
@@ -20,3 +20,8 @@ credential issuance, card lookup, and revocation contract. Read
 KDCube remains the first protocol host. Its authentication, descriptor, and MCP
 recipes describe how the Connection Hub state machine is mounted on KDCube public
 operations and guarded application surfaces.
+
+The KDCube DCR host accepts the bounded public registration metadata defined by
+that canonical contract, persists it with the client snapshot, and passes it to
+the resulting Card. The fields are owner-facing identification only; KDCube
+does not project them into caller identity or policy.

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/integrations/connection_hub/delegated_credentials/oauth/http/routes.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/integrations/connection_hub/delegated_credentials/oauth/http/routes.py
@@ -28,6 +28,7 @@ from connection_hub.delegated_credentials.oauth.clients import (
     client_from_record,
     dcr_redirect_allowed,
     get_client,
+    normalize_public_client_metadata,
 )
 from connection_hub.delegated_credentials.live_grant import (
     LiveGrantCardError,
@@ -829,6 +830,31 @@ async def register_client(request: Request) -> Response:
         body = {}
     if not isinstance(body, Mapping):
         body = {}
+    server_assigned = {
+        "client_id",
+        "client_secret",
+        "client_secret_expires_at",
+        "registration_access_token",
+        "registration_client_uri",
+    }
+    if server_assigned.intersection(body):
+        return JSONResponse(
+            status_code=400,
+            content={
+                "error": "invalid_client_metadata",
+                "error_description": "client metadata contains a server-assigned field",
+            },
+        )
+    try:
+        asserted_metadata = normalize_public_client_metadata(body)
+    except ValueError:
+        return JSONResponse(
+            status_code=400,
+            content={
+                "error": "invalid_client_metadata",
+                "error_description": "client metadata is too large, unsupported, or sensitive",
+            },
+        )
     application_type = str(
         body.get("application_type")
         or cfg.dynamic_client_registration.default_application_type
@@ -879,6 +905,7 @@ async def register_client(request: Request) -> Response:
         "client_name": body.get("client_name"),
         "logo_uri": logo_uri,
         "client_uri": client_uri,
+        "client_metadata": asserted_metadata,
     }
     # What the client ACTUALLY sends at registration decides the card's default
     # name. A client that registers one fixed name for every connector it opens
@@ -896,7 +923,8 @@ async def register_client(request: Request) -> Response:
         application_type=application_type,
         metadata=metadata,
     )
-    content = {
+    content = dict(asserted_metadata)
+    content.update({
         "client_id": record["client_id"],
         "redirect_uris": record["redirect_uris"],
         "token_endpoint_auth_method": "none",
@@ -904,7 +932,7 @@ async def register_client(request: Request) -> Response:
         "grant_types": ["authorization_code", "refresh_token"],
         "response_types": ["code"],
         "client_name": body.get("client_name"),
-    }
+    })
     if logo_uri:
         content["logo_uri"] = logo_uri
     if client_uri:
@@ -1679,6 +1707,18 @@ async def _issue_tokens(
         registered_name = str(metadata_snapshot.get("client_name") or "")
         if door_alias and door_alias.lower() not in client_label.lower():
             client_label = f"{client_label} · {door_alias}" if client_label else door_alias
+        asserted_metadata = (
+            metadata_snapshot.get("client_metadata")
+            if isinstance(metadata_snapshot.get("client_metadata"), Mapping)
+            else {}
+        )
+        agent_id = str(
+            asserted_metadata.get("kdcube_agent_id")
+            or asserted_metadata.get("kdcube_worker_id")
+            or ""
+        ).strip()
+        if agent_id and agent_id.lower() not in client_label.lower():
+            client_label = f"{client_label} · {agent_id}" if client_label else agent_id
         # Card naming is derived, not received: log every input so a wrong card
         # title is diagnosable from the proc log instead of by inspecting the
         # rendered UI (grep: connection_hub.oauth card_label).
@@ -1703,6 +1743,7 @@ async def _issue_tokens(
             account_scope=account_scope,
             named_service_operations=named_service_operations,
             catalog_version=catalog_version,
+            client_metadata=asserted_metadata,
         )
     except (AutomationAccessUnavailable, CardUnavailable, CardConflict, CardCommitFailed) as exc:
         # The card is the authority a governed call resolves; a token whose card

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/integrations/connection_hub/delegated_credentials/oauth/tests/test_dcr.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/integrations/connection_hub/delegated_credentials/oauth/tests/test_dcr.py
@@ -8,6 +8,8 @@ then runs the normal authorization_code + PKCE flow.
 """
 from __future__ import annotations
 
+import asyncio
+
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
@@ -59,6 +61,38 @@ def test_register_returns_public_client(client):
     assert body["application_type"] == "native"
     assert body["logo_uri"] == f"{ISSUER}/img/favicon.svg"
     assert body["client_uri"] == ISSUER
+
+
+def test_register_retains_safe_client_metadata_for_the_card(client):
+    response = client.post(
+        "/oauth/register",
+        json={
+            "client_name": "Connection Hub CLI · worker_stream · codex:session-1",
+            "redirect_uris": [CB],
+            "token_endpoint_auth_method": "none",
+            "kdcube_agent_id": "codex:session-1",
+            "kdcube_machine_id": "machine-1",
+        },
+    )
+
+    assert response.status_code == 201
+    registered = response.json()
+    assert registered["kdcube_agent_id"] == "codex:session-1"
+    record = asyncio.run(
+        client.app.state.oauth_grant_store.get_client_record(registered["client_id"])
+    )
+    assert record["metadata"]["client_metadata"]["kdcube_machine_id"] == "machine-1"
+
+
+@pytest.mark.parametrize("field", ["client_secret", "kdcube_access_token"])
+def test_register_rejects_secret_bearing_metadata(client, field):
+    response = client.post(
+        "/oauth/register",
+        json={"redirect_uris": [CB], field: "not-for-storage"},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["error"] == "invalid_client_metadata"
 
 
 def test_register_requires_redirect_uris(client):


### PR DESCRIPTION
## Summary
- validate and retain bounded public DCR metadata in KDCube OAuth client records
- pass accepted metadata into the delegated Connection Hub Card at token issuance
- reject server-assigned or secret-bearing registration fields

This complements elenaviter/app-ecosystem#6. Client metadata remains descriptive and is never projected into caller identity or policy.

## Verification
- OAuth delegated-credential suite: 210 passed, 17 Redis-dependent skipped
- source origins proved against this KDCube branch and App Ecosystem PR 6 source
- git diff --check passed