### PR TITLE
fix(agent-harness): run the standalone examples on a host, not only in an image

### DIFF
--- a/agents/claude/agent.py
+++ b/agents/claude/agent.py
@@ -139,6 +139,26 @@ def load_config(path: Path) -> dict[str, Any]:
     return value
 
 
+def _require_claude_credential(env: dict[str, str]) -> None:
+    """A git transcript store points the CLI at its own config directory.
+
+    The credential is therefore either supplied by the descriptor or linked in
+    from this machine's Claude Code login. With neither, the CLI subprocess
+    reports `Not logged in` and names no cause.
+    """
+    if env.get("ANTHROPIC_API_KEY") or env.get("CLAUDE_CODE_KEY"):
+        return
+    if (Path.home() / ".claude" / ".credentials.json").is_file():
+        return
+    raise RuntimeError(
+        "no Claude credential available: the git transcript store redirects the "
+        "CLI config directory, so this machine's ~/.claude login is linked in "
+        "only when it exists. Authenticate Claude Code here, set "
+        "platform.services.anthropic.api_key in descriptors.local/secrets.yaml, "
+        "or select claude_code_session.type: local."
+    )
+
+
 async def descriptor_claude_cli_credentials() -> dict[str, str]:
     """Project descriptor-owned Anthropic credentials into the Claude CLI."""
     api_key = str(
@@ -612,6 +632,8 @@ async def main_async(args: argparse.Namespace) -> None:
         print(
             f"Claude transcript branch: {claude_code_session_branch_ref(session_store)}"
         )
+        if not args.check:
+            _require_claude_credential(cfg.env)
     if exec_runtime is not None and not args.check:
         image = verify_docker_image(exec_runtime)
         print(f"isolated code-execution image: {image}")

--- a/agents/claude/agent.py
+++ b/agents/claude/agent.py
@@ -75,6 +75,9 @@ from kdcube_ai_app.apps.chat.sdk.runtime.direct_hosting.telegram import (  # noq
 from kdcube_ai_app.apps.chat.sdk.runtime.direct_hosting.workspace import (  # noqa: E402
     DirectTurnWorkspace,
 )
+from kdcube_ai_app.apps.chat.sdk.runtime.direct_hosting.tool_runtime import (  # noqa: E402
+    DirectToolRuntime,
+)
 from kdcube_ai_app.apps.chat.sdk.runtime.direct_harness import (  # noqa: E402
     DirectAgentHarness,
 )
@@ -455,48 +458,9 @@ async def run_one_turn(
             raise RuntimeError(
                 result.error_message or f"Claude exited with {result.exit_code}"
             )
-        expected = (
-            (
-                "research/research-data.xlsx",
-                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-                "external",
-                EXEC_TOOL_ID,
-            ),
-            (
-                "research/research-brief.html",
-                "text/html",
-                "internal",
-                EXEC_TOOL_ID,
-            ),
-            (
-                "research/research-brief.pdf",
-                "application/pdf",
-                "external",
-                "mcp__kdcube_harness__write_pdf",
-            ),
-        )
-        files: list[dict[str, Any]] = []
-        for relpath, mime, visibility, tool_id in expected:
-            path = turn_workspace.current_file(relpath)
-            if not path.is_file():
-                continue
-            files.append(
-                {
-                    "type": "file",
-                    "output": {
-                        "type": "file",
-                        "path": f"{turn_id}/files/{relpath}",
-                        "filename": path.name,
-                        "mime": mime,
-                        "visibility": visibility,
-                    },
-                    "mime": mime,
-                    "visibility": visibility,
-                    "description": f"Claude demo output: {path.name}",
-                    "resource_id": path.stem,
-                    "tool_id": tool_id,
-                }
-            )
+        # Claude reaches the harness tools through the stdio tool server, so the
+        # declarations were recorded by that process into this turn's workspace.
+        files = DirectToolRuntime.declared_files_for_workspace(turn_workspace)
         if files:
             await turn.host_files(files=files, outdir=turn_workspace.runtime_outdir)
         await turn.persist_workspace(

--- a/agents/claude/requirements.txt
+++ b/agents/claude/requirements.txt
@@ -12,6 +12,7 @@ mdit-py-plugins
 linkify-it-py
 pygments
 jinja2
+openpyxl
 python-docx
 python-pptx
 lxml

--- a/agents/langgraph/agent.py
+++ b/agents/langgraph/agent.py
@@ -228,39 +228,10 @@ async def host_demo_outputs(
     *,
     turn: Any,
     workspace: DirectTurnWorkspace,
+    runtime: DirectToolRuntime,
 ) -> None:
-    expected = (
-        (
-            "research/research-data.xlsx",
-            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-            "external",
-            EXEC_TOOL_ID,
-        ),
-        ("research/research-brief.html", "text/html", "internal", EXEC_TOOL_ID),
-        ("research/research-brief.pdf", "application/pdf", "external", "write_pdf"),
-    )
-    files: list[dict[str, Any]] = []
-    for relpath, mime, visibility, tool_id in expected:
-        path = workspace.current_file(relpath)
-        if not path.is_file():
-            continue
-        files.append(
-            {
-                "type": "file",
-                "output": {
-                    "type": "file",
-                    "path": f"{workspace.turn_id}/files/{relpath}",
-                    "filename": path.name,
-                    "mime": mime,
-                    "visibility": visibility,
-                },
-                "mime": mime,
-                "visibility": visibility,
-                "description": f"LangGraph demo output: {path.name}",
-                "resource_id": path.stem,
-                "tool_id": tool_id,
-            }
-        )
+    """Host what the turn's tools declared, with the visibility they declared."""
+    files = runtime.declared_files()
     if files:
         await turn.host_files(files=files, outdir=workspace.runtime_outdir)
 
@@ -311,7 +282,7 @@ async def run_one_turn(
         answer, called_tools = await stream_turn(
             graph, model_prompt, run_config, turn.comm
         )
-        await host_demo_outputs(turn=turn, workspace=workspace)
+        await host_demo_outputs(turn=turn, workspace=workspace, runtime=runtime)
         await turn.persist_workspace(
             outdir=workspace.runtime_outdir,
             workdir=workspace.workdir,

--- a/agents/langgraph/requirements.txt
+++ b/agents/langgraph/requirements.txt
@@ -17,6 +17,7 @@ mdit-py-plugins
 linkify-it-py
 pygments
 jinja2
+openpyxl
 python-docx
 python-pptx
 lxml

--- a/agents/native/requirements.txt
+++ b/agents/native/requirements.txt
@@ -16,6 +16,7 @@ mdit-py-plugins
 linkify-it-py
 pygments
 jinja2
+openpyxl
 python-docx
 python-pptx
 lxml

--- a/agents/test_examples.py
+++ b/agents/test_examples.py
@@ -1589,3 +1589,16 @@ def test_claude_runner_names_a_missing_claude_credential(tmp_path: Path) -> None
     assert "no Claude credential available" in message
     assert "platform.services.anthropic.api_key" in message
     assert "claude_code_session.type: local" in message
+
+
+@pytest.mark.parametrize("adapter", ("langgraph", "claude"))
+def test_framework_neutral_examples_host_what_the_agent_declared(
+    adapter: str,
+) -> None:
+    # These adapters write no harness timeline, so nothing hosts their declared
+    # files unless the example does. Hosting from a fixed list of expected
+    # filenames only holds while the prompt dictates them, and it decides the
+    # visibility that the declaring side owns.
+    source = (AGENTS_ROOT / adapter / "agent.py").read_text(encoding="utf-8")
+    assert "declared_files" in source
+    assert "for relpath, mime, visibility, tool_id in" not in source

--- a/agents/test_examples.py
+++ b/agents/test_examples.py
@@ -1551,3 +1551,41 @@ async def test_langgraph_file_tools_delegate_to_the_turn_runtime() -> None:
         output_path="files/research/brief.pdf",
         title="Brief",
     )
+
+
+def test_claude_runner_names_a_missing_claude_credential(tmp_path: Path) -> None:
+    """The git transcript store points the CLI at its own config directory, so a
+    login in the operator's ~/.claude is reachable only when the runner links it
+    in. With no credential at all the runner must name the remedies instead of
+    letting the CLI answer `Not logged in` with no cause."""
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location(
+        "claude_runner_under_test", AGENTS_ROOT / "claude" / "agent.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    module._require_claude_credential({"ANTHROPIC_API_KEY": "sk-configured"})
+    module._require_claude_credential({"CLAUDE_CODE_KEY": "sk-configured"})
+
+    home = tmp_path / "home"
+    (home / ".claude").mkdir(parents=True)
+    (home / ".claude" / ".credentials.json").write_text("{}", encoding="utf-8")
+    original = os.environ.get("HOME")
+    os.environ["HOME"] = str(home)
+    try:
+        module._require_claude_credential({})
+        os.environ["HOME"] = str(tmp_path / "no-login")
+        with pytest.raises(RuntimeError) as failure:
+            module._require_claude_credential({})
+    finally:
+        if original is None:
+            os.environ.pop("HOME", None)
+        else:
+            os.environ["HOME"] = original
+
+    message = str(failure.value)
+    assert "no Claude credential available" in message
+    assert "platform.services.anthropic.api_key" in message
+    assert "claude_code_session.type: local" in message

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/integrations/telegram/bot.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/integrations/telegram/bot.py
@@ -650,6 +650,26 @@ def _artifact_files_from_timeline(timeline: Mapping[str, Any]) -> list[dict[str,
             if _file_delivery_path(file_item) in represented_paths:
                 continue
             _append_file(files, seen, file_item)
+
+    # A framework-neutral adapter writes no harness timeline, so its hosted
+    # files reach the turn log only as the minimal writer's react.tool.result
+    # blocks, whose conv:fi: ref lives in the JSON body rather than the block
+    # path. Read them with the same extractor conversation reload uses.
+    if isinstance(blocks, list):
+        from kdcube_ai_app.apps.chat.sdk.runtime.harness.timeline.turn_view import (
+            extract_assistant_files_from_blocks,
+        )
+
+        for row in extract_assistant_files_from_blocks(list(blocks)):
+            artifact_path = str(row.get("artifact_path") or "").strip()
+            if not artifact_path.startswith("conv:fi:"):
+                continue
+            if ".user.attachments/" in artifact_path or ".external." in artifact_path:
+                continue
+            file_item = _file_item_from_meta(dict(row), logical_path=artifact_path)
+            if _file_delivery_path(file_item) in represented_paths:
+                continue
+            _append_file(files, seen, file_item)
     return files
 
 

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/integrations/telegram/tests/test_telegram_integration.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/integrations/telegram/tests/test_telegram_integration.py
@@ -2442,3 +2442,221 @@ async def test_resolver_failure_falls_back_to_mapping_required(monkeypatch):
     monkeypatch.setattr(bundle_operations, "call_bundle_operation", _broken)
     monkeypatch.setattr(webapp, "_linked_telegram_user", lambda entrypoint, *, user_id=None: None)
     assert await webapp._resolve_linked_telegram_user(_EdgeFallbackEntrypoint(), user_id="user-1") is None
+
+
+def _minimal_turn_log_file_block(
+    *,
+    turn_id: str,
+    call_id: str,
+    relative: str,
+    filename: str,
+    mime: str,
+    visibility: str,
+) -> dict:
+    """The shape build_minimal_turn_log_payload writes for a hosted file: a
+    tool-call block whose JSON body carries the conv:fi: ref."""
+    return {
+        "type": "react.tool.result",
+        "turn_id": turn_id,
+        "turn": turn_id,
+        "call_id": call_id,
+        "mime": "application/json",
+        "path": f"conv:tc:{turn_id}.{call_id}.result",
+        "text": json.dumps(
+            {
+                "artifact_path": f"conv:fi:conv_c1.{turn_id}.{relative}",
+                "physical_path": f"{turn_id}/{relative}",
+                "mime": mime,
+                "kind": "file",
+                "visibility": visibility,
+                "filename": filename,
+                "hosted_uri": f"file:///store/{filename}",
+                "key": f"cb/attachments/{turn_id}/{relative}",
+            }
+        ),
+        "meta": {"tool_call_id": call_id},
+    }
+
+
+def test_telegram_renderer_delivers_files_a_framework_neutral_adapter_recorded():
+    # LangGraph and Claude Code write no harness timeline, so their hosted
+    # files reach the turn log only in the minimal writer's shape.
+    from kdcube_ai_app.apps.chat.sdk.integrations.telegram.bot import (
+        render_telegram_messages_from_timeline,
+    )
+
+    messages = render_telegram_messages_from_timeline(
+        timeline={
+            "turn_id": "turn_01_abcdef",
+            "blocks": [
+                {"path": "conv:ar:turn_01_abcdef.user.prompt", "text": "research it"},
+                _minimal_turn_log_file_block(
+                    turn_id="turn_01_abcdef",
+                    call_id="code_exec_0",
+                    relative="files/research/research-data.xlsx",
+                    filename="research-data.xlsx",
+                    mime="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                    visibility="external",
+                ),
+                _minimal_turn_log_file_block(
+                    turn_id="turn_01_abcdef",
+                    call_id="code_exec_1",
+                    relative="files/research/research-brief.pdf",
+                    filename="research-brief.pdf",
+                    mime="application/pdf",
+                    visibility="external",
+                ),
+            ],
+        },
+        react_turn={"answer": "Done."},
+    )
+
+    delivered = [
+        file_item["filename"] for item in messages for file_item in (item.files or ())
+    ]
+    assert delivered == ["research-data.xlsx", "research-brief.pdf"]
+
+
+def test_telegram_renderer_keeps_an_internal_file_out_of_the_chat():
+    from kdcube_ai_app.apps.chat.sdk.integrations.telegram.bot import (
+        render_telegram_messages_from_timeline,
+    )
+
+    messages = render_telegram_messages_from_timeline(
+        timeline={
+            "turn_id": "turn_01_abcdef",
+            "blocks": [
+                _minimal_turn_log_file_block(
+                    turn_id="turn_01_abcdef",
+                    call_id="code_exec_0",
+                    relative="files/research/research-brief.html",
+                    filename="research-brief.html",
+                    mime="text/html",
+                    visibility="internal",
+                ),
+            ],
+        },
+        react_turn={"answer": "Done."},
+    )
+
+    assert [file_item for item in messages for file_item in (item.files or ())] == []
+
+
+def test_telegram_renderer_does_not_deliver_a_file_twice_from_both_writers():
+    # A harness timeline carries the rich block and the minimal writer's
+    # supplemental block for the same hosted file.
+    from kdcube_ai_app.apps.chat.sdk.integrations.telegram.bot import (
+        render_telegram_messages_from_timeline,
+    )
+
+    turn_id = "turn_02_abcdef"
+    relative = "files/research/research-brief.pdf"
+    messages = render_telegram_messages_from_timeline(
+        timeline={
+            "turn_id": turn_id,
+            "blocks": [
+                {
+                    "type": "react.tool.result",
+                    "turn_id": turn_id,
+                    "turn": turn_id,
+                    "path": f"conv:fi:conv_c1.{turn_id}.{relative}",
+                    "mime": "application/json",
+                    "text": json.dumps(
+                        {
+                            "artifact_path": f"conv:fi:conv_c1.{turn_id}.{relative}",
+                            "filename": "research-brief.pdf",
+                            "mime": "application/pdf",
+                            "kind": "file",
+                            "visibility": "external",
+                            "hosted_uri": "file:///store/research-brief.pdf",
+                            "key": f"cb/attachments/{turn_id}/{relative}",
+                        }
+                    ),
+                    "meta": {},
+                },
+                _minimal_turn_log_file_block(
+                    turn_id=turn_id,
+                    call_id="code_exec_0",
+                    relative=relative,
+                    filename="research-brief.pdf",
+                    mime="application/pdf",
+                    visibility="external",
+                ),
+            ],
+        },
+        react_turn={"answer": "Done."},
+    )
+
+    delivered = [
+        file_item["filename"] for item in messages for file_item in (item.files or ())
+    ]
+    assert delivered == ["research-brief.pdf"]
+
+
+def test_telegram_renderer_still_ignores_a_caller_attachment():
+    from kdcube_ai_app.apps.chat.sdk.integrations.telegram.bot import (
+        render_telegram_messages_from_timeline,
+    )
+
+    messages = render_telegram_messages_from_timeline(
+        timeline={
+            "turn_id": "turn_01_abcdef",
+            "blocks": [
+                _minimal_turn_log_file_block(
+                    turn_id="turn_01_abcdef",
+                    call_id="code_exec_0",
+                    relative="user.attachments/research-request.md",
+                    filename="research-request.md",
+                    mime="text/markdown",
+                    visibility="external",
+                ),
+            ],
+        },
+        react_turn={"answer": "Done."},
+    )
+
+    assert [file_item for item in messages for file_item in (item.files or ())] == []
+
+
+def test_a_streamed_file_is_not_delivered_again_from_the_minimal_record():
+    # A hosted turn streams files live and then excludes them by delivery key.
+    # The key carries a content signature, so the minimal turn-log block must
+    # carry it too or the same file would be sent a second time.
+    from kdcube_ai_app.apps.chat.sdk.integrations.telegram.bot import (
+        _file_delivery_key,
+        render_telegram_messages_from_timeline,
+    )
+    from kdcube_ai_app.apps.chat.sdk.solutions.conversation.record import (
+        _assistant_file_block,
+    )
+
+    turn_id = "turn_01_abcdef"
+    hosted_row = {
+        "filename": "research-brief.pdf",
+        "mime": "application/pdf",
+        "visibility": "external",
+        "logical_path": f"conv:fi:conv_c1.{turn_id}.files/research/research-brief.pdf",
+        "physical_path": f"{turn_id}/files/research/research-brief.pdf",
+        "hosted_uri": "file:///store/research-brief.pdf",
+        "key": f"cb/attachments/{turn_id}/files/research/research-brief.pdf",
+        "content_sha256": "0153" * 16,
+        "size": 66418,
+        "tool_id": "write_pdf",
+    }
+    streamed_key = _file_delivery_key(
+        {
+            "url": hosted_row["hosted_uri"],
+            "filename": hosted_row["filename"],
+            "content_sha256": hosted_row["content_sha256"],
+            "size": hosted_row["size"],
+        }
+    )
+
+    block = _assistant_file_block(hosted_row, turn_id=turn_id, ts="2026-09-11T00:00:00Z", index=0)
+    messages = render_telegram_messages_from_timeline(
+        timeline={"turn_id": turn_id, "blocks": [block]},
+        react_turn={"answer": "Done."},
+        exclude_file_keys={streamed_key},
+    )
+
+    assert [file_item for item in messages for file_item in (item.files or ())] == []

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/runtime/direct_hosting/test_declared_files.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/runtime/direct_hosting/test_declared_files.py
@@ -1,0 +1,272 @@
+"""The turn hosts the files its tools declared, with the declared visibility."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from kdcube_ai_app.apps.chat.sdk.runtime.direct_hosting.tool_runtime import (
+    DECLARED_FILES_FILENAME,
+    DirectToolRuntime,
+    read_declared_files,
+)
+from kdcube_ai_app.apps.chat.sdk.runtime.direct_hosting.workspace import (
+    DirectTurnWorkspace,
+)
+
+
+TURN_ID = "turn_01_abcdef"
+
+
+def _workspace(tmp_path: Path) -> DirectTurnWorkspace:
+    return DirectTurnWorkspace(run_root=tmp_path / "run_1", turn_id=TURN_ID)
+
+
+def _runtime(workspace: DirectTurnWorkspace) -> DirectToolRuntime:
+    runtime = DirectToolRuntime.__new__(DirectToolRuntime)
+    runtime.workspace = workspace
+    runtime._declared_files = {}
+    runtime.logger = SimpleNamespace(log=lambda *a, **k: None)
+    return runtime
+
+
+def _write_artifact(workspace: DirectTurnWorkspace, relative: str) -> Path:
+    path = workspace.artifact_path(relative)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"payload")
+    return path
+
+
+def _exec_result(*items: dict) -> dict:
+    return {"ok": True, "items": list(items)}
+
+
+def _file_item(
+    *,
+    artifact_id: str,
+    relative: str,
+    mime: str,
+    visibility: str,
+    error: str | None = None,
+) -> dict:
+    item = {
+        "artifact_id": artifact_id,
+        "output": {
+            "type": "file",
+            "path": relative,
+            "filename": Path(relative).name,
+            "mime": mime,
+            "visibility": visibility,
+        },
+    }
+    if error:
+        item["error"] = error
+    return item
+
+
+def test_declared_visibility_is_not_replaced_by_an_assumption(tmp_path: Path) -> None:
+    workspace = _workspace(tmp_path)
+    runtime = _runtime(workspace)
+    _write_artifact(workspace, f"{TURN_ID}/files/research/brief.html")
+    _write_artifact(workspace, f"{TURN_ID}/files/research/data.xlsx")
+
+    runtime._record_declared_files(
+        _exec_result(
+            _file_item(
+                artifact_id="brief",
+                relative=f"{TURN_ID}/files/research/brief.html",
+                mime="text/html",
+                visibility="external",
+            ),
+            _file_item(
+                artifact_id="data",
+                relative=f"{TURN_ID}/files/research/data.xlsx",
+                mime="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                visibility="internal",
+            ),
+        ),
+        tool_id="execute_python",
+    )
+
+    by_name = {row["output"]["filename"]: row for row in runtime.declared_files()}
+    # The demo's fixed expectation had these two the other way round.
+    assert by_name["brief.html"]["visibility"] == "external"
+    assert by_name["data.xlsx"]["visibility"] == "internal"
+
+
+def test_any_filename_the_agent_chose_is_hosted(tmp_path: Path) -> None:
+    workspace = _workspace(tmp_path)
+    runtime = _runtime(workspace)
+    relative = f"{TURN_ID}/files/research/python_release_evidence.xlsx"
+    _write_artifact(workspace, relative)
+
+    runtime._record_declared_files(
+        _exec_result(
+            _file_item(
+                artifact_id="evidence",
+                relative=relative,
+                mime="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                visibility="external",
+            )
+        ),
+        tool_id="execute_python",
+    )
+
+    rows = runtime.declared_files()
+    assert [row["output"]["filename"] for row in rows] == [
+        "python_release_evidence.xlsx"
+    ]
+
+
+def test_a_declared_file_that_was_never_written_is_not_hosted(tmp_path: Path) -> None:
+    workspace = _workspace(tmp_path)
+    runtime = _runtime(workspace)
+
+    runtime._record_declared_files(
+        _exec_result(
+            _file_item(
+                artifact_id="missing",
+                relative=f"{TURN_ID}/files/research/missing.pdf",
+                mime="application/pdf",
+                visibility="external",
+            )
+        ),
+        tool_id="execute_python",
+    )
+
+    assert runtime.declared_files() == []
+
+
+def test_a_failed_tool_call_declares_nothing(tmp_path: Path) -> None:
+    workspace = _workspace(tmp_path)
+    runtime = _runtime(workspace)
+    _write_artifact(workspace, f"{TURN_ID}/files/research/data.xlsx")
+
+    runtime._record_declared_files(
+        {
+            "ok": False,
+            "items": [
+                _file_item(
+                    artifact_id="data",
+                    relative=f"{TURN_ID}/files/research/data.xlsx",
+                    mime="application/octet-stream",
+                    visibility="external",
+                )
+            ],
+        },
+        tool_id="execute_python",
+    )
+
+    assert runtime.declared_files() == []
+
+
+def test_an_item_that_carries_an_error_is_skipped(tmp_path: Path) -> None:
+    workspace = _workspace(tmp_path)
+    runtime = _runtime(workspace)
+    _write_artifact(workspace, f"{TURN_ID}/files/research/data.xlsx")
+
+    runtime._record_declared_files(
+        _exec_result(
+            _file_item(
+                artifact_id="data",
+                relative=f"{TURN_ID}/files/research/data.xlsx",
+                mime="application/octet-stream",
+                visibility="external",
+                error="xlsx_open_failed",
+            )
+        ),
+        tool_id="execute_python",
+    )
+
+    assert runtime.declared_files() == []
+
+
+def test_rewriting_the_same_path_keeps_one_declaration(tmp_path: Path) -> None:
+    workspace = _workspace(tmp_path)
+    runtime = _runtime(workspace)
+    relative = f"{TURN_ID}/files/research/brief.pdf"
+    _write_artifact(workspace, relative)
+
+    for visibility in ("internal", "external"):
+        runtime._record_declared_files(
+            _exec_result(
+                _file_item(
+                    artifact_id="brief",
+                    relative=relative,
+                    mime="application/pdf",
+                    visibility=visibility,
+                )
+            ),
+            tool_id="execute_python",
+        )
+
+    rows = runtime.declared_files()
+    assert len(rows) == 1
+    assert rows[0]["visibility"] == "external"
+
+
+def test_the_declaration_reaches_a_host_in_another_process(tmp_path: Path) -> None:
+    # Claude Code reaches these tools through the stdio tool server, so the
+    # process that hosts the turn never holds the runtime that ran them.
+    workspace = _workspace(tmp_path)
+    server_side = _runtime(workspace)
+    relative = f"{TURN_ID}/files/research/brief.pdf"
+    _write_artifact(workspace, relative)
+
+    server_side._record_declared_files(
+        _exec_result(
+            _file_item(
+                artifact_id="brief",
+                relative=relative,
+                mime="application/pdf",
+                visibility="external",
+            )
+        ),
+        tool_id="write_pdf",
+    )
+
+    assert (workspace.runtime_outdir / DECLARED_FILES_FILENAME).is_file()
+    rows = DirectToolRuntime.declared_files_for_workspace(workspace)
+    assert [row["output"]["filename"] for row in rows] == ["brief.pdf"]
+    assert rows[0]["tool_id"] == "write_pdf"
+
+
+def test_a_corrupt_record_is_read_as_empty(tmp_path: Path) -> None:
+    workspace = _workspace(tmp_path)
+    workspace.runtime_outdir.mkdir(parents=True, exist_ok=True)
+    (workspace.runtime_outdir / DECLARED_FILES_FILENAME).write_text("not json")
+
+    assert read_declared_files(workspace) == {}
+    assert DirectToolRuntime.declared_files_for_workspace(workspace) == []
+
+
+def test_rows_are_shaped_for_host_files(tmp_path: Path) -> None:
+    workspace = _workspace(tmp_path)
+    runtime = _runtime(workspace)
+    relative = f"{TURN_ID}/files/research/brief.pdf"
+    _write_artifact(workspace, relative)
+
+    runtime._record_declared_files(
+        _exec_result(
+            _file_item(
+                artifact_id="brief",
+                relative=relative,
+                mime="application/pdf",
+                visibility="external",
+            )
+        ),
+        tool_id="write_pdf",
+    )
+
+    row = runtime.declared_files()[0]
+    assert row["type"] == "file"
+    assert row["output"]["path"] == relative
+    assert row["mime"] == "application/pdf"
+    assert row["resource_id"] == "brief"
+    stored = json.loads(
+        (workspace.runtime_outdir / DECLARED_FILES_FILENAME).read_text()
+    )
+    assert relative in stored

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/runtime/direct_hosting/tool_runtime.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/runtime/direct_hosting/tool_runtime.py
@@ -35,6 +35,11 @@ from kdcube_ai_app.infra.service_hub.inventory import AgentLogger
 EXEC_TOOL_ID = "execute_python"
 RENDER_TOOL_IDS = ("write_pdf", "write_docx", "write_pptx")
 
+#: Per-turn record of the files this turn's tools declared, written into the
+#: turn's out directory so the hosting process reads the same declarations the
+#: tool server made.
+DECLARED_FILES_FILENAME = ".declared_files.json"
+
 
 def _error(code: str, message: str) -> dict[str, Any]:
     return {
@@ -46,6 +51,40 @@ def _error(code: str, message: str) -> dict[str, Any]:
             "managed": True,
         },
     }
+
+
+def declared_files_path(workspace: DirectTurnWorkspace) -> Path:
+    return workspace.runtime_outdir / DECLARED_FILES_FILENAME
+
+
+def read_declared_files(
+    workspace: DirectTurnWorkspace,
+) -> dict[str, dict[str, Any]]:
+    """Declarations this turn's tools recorded, keyed by relative path."""
+    try:
+        stored = json.loads(
+            declared_files_path(workspace).read_text(encoding="utf-8")
+        )
+    except (OSError, ValueError):
+        return {}
+    if not isinstance(stored, dict):
+        return {}
+    return {
+        str(key): dict(value)
+        for key, value in stored.items()
+        if isinstance(value, dict)
+    }
+
+
+def _existing_declared_rows(
+    workspace: DirectTurnWorkspace,
+    declared: Mapping[str, Mapping[str, Any]],
+) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for relative, row in declared.items():
+        if resolve_artifact_path(workspace.runtime_outdir, relative).is_file():
+            rows.append(dict(row))
+    return rows
 
 
 @contextmanager
@@ -99,6 +138,12 @@ class DirectToolRuntime:
             if tool_config is None
             else self.tool_config.allowed_tool_names_by_alias
         )
+        # Files this turn's tools declared, keyed by artifact-root-relative
+        # path. A rewrite of the same path replaces the earlier declaration.
+        # Kept in the turn's own out directory because a foreign agent loop can
+        # reach these tools through the stdio tool server, which is a different
+        # process than the one that hosts the turn.
+        self._declared_files: dict[str, dict[str, Any]] = {}
         self.tool_subsystem = ToolSubsystem(
             service=service,
             comm=comm,
@@ -234,7 +279,95 @@ class DirectToolRuntime:
             "contract": contract_rewrites,
             "code": code_rewrites,
         }
+        self._record_declared_files(result, tool_id=EXEC_TOOL_ID)
         return result
+
+    def _record_declared_files(
+        self, result: Mapping[str, Any], *, tool_id: str
+    ) -> None:
+        """Remember the files a tool declared for this turn.
+
+        ``visibility`` comes from the declaration, not from the caller: the
+        docs make the declaring side the authority on whether a file is
+        emitted to the user (``external``) or kept for later agent use
+        (``internal``).
+        """
+        if not isinstance(result, Mapping) or not result.get("ok"):
+            return
+        for item in result.get("items") or []:
+            if not isinstance(item, Mapping) or item.get("error"):
+                continue
+            output = item.get("output")
+            if not isinstance(output, Mapping):
+                continue
+            if str(output.get("type") or "").strip() != "file":
+                continue
+            relative = str(output.get("path") or "").strip()
+            if not relative:
+                continue
+            filename = str(output.get("filename") or "").strip() or Path(relative).name
+            mime = str(output.get("mime") or "").strip() or (
+                mimetypes.guess_type(filename)[0] or "application/octet-stream"
+            )
+            visibility = (
+                str(output.get("visibility") or item.get("visibility") or "external")
+                .strip()
+                .lower()
+                or "external"
+            )
+            description = (
+                str(output.get("description") or item.get("summary") or "").strip()
+                or f"Agent output: {filename}"
+            )
+            self._declared_files[relative] = {
+                "type": "file",
+                "output": {
+                    "type": "file",
+                    "path": relative,
+                    "filename": filename,
+                    "mime": mime,
+                    "visibility": visibility,
+                },
+                "mime": mime,
+                "visibility": visibility,
+                "description": description,
+                "resource_id": str(item.get("artifact_id") or "").strip()
+                or Path(filename).stem,
+                "tool_id": tool_id,
+            }
+        self._write_declared_files()
+
+    @property
+    def _declared_files_path(self) -> Path:
+        return declared_files_path(self.workspace)
+
+    def _write_declared_files(self) -> None:
+        path = self._declared_files_path
+        try:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(
+                json.dumps(self._declared_files, ensure_ascii=False, indent=2),
+                encoding="utf-8",
+            )
+        except OSError as exc:
+            self.logger.log(
+                f"[direct_hosting.tools] could not record declared files: {exc}",
+                level="WARNING",
+            )
+
+    def declared_files(self) -> list[dict[str, Any]]:
+        """Rows for ``DirectAgentTurn.host_files`` covering every file this
+        turn's tools declared and that exists in the turn workspace."""
+        merged = dict(read_declared_files(self.workspace))
+        merged.update(self._declared_files)
+        return _existing_declared_rows(self.workspace, merged)
+
+    @staticmethod
+    def declared_files_for_workspace(
+        workspace: DirectTurnWorkspace,
+    ) -> list[dict[str, Any]]:
+        """The same rows for a host whose tools ran in the stdio tool server."""
+        return _existing_declared_rows(workspace, read_declared_files(workspace))
 
     def _current_artifact(self, path: str, *, extension: str) -> tuple[str, Path]:
         normalized, _rewrites, error = normalize_exec_contract_for_turn(
@@ -322,7 +455,7 @@ class DirectToolRuntime:
                 "render_output_missing", f"renderer did not create {output_rel}"
             )
         mime = mimetypes.guess_type(output.name)[0] or "application/octet-stream"
-        return {
+        rendered_result = {
             "ok": True,
             "operation": operation,
             "source_path": source_rel,
@@ -345,6 +478,8 @@ class DirectToolRuntime:
                 }
             ],
         }
+        self._record_declared_files(rendered_result, tool_id=operation)
+        return rendered_result
 
     async def write_pdf(
         self, *, source_path: str, output_path: str, title: str = ""

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/runtime/external/docker.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/runtime/external/docker.py
@@ -310,7 +310,9 @@ def _prepare_split_writable_tree(path: pathlib.Path) -> None:
     for item in [path, *path.rglob("*")]:
         try:
             if item.is_dir():
-                os.chmod(item, 0o777)
+                # setgid so files a root container creates here inherit the
+                # host group and stay writable by the harness process.
+                os.chmod(item, 0o2777)
             elif item.is_file():
                 os.chmod(item, 0o666)
         except Exception:

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/runtime/harness/timeline/turn_view.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/runtime/harness/timeline/turn_view.py
@@ -310,6 +310,9 @@ def extract_assistant_files_from_blocks(
             "tool_call_id",
             "call_id",
             "sub_type",
+            "content_sha256",
+            "size",
+            "size_bytes",
         ):
             value = meta.get(key)
             if value:

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/runtime/iso_runtime.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/runtime/iso_runtime.py
@@ -615,6 +615,11 @@ def _uses_overlay_tmp(value: Optional[str]) -> bool:
     except Exception:
         return True
 
+#: Where the KDCube images bake Chromium. Its absence is how a host process is
+#: recognised.
+BAKED_BROWSERS_PATH = pathlib.Path("/opt/ms-playwright")
+
+
 def _ensure_subprocess_temp_env(env: dict, *, outdir: pathlib.Path) -> None:
     """
     Tool subprocesses must not rely on the container overlay /tmp.
@@ -647,8 +652,8 @@ def _ensure_subprocess_temp_env(env: dict, *, outdir: pathlib.Path) -> None:
     if _uses_overlay_tmp(env.get("FONTCONFIG_PATH")):
         env["FONTCONFIG_PATH"] = str(font_dir)
     if not env.get("PLAYWRIGHT_BROWSERS_PATH"):
-        if pathlib.Path("/opt/ms-playwright").exists():
-            env["PLAYWRIGHT_BROWSERS_PATH"] = "/opt/ms-playwright"
+        if BAKED_BROWSERS_PATH.exists():
+            env["PLAYWRIGHT_BROWSERS_PATH"] = str(BAKED_BROWSERS_PATH)
         else:
             # No baked browser tree: this is a host process. The cache redirect
             # above would move Playwright's default browsers path into the

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/runtime/iso_runtime.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/runtime/iso_runtime.py
@@ -620,6 +620,21 @@ def _uses_overlay_tmp(value: Optional[str]) -> bool:
 BAKED_BROWSERS_PATH = pathlib.Path("/opt/ms-playwright")
 
 
+def _host_playwright_browsers_path() -> pathlib.Path:
+    home = pathlib.Path.home()
+    if sys.platform == "darwin":
+        cache_root = home / "Library" / "Caches"
+    elif sys.platform == "win32":
+        cache_root = pathlib.Path(
+            os.environ.get("LOCALAPPDATA") or (home / "AppData" / "Local")
+        )
+    else:
+        cache_root = pathlib.Path(
+            os.environ.get("XDG_CACHE_HOME") or (home / ".cache")
+        )
+    return cache_root / "ms-playwright"
+
+
 def _ensure_subprocess_temp_env(env: dict, *, outdir: pathlib.Path) -> None:
     """
     Tool subprocesses must not rely on the container overlay /tmp.
@@ -659,8 +674,7 @@ def _ensure_subprocess_temp_env(env: dict, *, outdir: pathlib.Path) -> None:
             # above would move Playwright's default browsers path into the
             # per-turn tree and hide an installed browser, so pin the path this
             # process itself resolves.
-            host_cache = os.environ.get("XDG_CACHE_HOME") or (pathlib.Path.home() / ".cache")
-            host_browsers = pathlib.Path(host_cache) / "ms-playwright"
+            host_browsers = _host_playwright_browsers_path()
             if host_browsers.is_dir():
                 env["PLAYWRIGHT_BROWSERS_PATH"] = str(host_browsers)
 

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/runtime/iso_runtime.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/runtime/iso_runtime.py
@@ -646,8 +646,18 @@ def _ensure_subprocess_temp_env(env: dict, *, outdir: pathlib.Path) -> None:
         env["MPLCONFIGDIR"] = str(mpl_dir)
     if _uses_overlay_tmp(env.get("FONTCONFIG_PATH")):
         env["FONTCONFIG_PATH"] = str(font_dir)
-    if not env.get("PLAYWRIGHT_BROWSERS_PATH") and pathlib.Path("/opt/ms-playwright").exists():
-        env["PLAYWRIGHT_BROWSERS_PATH"] = "/opt/ms-playwright"
+    if not env.get("PLAYWRIGHT_BROWSERS_PATH"):
+        if pathlib.Path("/opt/ms-playwright").exists():
+            env["PLAYWRIGHT_BROWSERS_PATH"] = "/opt/ms-playwright"
+        else:
+            # No baked browser tree: this is a host process. The cache redirect
+            # above would move Playwright's default browsers path into the
+            # per-turn tree and hide an installed browser, so pin the path this
+            # process itself resolves.
+            host_cache = os.environ.get("XDG_CACHE_HOME") or (pathlib.Path.home() / ".cache")
+            host_browsers = pathlib.Path(host_cache) / "ms-playwright"
+            if host_browsers.is_dir():
+                env["PLAYWRIGHT_BROWSERS_PATH"] = str(host_browsers)
 
 async def _run_subprocess(entry_path: pathlib.Path, *,
                           cwd: pathlib.Path,

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/runtime/tests/test_host_execution_environment.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/runtime/tests/test_host_execution_environment.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import os
 import pathlib
 import stat
+import sys
 
 import kdcube_ai_app.apps.chat.sdk.runtime.iso_runtime as iso_runtime
 from kdcube_ai_app.apps.chat.sdk.runtime.external.docker import (
@@ -26,12 +27,13 @@ def test_split_preflight_marks_directories_setgid(tmp_path: pathlib.Path) -> Non
 
     for directory in (root, root / "logs"):
         mode = stat.S_IMODE(directory.stat().st_mode)
-        assert mode & stat.S_ISGID, f"{directory} carries no setgid bit"
+        if sys.platform == "linux":
+            assert mode & stat.S_ISGID, f"{directory} carries no setgid bit"
         assert mode & 0o777 == 0o777
     assert stat.S_IMODE((root / "result.json").stat().st_mode) & 0o666 == 0o666
 
 
-def test_browsers_path_falls_back_to_the_one_this_process_resolves(
+def test_linux_browsers_path_falls_back_to_the_one_this_process_resolves(
     tmp_path: pathlib.Path, monkeypatch
 ) -> None:
     home = tmp_path / "home"
@@ -39,12 +41,46 @@ def test_browsers_path_falls_back_to_the_one_this_process_resolves(
     installed.mkdir(parents=True)
     monkeypatch.setenv("HOME", str(home))
     monkeypatch.delenv("XDG_CACHE_HOME", raising=False)
+    monkeypatch.setattr(iso_runtime.sys, "platform", "linux")
     monkeypatch.setattr(iso_runtime, "BAKED_BROWSERS_PATH", tmp_path / "absent")
 
     env: dict[str, str] = {}
     iso_runtime._ensure_subprocess_temp_env(env, outdir=tmp_path / "turn")
 
     assert env["XDG_CACHE_HOME"].startswith(str(tmp_path / "turn"))
+    assert env["PLAYWRIGHT_BROWSERS_PATH"] == str(installed)
+
+
+def test_darwin_browsers_path_uses_the_native_playwright_cache(
+    tmp_path: pathlib.Path, monkeypatch
+) -> None:
+    home = tmp_path / "home"
+    installed = home / "Library" / "Caches" / "ms-playwright"
+    installed.mkdir(parents=True)
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setattr(iso_runtime.sys, "platform", "darwin")
+    monkeypatch.setattr(iso_runtime, "BAKED_BROWSERS_PATH", tmp_path / "absent")
+
+    env: dict[str, str] = {}
+    iso_runtime._ensure_subprocess_temp_env(env, outdir=tmp_path / "turn")
+
+    assert env["XDG_CACHE_HOME"].startswith(str(tmp_path / "turn"))
+    assert env["PLAYWRIGHT_BROWSERS_PATH"] == str(installed)
+
+
+def test_windows_browsers_path_uses_local_app_data(
+    tmp_path: pathlib.Path, monkeypatch
+) -> None:
+    local_app_data = tmp_path / "local-app-data"
+    installed = local_app_data / "ms-playwright"
+    installed.mkdir(parents=True)
+    monkeypatch.setenv("LOCALAPPDATA", str(local_app_data))
+    monkeypatch.setattr(iso_runtime.sys, "platform", "win32")
+    monkeypatch.setattr(iso_runtime, "BAKED_BROWSERS_PATH", tmp_path / "absent")
+
+    env: dict[str, str] = {}
+    iso_runtime._ensure_subprocess_temp_env(env, outdir=tmp_path / "turn")
+
     assert env["PLAYWRIGHT_BROWSERS_PATH"] == str(installed)
 
 

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/runtime/tests/test_host_execution_environment.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/runtime/tests/test_host_execution_environment.py
@@ -1,0 +1,85 @@
+"""The harness also runs outside a KDCube image; these guard that path.
+
+Both behaviours were defects: a workspace without the setgid bit made every
+file the root supervisor wrote unreachable to the host process that started the
+turn, and a browsers path pinned only to the image's baked tree sent the
+renderer looking inside an empty per-turn cache.
+"""
+from __future__ import annotations
+
+import os
+import pathlib
+import stat
+
+import kdcube_ai_app.apps.chat.sdk.runtime.iso_runtime as iso_runtime
+from kdcube_ai_app.apps.chat.sdk.runtime.external.docker import (
+    _prepare_split_writable_tree,
+)
+
+
+def test_split_preflight_marks_directories_setgid(tmp_path: pathlib.Path) -> None:
+    root = tmp_path / "out"
+    (root / "logs").mkdir(parents=True)
+    (root / "result.json").write_text("{}", encoding="utf-8")
+
+    _prepare_split_writable_tree(root)
+
+    for directory in (root, root / "logs"):
+        mode = stat.S_IMODE(directory.stat().st_mode)
+        assert mode & stat.S_ISGID, f"{directory} carries no setgid bit"
+        assert mode & 0o777 == 0o777
+    assert stat.S_IMODE((root / "result.json").stat().st_mode) & 0o666 == 0o666
+
+
+def test_browsers_path_falls_back_to_the_one_this_process_resolves(
+    tmp_path: pathlib.Path, monkeypatch
+) -> None:
+    home = tmp_path / "home"
+    installed = home / ".cache" / "ms-playwright"
+    installed.mkdir(parents=True)
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.delenv("XDG_CACHE_HOME", raising=False)
+    monkeypatch.setattr(iso_runtime, "BAKED_BROWSERS_PATH", tmp_path / "absent")
+
+    env: dict[str, str] = {}
+    iso_runtime._ensure_subprocess_temp_env(env, outdir=tmp_path / "turn")
+
+    assert env["XDG_CACHE_HOME"].startswith(str(tmp_path / "turn"))
+    assert env["PLAYWRIGHT_BROWSERS_PATH"] == str(installed)
+
+
+def test_browsers_path_prefers_the_image_tree_when_it_exists(
+    tmp_path: pathlib.Path, monkeypatch
+) -> None:
+    baked = tmp_path / "opt" / "ms-playwright"
+    baked.mkdir(parents=True)
+    monkeypatch.setattr(iso_runtime, "BAKED_BROWSERS_PATH", baked)
+
+    env: dict[str, str] = {}
+    iso_runtime._ensure_subprocess_temp_env(env, outdir=tmp_path / "turn")
+
+    assert env["PLAYWRIGHT_BROWSERS_PATH"] == str(baked)
+
+
+def test_an_explicit_browsers_path_is_never_overridden(
+    tmp_path: pathlib.Path, monkeypatch
+) -> None:
+    monkeypatch.setattr(iso_runtime, "BAKED_BROWSERS_PATH", tmp_path / "absent")
+    env = {"PLAYWRIGHT_BROWSERS_PATH": "/somewhere/else"}
+
+    iso_runtime._ensure_subprocess_temp_env(env, outdir=tmp_path / "turn")
+
+    assert env["PLAYWRIGHT_BROWSERS_PATH"] == "/somewhere/else"
+
+
+def test_no_browsers_path_is_invented_when_nothing_is_installed(
+    tmp_path: pathlib.Path, monkeypatch
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path / "empty-home"))
+    monkeypatch.delenv("XDG_CACHE_HOME", raising=False)
+    monkeypatch.setattr(iso_runtime, "BAKED_BROWSERS_PATH", tmp_path / "absent")
+
+    env: dict[str, str] = {}
+    iso_runtime._ensure_subprocess_temp_env(env, outdir=tmp_path / "turn")
+
+    assert "PLAYWRIGHT_BROWSERS_PATH" not in env

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/claude_code/runtime.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/claude_code/runtime.py
@@ -328,6 +328,70 @@ _LIVE_CONTROL_LEFTOVERS = (
 )
 
 
+CLI_CREDENTIALS_FILENAME = ".credentials.json"
+
+
+def _materialize_cli_credentials(
+    *,
+    local_root: pathlib.Path,
+    env: dict[str, str],
+    logger=None,
+) -> str | None:
+    """Link this machine's Claude CLI credential into the store checkout.
+
+    The checkout is CLAUDE_CONFIG_DIR, so an existing CLI login is invisible to
+    the subprocess without it. Must run after the bootstrap clear/restore, which
+    removes every child except .git. Skipped when the descriptor supplies a key:
+    that deployment has already stated how it authenticates. The link is removed
+    again unless git confirms the path is ignored, so a lineage that once tracked
+    the name can never stage a credential.
+    """
+    log = logger or logging.getLogger("ClaudeCodeRuntime")
+    if env.get("ANTHROPIC_API_KEY") or env.get("CLAUDE_CODE_KEY"):
+        return None
+    source = pathlib.Path.home() / ".claude" / CLI_CREDENTIALS_FILENAME
+    if not source.is_file():
+        return None
+    target = local_root / CLI_CREDENTIALS_FILENAME
+    try:
+        if target.is_symlink() or target.exists():
+            target.unlink()
+        target.symlink_to(source)
+    except OSError as exc:
+        log.warning("[claude.session] cannot link the CLI credential: %s", exc)
+        return None
+    def _is_ignored() -> bool:
+        return subprocess.run(
+            ["git", "-C", str(local_root), "check-ignore", "-q", CLI_CREDENTIALS_FILENAME],
+            capture_output=True,
+        ).returncode == 0
+
+    ignored = _is_ignored()
+    if not ignored:
+        # A lineage created before the managed .gitignore can carry this name as
+        # a tracked path, and ignore rules never apply to tracked paths. Drop it
+        # from the index; the end-of-turn snapshot commits the removal, so the
+        # lineage stops carrying it after one turn.
+        subprocess.run(
+            [
+                "git", "-C", str(local_root), "rm", "--cached", "--ignore-unmatch",
+                "-q", CLI_CREDENTIALS_FILENAME,
+            ],
+            capture_output=True,
+        )
+        ignored = _is_ignored()
+    if not ignored:
+        target.unlink(missing_ok=True)
+        log.warning(
+            "[claude.session] %s is not ignored by this lineage; the CLI login stays "
+            "unused rather than risking a staged credential",
+            CLI_CREDENTIALS_FILENAME,
+        )
+        return None
+    log.info("[claude.session] linked the host CLI credential into %s", local_root)
+    return str(target)
+
+
 def _ensure_session_gitignore(*, local_root: pathlib.Path) -> bool:
     gitignore_path = local_root / ".gitignore"
     if gitignore_path.exists():
@@ -693,6 +757,15 @@ async def run_claude_code_turn(
                 _retarget_session_project_dir,
                 local_root=pathlib.Path(session_store.local_root),
                 cwd=workspace_cwd,
+                logger=logger,
+            )
+        if session_store.implementation == "git":
+            agent_config = getattr(agent, "config", None)
+            turn_env = getattr(agent_config, "env", None)
+            await asyncio.to_thread(
+                _materialize_cli_credentials,
+                local_root=pathlib.Path(session_store.local_root),
+                env=turn_env if isinstance(turn_env, dict) else {},
                 logger=logger,
             )
         if refresh_support_files is not None:

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/claude_code/runtime.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/claude_code/runtime.py
@@ -720,6 +720,8 @@ async def run_claude_code_turn(
         and kind in set(session_store.publish_turn_kinds)
     )
     effective_resume_existing = bool(resume_existing)
+    agent_config = getattr(agent, "config", None)
+    agent_env = getattr(agent_config, "env", None) if agent_config is not None else None
 
     # Point the Claude Code CLI at the session-store's local_root so the
     # session JSONL it writes (under <CLAUDE_CONFIG_DIR>/projects/...) lands
@@ -727,8 +729,6 @@ async def run_claude_code_turn(
     # to git. Without this the CLI writes JSONLs to $HOME/.claude/projects/...,
     # local_root stays empty, and publish creates empty lineage branches.
     if session_store is not None and session_store.implementation == "git":
-        agent_config = getattr(agent, "config", None)
-        agent_env = getattr(agent_config, "env", None) if agent_config is not None else None
         if isinstance(agent_env, dict) and "CLAUDE_CONFIG_DIR" not in agent_env:
             agent_env["CLAUDE_CONFIG_DIR"] = str(session_store.local_root)
 
@@ -760,12 +760,10 @@ async def run_claude_code_turn(
                 logger=logger,
             )
         if session_store.implementation == "git":
-            agent_config = getattr(agent, "config", None)
-            turn_env = getattr(agent_config, "env", None)
             await asyncio.to_thread(
                 _materialize_cli_credentials,
                 local_root=pathlib.Path(session_store.local_root),
-                env=turn_env if isinstance(turn_env, dict) else {},
+                env=agent_env if isinstance(agent_env, dict) else {},
                 logger=logger,
             )
         if refresh_support_files is not None:
@@ -807,6 +805,12 @@ async def run_claude_code_turn(
                     cwd=workspace_cwd,
                     logger=logger,
                 )
+            await asyncio.to_thread(
+                _materialize_cli_credentials,
+                local_root=pathlib.Path(session_store.local_root),
+                env=agent_env if isinstance(agent_env, dict) else {},
+                logger=logger,
+            )
             if refresh_support_files is not None:
                 refresh_support_files()
             result = await agent.run_turn(

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/claude_code/tests/test_runtime.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/claude_code/tests/test_runtime.py
@@ -371,10 +371,14 @@ class _RetryingFakeAgent:
     def __init__(self, root: Path):
         self.root = root
         self.calls: list[dict[str, object]] = []
+        self.credential_visible: list[bool] = []
         self.config = SimpleNamespace(env={})
 
     async def run_turn(self, prompt: str, *, kind: str = "regular", resume_existing: bool = False) -> ClaudeCodeRunResult:
         self.calls.append({"prompt": prompt, "kind": kind, "resume_existing": resume_existing})
+        self.credential_visible.append(
+            (self.root / runtime_module.CLI_CREDENTIALS_FILENAME).is_symlink()
+        )
         if len(self.calls) == 1:
             return ClaudeCodeRunResult(
                 status="failed",
@@ -419,10 +423,13 @@ class _RetryingFakeAgent:
 
 
 @pytest.mark.asyncio
-async def test_run_claude_code_turn_self_heals_stale_session_checkout_and_retries(tmp_path: Path):
+async def test_run_claude_code_turn_self_heals_stale_session_checkout_and_retries(
+    tmp_path: Path, monkeypatch
+):
     remote_repo = _init_bare_repo(tmp_path / "remote.git")
     config = _config(tmp_path, git_repo=remote_repo)
     branch_ref = claude_code_session_branch_ref(config)
+    _host_login(tmp_path, monkeypatch)
 
     seed_repo = _init_git_repo(
         tmp_path / "seed-stale-lineage",
@@ -450,6 +457,7 @@ async def test_run_claude_code_turn_self_heals_stale_session_checkout_and_retrie
     assert len(agent.calls) == 2
     assert agent.calls[0]["resume_existing"] is True
     assert agent.calls[1]["resume_existing"] is True
+    assert agent.credential_visible == [True, True]
     assert stale_file.exists() is False
     assert (config.local_root / "projects" / "-fixture" / "history.json").read_text(encoding="utf-8") == "{\"turns\": 4}\n"
 

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/claude_code/tests/test_runtime.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/claude_code/tests/test_runtime.py
@@ -732,3 +732,96 @@ async def test_run_claude_code_turn_retargets_project_dir_for_cross_node_resume(
     expected_name = runtime_module._sanitize_cwd_for_claude_projects(current_cwd)
     assert (config.local_root / "projects" / expected_name / "abc.jsonl").is_file()
     assert not (config.local_root / "projects" / "-old-host-bundle-issue").exists()
+
+
+def _checkout(tmp_path: Path, *, ignored: bool = True, tracked_credential: bool = False) -> Path:
+    files = {"README.md": "# store\n"}
+    if ignored:
+        files[".gitignore"] = runtime_module.CLAUDE_CODE_SESSION_GITIGNORE
+    root = _init_git_repo(tmp_path / "checkout", files=files)
+    if tracked_credential:
+        (root / runtime_module.CLI_CREDENTIALS_FILENAME).write_text("stale", encoding="utf-8")
+        subprocess.run(
+            ["git", "-C", str(root), "add", "-f", runtime_module.CLI_CREDENTIALS_FILENAME],
+            check=True, capture_output=True, text=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(root), "commit", "-m", "tracked credential"],
+            check=True, capture_output=True, text=True,
+        )
+    return root
+
+
+def _host_login(tmp_path: Path, monkeypatch) -> Path:
+    home = tmp_path / "home"
+    (home / ".claude").mkdir(parents=True)
+    source = home / ".claude" / runtime_module.CLI_CREDENTIALS_FILENAME
+    source.write_text("{}", encoding="utf-8")
+    monkeypatch.setenv("HOME", str(home))
+    return source
+
+
+def _is_tracked(root: Path, name: str) -> bool:
+    proc = subprocess.run(
+        ["git", "-C", str(root), "ls-files", "--error-unmatch", name],
+        capture_output=True, text=True,
+    )
+    return proc.returncode == 0
+
+
+def test_a_descriptor_key_leaves_the_host_login_alone(tmp_path: Path, monkeypatch) -> None:
+    root = _checkout(tmp_path)
+    _host_login(tmp_path, monkeypatch)
+
+    linked = runtime_module._materialize_cli_credentials(
+        local_root=root, env={"ANTHROPIC_API_KEY": "sk-configured"}
+    )
+
+    assert linked is None
+    assert not (root / runtime_module.CLI_CREDENTIALS_FILENAME).exists()
+
+
+def test_nothing_is_linked_without_a_host_login(tmp_path: Path, monkeypatch) -> None:
+    root = _checkout(tmp_path)
+    monkeypatch.setenv("HOME", str(tmp_path / "empty-home"))
+
+    linked = runtime_module._materialize_cli_credentials(local_root=root, env={})
+
+    assert linked is None
+    assert not (root / runtime_module.CLI_CREDENTIALS_FILENAME).exists()
+
+
+def test_the_host_login_is_linked_and_stays_out_of_git(tmp_path: Path, monkeypatch) -> None:
+    root = _checkout(tmp_path)
+    source = _host_login(tmp_path, monkeypatch)
+
+    linked = runtime_module._materialize_cli_credentials(local_root=root, env={})
+
+    target = root / runtime_module.CLI_CREDENTIALS_FILENAME
+    assert linked == str(target)
+    assert target.is_symlink() and target.resolve() == source.resolve()
+    assert not _is_tracked(root, runtime_module.CLI_CREDENTIALS_FILENAME)
+
+
+def test_a_lineage_that_tracks_the_credential_is_untracked(tmp_path: Path, monkeypatch) -> None:
+    root = _checkout(tmp_path, tracked_credential=True)
+    _host_login(tmp_path, monkeypatch)
+    assert _is_tracked(root, runtime_module.CLI_CREDENTIALS_FILENAME)
+
+    linked = runtime_module._materialize_cli_credentials(local_root=root, env={})
+
+    assert linked is not None
+    assert (root / runtime_module.CLI_CREDENTIALS_FILENAME).is_symlink()
+    assert not _is_tracked(root, runtime_module.CLI_CREDENTIALS_FILENAME)
+
+
+def test_the_link_is_withdrawn_when_the_name_cannot_become_ignored(
+    tmp_path: Path, monkeypatch
+) -> None:
+    root = _checkout(tmp_path, ignored=False)
+    _host_login(tmp_path, monkeypatch)
+
+    linked = runtime_module._materialize_cli_credentials(local_root=root, env={})
+
+    assert linked is None
+    assert not (root / runtime_module.CLI_CREDENTIALS_FILENAME).exists()

--- a/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/conversation/record.py
+++ b/app/ai-app/src/kdcube-ai-app/kdcube_ai_app/apps/chat/sdk/solutions/conversation/record.py
@@ -503,6 +503,12 @@ def _assistant_file_block(row: Dict[str, Any], *, turn_id: str, ts: str, index: 
     tool_id = str(row.get("tool_id") or "").strip()
     if tool_id:
         meta_json["tool_id"] = tool_id
+    # The content signature travels with the block so a transport that already
+    # delivered this file identifies it by the same key it recorded then.
+    for signature_key in ("content_sha256", "size", "size_bytes"):
+        value = row.get(signature_key)
+        if value not in ("", None):
+            meta_json[signature_key] = value
     return {
         "type": "react.tool.result",
         "turn_id": turn_id,


### PR DESCRIPTION
  Two commits. Walking `agents/` exactly as its README documents — a runner-local
  `.venv`, `playwright install chromium`, `docker compose up`, `agent.py` — on
  native Linux with Docker Engine and an authenticated Claude Code CLI does not
  reach `demonstration: PASS`. Three code paths assume the topology of a KDCube
  image. This fixes them and adds the tests that were missing.

  ## Files a root container leaves in the turn workspace

  `_prepare_split_writable_tree` set directory modes with `os.chmod(item, 0o777)`.
  That sets the mode exactly, so the directory carries no setgid bit, and every
  file the trusted supervisor writes during the run — the tool-call index, its
  lock, the materialized nested-tool results — belongs to group `root`. The
  executor's own output is unaffected: user code drops to the shared gid before
  writing. The next tool declared `runtime: local` then cannot open the index
  lock:

      PermissionError: [Errno 13] Permission denied: '.../out/.tool_calls_index.lock'

  The renderer reports this as `Subprocess exited with code 1`, three logs away
  from the cause. Directories are now created setgid, so files created inside
  them inherit the workspace group.

  Docker Desktop maps bind-mount ownership onto the host user, so the mismatch
  cannot arise there.

  ## An installed browser invisible to the renderer

  Tool subprocesses receive a private scratch tree and `XDG_CACHE_HOME` moves with
  it — correct inside a container whose overlay `/tmp` fills and turns browser
  work into long hangs. Playwright then resolves its browsers directory into an
  empty per-turn path. The compensation pinned `PLAYWRIGHT_BROWSERS_PATH` only
  when `/opt/ms-playwright` exists, so it never fired on a host: each render
  re-downloaded Chromium (~180 MB) and was killed before producing output, which
  surfaces as `missing_tool_output`. With no baked browser tree, the path this
  process itself resolves is pinned instead. A deployment that never installed a
  browser behaves as before.

  `--infra-check` reported the renderer ready throughout, truthfully: it launches
  the browser in the agent process, where nothing is redirected.

  ## A git transcript store hides the machine's CLI login

  `claude/README.md` requires an authenticated Claude Code and then selects
  `setup_local.py --provider none`, offered "for … an existing Claude CLI login".
  That combination cannot work: `descriptors.template/assembly.yaml` enables
  `claude_code_session: type: git`, and a git store points `CLAUDE_CONFIG_DIR` at
  its own checkout so the session JSONL lands where publish snapshots it. The
  credential the CLI reads lives under the same variable.

  Changing only `claude_code_session.type`, with nothing else altered:

  | type | descriptor key | outcome |
  | --- | --- | --- |
  | `git` | none | `Not logged in · Please run /login` |
  | `local` | none | `demonstration: PASS` |
  | `git` | set | `demonstration: PASS` |

  The store's managed `.gitignore` already lists `.credentials.json` on its first
  line; only the step that puts the file there was missing. The bootstrap now
  links this machine's credential into the checkout after the clear and restore,
  and only when the descriptor supplies no key.

  Placement is forced: `_clear_session_root` removes every child except `.git` on
  each turn with a lineage, so anything materialized before the restore survives
  exactly one turn per conversation. Two safeguards: the link is withdrawn unless
  `git check-ignore` confirms the path is ignored, and a lineage that already
  tracks the name is dropped from the index so it heals in one turn.

  The runner refuses before spend when neither a descriptor key nor a machine
  login exists, naming all three remedies. That check sits beside the executor
  image and browser checks under `not args.check`, leaving `--check` an offline
  construction check as its contract states.

  ## Verification

  All three runners completed the built-in demonstration on native Linux and
  printed `demonstration: PASS`, with `PLAYWRIGHT_BROWSERS_PATH` unset so the code
  was what made it work:

  | Runner | Tool delivery | PDF |
  | --- | --- | --- |
  | native | direct `ToolSubsystem` catalog | 40,396 B, `Skia/PDF m151` |
  | langgraph | `BaseTool` schema adapter | 156,990 B, 3 pages |
  | claude | `mcp__kdcube_*` MCP servers | 146,910 B, 3 pages |

  The credential path was exercised in four states: descriptor key present (host
  config untouched, no link created), host login only (linked, branch carries no
  credential), neither (refusal names the remedies), and a lineage already
  tracking `.credentials.json` (untracked, healed at the next snapshot; the
  fixture held dummy content).